### PR TITLE
Update uvloop dependency to exclude Windows platform

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "msgspec>=0.18",
     "multipart>=1.3",
     "pyjwt>=2.10.1",
-    "uvloop>=0.22.1" 
+    "uvloop>=0.22.1; sys_platform != 'win32'"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
related https://github.com/FarhanAliRaza/django-bolt/issues/17