### PR TITLE
refactor: Remove redundant type checks

### DIFF
--- a/python/django_bolt/_kwargs/extractors.py
+++ b/python/django_bolt/_kwargs/extractors.py
@@ -759,8 +759,8 @@ def coerce_to_response_type(value: Any, annotation: Any, meta: HandlerMetadata |
         # This is a list[Struct] response - use pre-computed field names
         origin = get_origin(annotation)
 
-        # Handle List[T]
-        if origin in (list, list):
+        # Handle list[T]
+        if origin is list:
             # Check if value is actually a list/iterable
             if not isinstance(value, (list, tuple)) and value is not None:
                 args = get_args(annotation)
@@ -824,7 +824,7 @@ def coerce_to_response_type(value: Any, annotation: Any, meta: HandlerMetadata |
 
     # Fallback: Check if it's a list without metadata
     origin = get_origin(annotation)
-    if origin in (list, list):
+    if origin is list:
         if not isinstance(value, (list, tuple)) and value is not None:
             args = get_args(annotation)
             elem_name = args[0].__name__ if args else "Any"

--- a/python/django_bolt/_kwargs/model.py
+++ b/python/django_bolt/_kwargs/model.py
@@ -52,7 +52,7 @@ def extract_response_metadata(response_type: Any) -> dict[str, Any]:
 
     # Check if response type is list[Struct] for QuerySet optimization
     origin = get_origin(response_type)
-    if origin in (list, list):
+    if origin is list:
         args = get_args(response_type)
         if args:
             elem_type = args[0]

--- a/python/django_bolt/openapi/schema_generator.py
+++ b/python/django_bolt/openapi/schema_generator.py
@@ -734,14 +734,14 @@ class SchemaGenerator:
             else:
                 return self._struct_to_schema(type_annotation)
 
-        # Handle list/List
-        if origin in (list, list):
+        # Handle list
+        if origin is list:
             item_type = args[0] if args else Any
             item_schema = self._type_to_schema(item_type, register_component=register_component)
             return Schema(type="array", items=item_schema)
 
-        # Handle dict/Dict
-        if origin in (dict, dict):
+        # Handle dict
+        if origin is dict:
             return Schema(type="object", additional_properties=True)
 
         # Handle primitive types

--- a/python/django_bolt/typing.py
+++ b/python/django_bolt/typing.py
@@ -193,7 +193,7 @@ def is_simple_type(annotation: Any) -> bool:
 def is_sequence_type(annotation: Any) -> bool:
     """Check if annotation is a sequence type like List[T]."""
     origin = get_origin(annotation)
-    return origin in (list, list, tuple, set, frozenset)
+    return origin in (list, tuple, set, frozenset)
 
 
 def is_optional(annotation: Any) -> bool:


### PR DESCRIPTION
Small change.
`origin in (list, list)` -> `origin is list`
`origin in (dict, dict)` -> `origin is dict`