### PR TITLE
feat: implement named routes and {% bolt_url %} template tag (#114)

### DIFF
--- a/python/django_bolt/templatetags/bolt_urls.py
+++ b/python/django_bolt/templatetags/bolt_urls.py
@@ -1,0 +1,31 @@
+from django import template
+from django.urls.exceptions import NoReverseMatch
+from django_bolt.api import _BOLT_API_REGISTRY
+
+register = template.Library()
+
+@register.simple_tag
+def bolt_url(name, **kwargs):
+    """
+    Reverse a BoltAPI named route.
+    
+    Usage:
+        {% bolt_url 'my-route' id=1 %}
+    """
+    for api in _BOLT_API_REGISTRY:
+        if name in api._named_routes:
+            path_pattern = api._named_routes[name]
+            try:
+                # Replace {param} with values from kwargs
+                # We need to handle potentially missing params by raising NoReverseMatch
+                # Bolt paths use {param} syntax which is compatible with python format()
+                return path_pattern.format(**kwargs)
+            except KeyError as e:
+                # If a key is missing in kwargs that is required by the pattern
+                raise NoReverseMatch(f"Missing argument for bolt_url '{name}': {e}")
+            except ValueError as e:
+                # If format string is invalid
+                raise NoReverseMatch(f"Invalid format for bolt_url '{name}': {e}")
+                
+    # If we fall through, the named route was not found in any registered API
+    raise NoReverseMatch(f"Bolt URL '{name}' not found")

--- a/python/tests/test_bolt_url.py
+++ b/python/tests/test_bolt_url.py
@@ -1,0 +1,83 @@
+import pytest
+from django.template import Template, Context, TemplateSyntaxError
+from django.urls.exceptions import NoReverseMatch
+from django_bolt import BoltAPI
+
+def test_bolt_url_tag_resolution():
+    """Test standard named route resolution."""
+    api = BoltAPI()
+    
+    @api.get("/users/{id}", name="user-detail")
+    def user_detail(req, id: int):
+        return {"id": id}
+        
+    template = Template("{% load bolt_urls %}{% bolt_url 'user-detail' id=123 %}")
+    rendered = template.render(Context())
+    assert rendered == "/users/123"
+
+def test_bolt_url_multiple_params():
+    """Test resolution with multiple parameters."""
+    api = BoltAPI()
+    
+    @api.get("/posts/{post_id}/comments/{comment_id}", name="comment-detail")
+    def comment_detail(req, post_id: int, comment_id: int):
+        return {}
+        
+    template = Template("{% load bolt_urls %}{% bolt_url 'comment-detail' post_id=10 comment_id=20 %}")
+    rendered = template.render(Context())
+    assert rendered == "/posts/10/comments/20"
+
+def test_bolt_url_missing_name():
+    """Test error when route name is not found."""
+    api = BoltAPI()
+    template = Template("{% load bolt_urls %}{% bolt_url 'missing-route' %}")
+    
+    with pytest.raises(NoReverseMatch) as excinfo:
+        template.render(Context())
+    assert "Bolt URL 'missing-route' not found" in str(excinfo.value)
+
+def test_bolt_url_missing_param():
+    """Test error when parameter is missing."""
+    api = BoltAPI()
+    
+    @api.get("/users/{id}", name="user-detail")
+    def user_detail(req, id: int):
+        return {}
+        
+    template = Template("{% load bolt_urls %}{% bolt_url 'user-detail' %}")
+    
+    with pytest.raises(NoReverseMatch) as excinfo:
+        template.render(Context())
+    assert "Missing argument" in str(excinfo.value)
+
+def test_view_named_route():
+    """Test named route using @api.view decorator."""
+    api = BoltAPI()
+    from django_bolt.views import APIView
+    
+    @api.view("/profile", name="user-profile")
+    class ProfileView(APIView):
+        def get(self):
+            pass
+            
+    template = Template("{% load bolt_urls %}{% bolt_url 'user-profile' %}")
+    rendered = template.render(Context())
+    assert rendered == "/profile"
+
+def test_viewset_named_route_auto_generation():
+    """Test automatic name generation for ViewSets."""
+    api = BoltAPI()
+    from django_bolt.views import ViewSet
+    
+    @api.viewset("/items", name="items")
+    class ItemViewSet(ViewSet):
+        def list(self): pass
+        def retrieve(self, pk): pass
+        
+    # Test list route
+    template_list = Template("{% load bolt_urls %}{% bolt_url 'items-list' %}")
+    assert template_list.render(Context()) == "/items"
+    
+    # Test retrieve route
+    template_detail = Template("{% load bolt_urls %}{% bolt_url 'items-retrieve' pk=99 %}")
+    assert template_detail.render(Context()) == "/items/99"


### PR DESCRIPTION
This PR resolves issue #114 by introducing support for named routes in BoltAPI. It allows developers to define route names within the @api decorators and resolve those URLs dynamically in templates using a new custom tag, {% bolt_url %}.

Changes
Routing: Updated the @api decorator to accept a name parameter.

Template Tags: Created the bolt_urls library containing the {% bolt_url %} tag.

Reverse Resolution: Implemented the logic to map route names back to their defined paths.

Documentation: Added walkthrough.md with implementation details and usage examples.

How to Use
1. Define the route name in your Python code:

Python
@api.get("/my-route", name="my-route")
def handler(req):
    ...
2. Use the tag in your HTML template:

HTML
{% load bolt_urls %}
<a href="{% bolt_url 'my-route' %}">Link</a>
Testing Conducted
Verified that {% bolt_url %} correctly resolves paths for static routes.

Confirmed that the template tag loads correctly via {% load bolt_urls %}.

Checked that meaningful errors are raised if a route name does not exist.

Fixes: #114