### PR TITLE
Fix typo in README (reponse → Response)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ class UserSchema(msgspec.Struct):
 
 
 @api.get("/users/{user_id}")
-async def get_user(user_id: int) -> UserSchema: # 🎉 Reponse is type validated
+async def get_user(user_id: int) -> UserSchema: # 🎉 Response is type validated
     user = await User.objects.aget(id=user_id) # 🤯 Yes and Django orm works without any setup
     return {"id": user.id, "username": user.username} # or you could just return the queryset
 


### PR DESCRIPTION
### What changed
- Fixed a typo in the README where `reponse` was corrected to `Response`.

### Why
- Improves documentation clarity and avoids confusion for readers.