### PR TITLE
Pre-compile response serialization handlers at registration time (#167)

### DIFF
--- a/bench/BENCHMARK_BASELINE.md
+++ b/bench/BENCHMARK_BASELINE.md
@@ -1,391 +1,390 @@
 # Django-Bolt Benchmark
-Generated: Tue 03 Mar 2026 12:02:02 AM PKT
+Generated: Sat 07 Mar 2026 05:40:15 AM PKT
 Config: 8 processes × 1 workers | C=100 N=10000
 
 ## Root Endpoint Performance
-  Reqs/sec    163024.89   16427.87  178705.14
-  Latency      595.95us   286.26us     5.78ms
+  Reqs/sec    172753.17   22391.66  187053.20
+  Latency      566.08us   344.59us     6.85ms
   Latency Distribution
-     50%   544.00us
-     75%   683.00us
-     90%     0.88ms
-     99%     1.72ms
+     50%   500.00us
+     75%   628.00us
+     90%     0.87ms
+     99%     1.95ms
 
 ## 10kb JSON Response Performance
 ### 10kb JSON (Async) (/10k-json)
-  Reqs/sec    108659.12    6795.37  113247.35
-  Latency        0.90ms   356.48us     6.74ms
+  Reqs/sec    120593.26    9832.62  129439.80
+  Latency      818.79us   311.60us     5.51ms
   Latency Distribution
-     50%     0.85ms
-     75%     1.11ms
-     90%     1.40ms
-     99%     2.30ms
+     50%   762.00us
+     75%     0.97ms
+     90%     1.21ms
+     99%     2.02ms
 ### 10kb JSON (Sync) (/sync-10k-json)
-  Reqs/sec    115059.83    8935.83  124187.95
-  Latency        0.85ms   397.67us     6.42ms
+  Reqs/sec    123821.79   10897.95  133339.15
+  Latency      779.74us   294.50us     5.41ms
   Latency Distribution
-     50%   793.00us
-     75%     1.03ms
-     90%     1.33ms
-     99%     2.56ms
+     50%   757.00us
+     75%     0.93ms
+     90%     1.12ms
+     99%     1.93ms
 
 ## Response Type Endpoints
 ### Header Endpoint (/header)
-  Reqs/sec    104252.31    9326.67  108766.13
-  Latency        0.94ms   354.61us     5.91ms
+  Reqs/sec    100276.23    8477.12  106279.97
+  Latency        0.97ms   331.90us     5.54ms
   Latency Distribution
-     50%     0.86ms
-     75%     1.18ms
-     90%     1.49ms
-     99%     2.46ms
+     50%     0.89ms
+     75%     1.21ms
+     90%     1.56ms
+     99%     2.31ms
 ### Cookie Endpoint (/cookie)
-  Reqs/sec    103196.74    7486.82  108003.70
-  Latency        0.95ms   357.57us     5.14ms
+  Reqs/sec    103429.45    8256.71  109911.96
+  Latency        0.95ms   276.75us     4.55ms
   Latency Distribution
-     50%     0.86ms
-     75%     1.16ms
-     90%     1.52ms
-     99%     2.59ms
+     50%     0.90ms
+     75%     1.15ms
+     90%     1.42ms
+     99%     2.08ms
 ### Exception Endpoint (/exc)
-  Reqs/sec    131045.42   11329.81  138428.52
-  Latency      745.20us   226.32us     3.28ms
+  Reqs/sec    129386.25   13511.65  138891.42
+  Latency      751.21us   256.66us     5.51ms
   Latency Distribution
-     50%   719.00us
-     75%     0.88ms
-     90%     1.14ms
-     99%     1.79ms
+     50%   723.00us
+     75%     0.92ms
+     90%     1.13ms
+     99%     1.75ms
 ### HTML Response (/html)
-  Reqs/sec    148187.50   10283.42  158276.50
-  Latency      645.33us   217.93us     4.98ms
+  Reqs/sec    148007.57   13989.76  160350.19
+  Latency      651.41us   301.19us     5.61ms
   Latency Distribution
-     50%   616.00us
-     75%   796.00us
-     90%     0.97ms
-     99%     1.52ms
+     50%   611.00us
+     75%   789.00us
+     90%     1.02ms
+     99%     1.87ms
 ### Redirect Response (/redirect)
 ### File Static via FileResponse (/file-static)
-  Reqs/sec     36926.41    6854.12   40204.96
-  Latency        2.70ms     1.21ms    18.11ms
+  Reqs/sec     37803.35    8109.26   44473.58
+  Latency        2.66ms     1.55ms    23.30ms
   Latency Distribution
-     50%     2.45ms
-     75%     3.15ms
-     90%     4.09ms
-     99%     8.25ms
+     50%     2.32ms
+     75%     3.16ms
+     90%     4.21ms
+     99%     9.03ms
 
 ## Authentication & Authorization Performance
 ### Auth NO User Access (/auth/no-user-access) - lazy loading, no DB query
-  Reqs/sec     77331.34    4886.60   80624.88
-  Latency        1.28ms   430.52us     5.28ms
+  Reqs/sec     77222.56    5659.26   81113.76
+  Latency        1.27ms   342.00us     4.63ms
   Latency Distribution
-     50%     1.19ms
-     75%     1.63ms
-     90%     2.07ms
-     99%     3.14ms
+     50%     1.23ms
+     75%     1.53ms
+     90%     1.86ms
+     99%     2.72ms
 ### Get Authenticated User (/auth/me) - accesses request.user, triggers DB query
-  Reqs/sec     17087.12    1654.07   20101.21
-  Latency        5.84ms     1.86ms    16.06ms
+  Reqs/sec     17438.55    1200.87   19326.99
+  Latency        5.71ms     1.41ms    18.84ms
   Latency Distribution
-     50%     5.66ms
-     75%     7.10ms
-     90%     8.60ms
-     99%    12.10ms
+     50%     5.74ms
+     75%     6.95ms
+     90%     7.90ms
+     99%     9.77ms
 ### Get User via Dependency (/auth/me-dependency)
-  Reqs/sec     15710.03     953.93   16674.67
-  Latency        6.32ms     1.63ms    14.46ms
+  Reqs/sec     15565.93     813.86   16646.78
+  Latency        6.39ms     1.42ms    13.85ms
   Latency Distribution
-     50%     6.21ms
-     75%     7.60ms
-     90%     8.84ms
-     99%    11.37ms
+     50%     6.20ms
+     75%     7.37ms
+     90%     8.63ms
+     99%    11.11ms
 ### Get Auth Context (/auth/context) validated jwt no db
-  Reqs/sec     84363.61    6680.46   92023.07
-  Latency        1.16ms   392.24us     4.66ms
+  Reqs/sec     87228.01    6545.25   92217.60
+  Latency        1.12ms   348.57us     6.74ms
   Latency Distribution
-     50%     1.08ms
-     75%     1.45ms
-     90%     1.83ms
-     99%     2.87ms
+     50%     1.07ms
+     75%     1.38ms
+     90%     1.73ms
+     99%     2.40ms
 
 ## Items GET Performance (/items/1?q=hello)
-  Reqs/sec    143626.13   15029.20  155961.11
-  Latency      673.59us   369.53us     5.39ms
+  Reqs/sec    155017.78   13239.06  163450.43
+  Latency      630.77us   252.32us     7.94ms
   Latency Distribution
-     50%   604.00us
-     75%   725.00us
-     90%     0.91ms
-     99%     2.67ms
+     50%   592.00us
+     75%   707.00us
+     90%     0.89ms
+     99%     1.75ms
 
 ## Items PUT JSON Performance (/items/1)
-  Reqs/sec     99802.74    7139.32  104342.34
-  Latency        0.99ms   341.69us     4.54ms
+  Reqs/sec    102177.92    7272.26  107881.39
+  Latency        0.96ms   316.69us     5.34ms
   Latency Distribution
-     50%     0.92ms
-     75%     1.21ms
-     90%     1.51ms
-     99%     2.49ms
+     50%     0.89ms
+     75%     1.20ms
+     90%     1.53ms
+     99%     2.21ms
 
 ## ORM Performance
 Seeding 1000 users for benchmark...
 Successfully seeded users
 Validated: 10 users exist in database
 ### Users Full10 (Async) (/users/full10)
-  Reqs/sec     14407.03    1038.18   15684.78
-  Latency        6.91ms     1.84ms    19.21ms
+  Reqs/sec     14426.40     929.47   16120.81
+  Latency        6.90ms     2.00ms    19.12ms
   Latency Distribution
-     50%     7.14ms
-     75%     8.37ms
-     90%     9.60ms
-     99%    11.91ms
+     50%     7.09ms
+     75%     8.65ms
+     90%     9.84ms
+     99%    12.23ms
 ### Users Full10 (Sync) (/users/sync-full10)
-  Reqs/sec     10603.82    1254.57   13712.67
-  Latency        9.42ms     4.78ms    35.27ms
+  Reqs/sec     10022.72    1058.17   12591.72
+  Latency        9.95ms     4.20ms    32.67ms
   Latency Distribution
-     50%     8.29ms
-     75%    12.06ms
-     90%    16.62ms
-     99%    25.70ms
+     50%     9.13ms
+     75%    12.54ms
+     90%    16.46ms
+     99%    23.03ms
 ### Users Mini10 (Async) (/users/mini10)
-  Reqs/sec     16704.64     766.31   17448.32
-  Latency        5.95ms     2.01ms    14.46ms
+  Reqs/sec     16670.79     755.83   17372.72
+  Latency        5.96ms     1.42ms    15.01ms
   Latency Distribution
-     50%     5.81ms
-     75%     7.62ms
-     90%     9.10ms
-     99%    11.51ms
+     50%     5.77ms
+     75%     7.10ms
+     90%     8.33ms
+     99%    10.27ms
 ### Users Mini10 (Sync) (/users/sync-mini10)
-  Reqs/sec     12348.04     963.37   14636.37
-  Latency        8.07ms     2.91ms    25.19ms
+  Reqs/sec     12256.80    1036.43   14738.06
+  Latency        8.05ms     4.33ms    36.00ms
   Latency Distribution
-     50%     7.51ms
-     75%     9.76ms
-     90%    12.46ms
-     99%    17.93ms
+     50%     7.03ms
+     75%     9.41ms
+     90%    13.65ms
+     99%    24.88ms
 Cleaning up test users...
 
 ## Class-Based Views (CBV) Performance
 ### Simple APIView GET (/cbv-simple)
-  Reqs/sec    110643.19    8450.07  117919.84
-  Latency        0.89ms   328.26us     5.10ms
+  Reqs/sec    108777.69    9141.80  115683.00
+  Latency        0.90ms   321.09us     5.30ms
   Latency Distribution
-     50%   816.00us
-     75%     1.08ms
-     90%     1.36ms
-     99%     2.18ms
+     50%   829.00us
+     75%     1.11ms
+     90%     1.42ms
+     99%     2.27ms
 ### Simple APIView POST (/cbv-simple)
-  Reqs/sec     99582.71   26748.78  113346.83
-  Latency        1.00ms     1.01ms    13.46ms
+  Reqs/sec    108054.99    6378.76  114500.95
+  Latency        0.91ms   276.73us     3.85ms
   Latency Distribution
-     50%     0.85ms
-     75%     1.14ms
-     90%     1.46ms
-     99%     2.67ms
+     50%   844.00us
+     75%     1.11ms
+     90%     1.43ms
+     99%     2.18ms
 ### Items100 ViewSet GET (/cbv-items100)
-  Reqs/sec     69991.61    5268.92   76863.73
-  Latency        1.43ms   346.60us     4.24ms
+  Reqs/sec     71144.79    6621.37   83675.75
+  Latency        1.42ms   347.24us     4.41ms
   Latency Distribution
-     50%     1.34ms
-     75%     1.71ms
-     90%     2.08ms
-     99%     2.87ms
+     50%     1.35ms
+     75%     1.63ms
+     90%     2.02ms
+     99%     2.89ms
 
 ## CBV Items - Basic Operations
 ### CBV Items GET (Retrieve) (/cbv-items/1)
-  Reqs/sec    103972.27    4747.33  109179.14
-  Latency        0.94ms   315.14us     5.62ms
+  Reqs/sec    106119.86    8093.90  112035.86
+  Latency        0.92ms   299.61us     4.90ms
+  Latency Distribution
+     50%     0.86ms
+     75%     1.13ms
+     90%     1.40ms
+     99%     2.08ms
+### CBV Items PUT (Update) (/cbv-items/1)
+  Reqs/sec    103297.30    5588.74  107429.71
+  Latency        0.95ms   303.56us     4.19ms
   Latency Distribution
      50%     0.88ms
-     75%     1.15ms
-     90%     1.44ms
-     99%     2.14ms
-### CBV Items PUT (Update) (/cbv-items/1)
-  Reqs/sec    101875.01    6290.42  106266.25
-  Latency        0.96ms   302.92us     3.91ms
-  Latency Distribution
-     50%     0.89ms
-     75%     1.20ms
+     75%     1.17ms
      90%     1.49ms
-     99%     2.27ms
+     99%     2.34ms
 
 ## CBV Additional Benchmarks
 ### CBV Bench Parse (POST /cbv-bench-parse)
-  Reqs/sec    103816.96    6010.98  110677.01
-  Latency        0.95ms   310.81us     4.68ms
+  Reqs/sec    103859.55    7332.08  109815.81
+  Latency        0.94ms   294.38us     4.41ms
   Latency Distribution
-     50%     0.89ms
+     50%     0.87ms
      75%     1.17ms
-     90%     1.48ms
-     99%     2.29ms
+     90%     1.45ms
+     99%     2.19ms
 ### CBV Response Types (/cbv-response)
-  Reqs/sec    113813.75   10519.18  122069.68
-  Latency        0.87ms   288.67us     6.07ms
+  Reqs/sec    109067.69    5861.10  113356.97
+  Latency        0.90ms   285.76us     4.79ms
   Latency Distribution
-     50%   813.00us
-     75%     1.07ms
-     90%     1.35ms
-     99%     2.08ms
+     50%   845.00us
+     75%     1.12ms
+     90%     1.39ms
+     99%     1.94ms
 
 ## ORM Performance with CBV
 Seeding 1000 users for CBV benchmark...
 Successfully seeded users
 Validated: 10 users exist in database
 ### Users CBV Mini10 (List) (/users/cbv-mini10)
-  Reqs/sec     17228.47    1580.93   22381.86
-  Latency        5.82ms     1.60ms    15.86ms
+  Reqs/sec     16725.47    1208.37   18054.52
+  Latency        5.95ms     1.68ms    14.55ms
   Latency Distribution
-     50%     5.69ms
-     75%     7.11ms
-     90%     8.33ms
-     99%    10.87ms
+     50%     5.78ms
+     75%     7.29ms
+     90%     8.56ms
+     99%    11.01ms
 Cleaning up test users...
 
 
 ## Form and File Upload Performance
 ### Form Data (POST /form)
-  Reqs/sec    133173.34    9212.48  139565.01
-  Latency      728.66us   266.10us     5.55ms
+  Reqs/sec    130986.66    9333.73  138692.24
+  Latency      732.38us   276.19us     5.26ms
   Latency Distribution
-     50%   678.00us
+     50%   644.00us
      75%     0.88ms
-     90%     1.12ms
-     99%     1.70ms
+     90%     1.34ms
+     99%     1.93ms
 ### File Upload (POST /upload)
-  Reqs/sec    114059.45    8559.89  120291.50
-  Latency      843.62us   271.71us     5.51ms
+  Reqs/sec    116971.54    9220.70  122702.59
+  Latency      833.04us   248.79us     4.49ms
   Latency Distribution
-     50%   809.00us
-     75%     1.05ms
+     50%   787.00us
+     75%     1.00ms
+     90%     1.22ms
+     99%     1.84ms
+### Mixed Form with Files (POST /mixed-form)
+  Reqs/sec    112451.02    7925.45  119557.84
+  Latency        0.87ms   250.35us     4.11ms
+  Latency Distribution
+     50%     0.85ms
+     75%     1.07ms
      90%     1.31ms
      99%     1.90ms
-### Mixed Form with Files (POST /mixed-form)
-  Reqs/sec    107268.89    9658.58  115439.81
-  Latency        0.92ms   348.33us     6.20ms
-  Latency Distribution
-     50%     0.88ms
-     75%     1.09ms
-     90%     1.40ms
-     99%     2.35ms
 
 ## Django Middleware Performance
 ### Django Middleware + Messages Framework (/middleware/demo)
 Tests: SessionMiddleware, AuthenticationMiddleware, MessageMiddleware, custom middleware, template rendering
- 7890 / 10000 [======================================>----------]  78.90% 9844/s
-  Reqs/sec      9984.16    1021.00   13254.44
-  Latency       10.04ms     2.10ms    21.13ms
+  Reqs/sec      9902.23     950.72   13257.58
+  Latency       10.09ms     1.84ms    20.54ms
   Latency Distribution
-     50%     9.82ms
-     75%    11.45ms
-     90%    12.83ms
-     99%    17.19ms
+     50%    10.15ms
+     75%    11.38ms
+     90%    12.60ms
+     99%    15.86ms
 
 ## Django Ninja-style Benchmarks
 ### JSON Parse/Validate (POST /bench/parse)
-  Reqs/sec    138876.06    9566.50  144858.13
-  Latency      695.00us   244.99us     5.08ms
+  Reqs/sec    147336.90   18313.81  159151.03
+  Latency      667.26us   279.34us     5.70ms
   Latency Distribution
-     50%   621.00us
-     75%     0.86ms
-     90%     1.13ms
-     99%     1.77ms
+     50%   619.00us
+     75%   777.00us
+     90%     0.98ms
+     99%     1.91ms
 
 ## Serializer Performance Benchmarks
 ### Raw msgspec Serializer (POST /bench/serializer-raw)
-  Reqs/sec     98961.10    9475.12  105380.52
-  Latency        0.99ms   360.79us     7.00ms
+  Reqs/sec    103678.55    9009.08  108659.10
+  Latency        0.95ms   359.40us     5.46ms
   Latency Distribution
-     50%     0.91ms
-     75%     1.20ms
-     90%     1.51ms
-     99%     2.29ms
+     50%     0.87ms
+     75%     1.18ms
+     90%     1.50ms
+     99%     2.47ms
 ### Django-Bolt Serializer with Validators (POST /bench/serializer-validated)
-  Reqs/sec     88651.46    7266.17   93474.56
-  Latency        1.11ms   447.98us     4.88ms
+  Reqs/sec     96704.52    8745.98  106555.46
+  Latency        1.04ms   366.94us     5.83ms
   Latency Distribution
-     50%     0.98ms
-     75%     1.32ms
-     90%     1.82ms
-     99%     3.27ms
+     50%     0.95ms
+     75%     1.26ms
+     90%     1.61ms
+     99%     2.48ms
 ### Users msgspec Serializer (POST /users/bench/msgspec)
-  Reqs/sec     94363.92    8599.11  102685.62
-  Latency        1.05ms   363.25us     4.88ms
+  Reqs/sec    104853.84    6786.62  109088.29
+  Latency        0.94ms   299.52us     5.87ms
   Latency Distribution
-     50%     0.99ms
-     75%     1.31ms
-     90%     1.62ms
-     99%     2.52ms
+     50%     0.88ms
+     75%     1.15ms
+     90%     1.42ms
+     99%     1.98ms
 
 ## Multi-Response Performance
 
 ### Multi-response tuple return (/bench/multi/tuple)
-  Reqs/sec     98235.58    7136.58  104940.90
-  Latency        1.00ms   357.36us     5.04ms
+  Reqs/sec    110363.09    6650.22  115808.21
+  Latency        0.88ms   255.13us     5.45ms
   Latency Distribution
-     50%     0.92ms
-     75%     1.23ms
-     90%     1.62ms
-     99%     2.59ms
+     50%   828.00us
+     75%     1.07ms
+     90%     1.35ms
+     99%     1.97ms
 
 ### Multi-response bare dict (/bench/multi/dict)
-  Reqs/sec    103554.64    7438.62  110138.37
-  Latency        0.94ms   321.19us     4.70ms
+  Reqs/sec    111087.19    9766.90  117257.20
+  Latency        0.89ms   290.09us     5.25ms
   Latency Distribution
-     50%     0.87ms
-     75%     1.16ms
-     90%     1.50ms
-     99%     2.37ms
+     50%   823.00us
+     75%     1.08ms
+     90%     1.36ms
+     99%     2.09ms
 
 ## Latency Percentile Benchmarks
 Measures p50/p75/p90/p99 latency for type coercion overhead analysis
 
 ### Baseline - No Parameters (/)
-  Reqs/sec    171028.89   11760.44  180734.67
-  Latency      563.58us   258.35us     5.88ms
+  Reqs/sec    180126.03   11669.83  189094.84
+  Latency      542.71us   291.87us     5.03ms
   Latency Distribution
-     50%   539.00us
-     75%   663.00us
-     90%   842.00us
-     99%     1.76ms
+     50%   489.00us
+     75%   589.00us
+     90%   777.00us
+     99%     1.58ms
 
 ### Path Parameter - int (/items/12345)
-  Reqs/sec    149969.56   11062.24  156286.72
-  Latency      646.07us   314.46us     5.86ms
+  Reqs/sec    152031.30   13845.73  166130.49
+  Latency      636.38us   274.35us     5.71ms
   Latency Distribution
-     50%   598.00us
-     75%   762.00us
-     90%     0.96ms
-     99%     1.67ms
+     50%   582.00us
+     75%   773.00us
+     90%     0.99ms
+     99%     1.83ms
 
 ### Path + Query Parameters (/items/12345?q=hello)
-  Reqs/sec    149007.04   13532.97  156859.92
-  Latency      654.24us   249.26us     4.66ms
+  Reqs/sec    145538.85    8579.79  152675.47
+  Latency      668.21us   305.59us     5.64ms
   Latency Distribution
-     50%   577.00us
-     75%   818.00us
-     90%     1.04ms
-     99%     1.71ms
+     50%   631.00us
+     75%   804.00us
+     90%     1.03ms
+     99%     1.65ms
 
 ### Header Parameter (/header)
-  Reqs/sec    100719.79    9763.64  109475.63
-  Latency        0.97ms   350.23us     5.53ms
+  Reqs/sec    102013.76    7342.16  106203.28
+  Latency        0.96ms   326.16us     5.08ms
   Latency Distribution
      50%     0.90ms
-     75%     1.18ms
+     75%     1.20ms
      90%     1.50ms
-     99%     2.28ms
+     99%     2.36ms
 
 ### Cookie Parameter (/cookie)
-  Reqs/sec    104510.29    7336.50  109947.69
-  Latency        0.94ms   306.82us     4.24ms
+  Reqs/sec    101603.23    7588.00  106427.72
+  Latency        0.96ms   311.63us     4.70ms
   Latency Distribution
-     50%     0.87ms
-     75%     1.15ms
-     90%     1.45ms
-     99%     2.41ms
+     50%     0.90ms
+     75%     1.21ms
+     90%     1.54ms
+     99%     2.24ms
 
 ### Auth Context - JWT validated, no DB (/auth/context)
-  Reqs/sec     86593.08    7048.52   94461.60
-  Latency        1.13ms   357.57us     6.86ms
+  Reqs/sec     87614.19    5702.34   91616.18
+  Latency        1.12ms   319.02us     5.13ms
   Latency Distribution
-     50%     1.09ms
-     75%     1.40ms
-     90%     1.75ms
-     99%     2.59ms
+     50%     1.06ms
+     75%     1.38ms
+     90%     1.68ms
+     99%     2.43ms

--- a/bench/BENCHMARK_DEV.md
+++ b/bench/BENCHMARK_DEV.md
@@ -1,390 +1,391 @@
 # Django-Bolt Benchmark
-Generated: Sat 07 Mar 2026 05:40:15 AM PKT
+Generated: Sun 08 Mar 2026 04:40:37 AM PKT
 Config: 8 processes × 1 workers | C=100 N=10000
 
 ## Root Endpoint Performance
-  Reqs/sec    172753.17   22391.66  187053.20
-  Latency      566.08us   344.59us     6.85ms
+  Reqs/sec    168772.82   10874.85  175061.92
+  Latency      567.51us   244.18us     4.71ms
   Latency Distribution
-     50%   500.00us
-     75%   628.00us
+     50%   519.00us
+     75%   674.00us
      90%     0.87ms
-     99%     1.95ms
+     99%     1.76ms
 
 ## 10kb JSON Response Performance
 ### 10kb JSON (Async) (/10k-json)
-  Reqs/sec    120593.26    9832.62  129439.80
-  Latency      818.79us   311.60us     5.51ms
+  Reqs/sec    112134.03    7479.22  118765.68
+  Latency        0.87ms   311.84us     5.04ms
   Latency Distribution
-     50%   762.00us
-     75%     0.97ms
-     90%     1.21ms
-     99%     2.02ms
+     50%   822.00us
+     75%     1.04ms
+     90%     1.31ms
+     99%     2.34ms
 ### 10kb JSON (Sync) (/sync-10k-json)
-  Reqs/sec    123821.79   10897.95  133339.15
-  Latency      779.74us   294.50us     5.41ms
+  Reqs/sec    112136.52   23667.92  128300.25
+  Latency        0.90ms     0.96ms    15.44ms
   Latency Distribution
-     50%   757.00us
-     75%     0.93ms
-     90%     1.12ms
-     99%     1.93ms
+     50%   713.00us
+     75%     1.07ms
+     90%     1.39ms
+     99%     3.08ms
 
 ## Response Type Endpoints
 ### Header Endpoint (/header)
-  Reqs/sec    100276.23    8477.12  106279.97
-  Latency        0.97ms   331.90us     5.54ms
+  Reqs/sec    103789.52    7970.14  109806.07
+  Latency        0.95ms   346.57us     5.06ms
   Latency Distribution
-     50%     0.89ms
-     75%     1.21ms
-     90%     1.56ms
+     50%     0.87ms
+     75%     1.17ms
+     90%     1.46ms
      99%     2.31ms
 ### Cookie Endpoint (/cookie)
-  Reqs/sec    103429.45    8256.71  109911.96
-  Latency        0.95ms   276.75us     4.55ms
+  Reqs/sec    100821.99    6596.85  107773.96
+  Latency        0.97ms   293.37us     4.46ms
   Latency Distribution
-     50%     0.90ms
-     75%     1.15ms
-     90%     1.42ms
-     99%     2.08ms
+     50%     0.91ms
+     75%     1.21ms
+     90%     1.55ms
+     99%     2.21ms
 ### Exception Endpoint (/exc)
-  Reqs/sec    129386.25   13511.65  138891.42
-  Latency      751.21us   256.66us     5.51ms
+  Reqs/sec    132312.26   13049.56  140079.17
+  Latency      744.85us   332.90us     6.46ms
   Latency Distribution
-     50%   723.00us
-     75%     0.92ms
-     90%     1.13ms
-     99%     1.75ms
+     50%   697.00us
+     75%     0.86ms
+     90%     1.09ms
+     99%     1.98ms
 ### HTML Response (/html)
-  Reqs/sec    148007.57   13989.76  160350.19
-  Latency      651.41us   301.19us     5.61ms
+  Reqs/sec    144390.87   12257.61  157078.15
+  Latency      669.02us   376.40us     6.71ms
   Latency Distribution
-     50%   611.00us
-     75%   789.00us
-     90%     1.02ms
-     99%     1.87ms
+     50%   578.00us
+     75%   812.00us
+     90%     1.09ms
+     99%     3.00ms
 ### Redirect Response (/redirect)
 ### File Static via FileResponse (/file-static)
-  Reqs/sec     37803.35    8109.26   44473.58
-  Latency        2.66ms     1.55ms    23.30ms
+  Reqs/sec     36361.95    8136.85   41655.87
+  Latency        2.74ms     1.40ms    18.89ms
   Latency Distribution
-     50%     2.32ms
-     75%     3.16ms
-     90%     4.21ms
-     99%     9.03ms
+     50%     2.42ms
+     75%     3.19ms
+     90%     4.14ms
+     99%     9.81ms
 
 ## Authentication & Authorization Performance
 ### Auth NO User Access (/auth/no-user-access) - lazy loading, no DB query
-  Reqs/sec     77222.56    5659.26   81113.76
-  Latency        1.27ms   342.00us     4.63ms
+  Reqs/sec     74800.80    4747.87   77447.11
+  Latency        1.31ms   359.16us     5.36ms
   Latency Distribution
-     50%     1.23ms
-     75%     1.53ms
-     90%     1.86ms
-     99%     2.72ms
+     50%     1.27ms
+     75%     1.65ms
+     90%     2.05ms
+     99%     2.74ms
 ### Get Authenticated User (/auth/me) - accesses request.user, triggers DB query
-  Reqs/sec     17438.55    1200.87   19326.99
-  Latency        5.71ms     1.41ms    18.84ms
+  Reqs/sec     16865.38    1550.96   18982.12
+  Latency        5.91ms     1.18ms    13.62ms
   Latency Distribution
-     50%     5.74ms
-     75%     6.95ms
-     90%     7.90ms
-     99%     9.77ms
+     50%     5.92ms
+     75%     6.66ms
+     90%     7.43ms
+     99%    10.09ms
 ### Get User via Dependency (/auth/me-dependency)
-  Reqs/sec     15565.93     813.86   16646.78
-  Latency        6.39ms     1.42ms    13.85ms
+ 5975 / 10000 [=========================================================================================>------------------------------------------------------------]  59.75% 14890/s
+  Reqs/sec     14554.52    1502.58   15745.97
+  Latency        6.84ms     2.11ms    24.57ms
   Latency Distribution
-     50%     6.20ms
-     75%     7.37ms
-     90%     8.63ms
-     99%    11.11ms
+     50%     6.69ms
+     75%     8.28ms
+     90%     9.72ms
+     99%    13.45ms
 ### Get Auth Context (/auth/context) validated jwt no db
-  Reqs/sec     87228.01    6545.25   92217.60
-  Latency        1.12ms   348.57us     6.74ms
+  Reqs/sec     58291.30    4167.45   63511.39
+  Latency        1.68ms   644.51us     8.45ms
   Latency Distribution
-     50%     1.07ms
-     75%     1.38ms
-     90%     1.73ms
-     99%     2.40ms
+     50%     1.60ms
+     75%     2.15ms
+     90%     2.79ms
+     99%     4.22ms
 
 ## Items GET Performance (/items/1?q=hello)
-  Reqs/sec    155017.78   13239.06  163450.43
-  Latency      630.77us   252.32us     7.94ms
+  Reqs/sec    109473.67   18624.64  119472.35
+  Latency        0.90ms   644.28us     9.41ms
   Latency Distribution
-     50%   592.00us
-     75%   707.00us
-     90%     0.89ms
-     99%     1.75ms
+     50%   714.00us
+     75%     1.04ms
+     90%     1.62ms
+     99%     4.00ms
 
 ## Items PUT JSON Performance (/items/1)
-  Reqs/sec    102177.92    7272.26  107881.39
-  Latency        0.96ms   316.69us     5.34ms
+  Reqs/sec     96422.49    6852.84  104309.35
+  Latency        1.01ms   657.21us     6.22ms
   Latency Distribution
-     50%     0.89ms
-     75%     1.20ms
-     90%     1.53ms
-     99%     2.21ms
+     50%   781.00us
+     75%     1.28ms
+     90%     1.99ms
+     99%     4.20ms
 
 ## ORM Performance
 Seeding 1000 users for benchmark...
 Successfully seeded users
 Validated: 10 users exist in database
 ### Users Full10 (Async) (/users/full10)
-  Reqs/sec     14426.40     929.47   16120.81
-  Latency        6.90ms     2.00ms    19.12ms
+  Reqs/sec     14657.72    1106.08   16732.03
+  Latency        6.80ms     1.31ms    16.10ms
   Latency Distribution
-     50%     7.09ms
-     75%     8.65ms
-     90%     9.84ms
-     99%    12.23ms
+     50%     6.83ms
+     75%     8.07ms
+     90%     8.72ms
+     99%    10.80ms
 ### Users Full10 (Sync) (/users/sync-full10)
-  Reqs/sec     10022.72    1058.17   12591.72
-  Latency        9.95ms     4.20ms    32.67ms
+  Reqs/sec     11872.20   10321.48   82261.65
+  Latency        9.56ms     4.05ms    27.89ms
   Latency Distribution
-     50%     9.13ms
-     75%    12.54ms
-     90%    16.46ms
-     99%    23.03ms
+     50%     9.10ms
+     75%    12.34ms
+     90%    15.72ms
+     99%    21.25ms
 ### Users Mini10 (Async) (/users/mini10)
-  Reqs/sec     16670.79     755.83   17372.72
-  Latency        5.96ms     1.42ms    15.01ms
+  Reqs/sec     17806.15    1409.26   23418.75
+  Latency        5.63ms     1.64ms    16.10ms
   Latency Distribution
-     50%     5.77ms
-     75%     7.10ms
-     90%     8.33ms
-     99%    10.27ms
+     50%     5.40ms
+     75%     6.79ms
+     90%     8.47ms
+     99%    10.58ms
 ### Users Mini10 (Sync) (/users/sync-mini10)
-  Reqs/sec     12256.80    1036.43   14738.06
-  Latency        8.05ms     4.33ms    36.00ms
+  Reqs/sec     12044.09    1017.44   14647.10
+  Latency        8.27ms     2.87ms    23.29ms
   Latency Distribution
-     50%     7.03ms
-     75%     9.41ms
-     90%    13.65ms
-     99%    24.88ms
+     50%     8.01ms
+     75%    10.32ms
+     90%    12.57ms
+     99%    16.79ms
 Cleaning up test users...
 
 ## Class-Based Views (CBV) Performance
 ### Simple APIView GET (/cbv-simple)
-  Reqs/sec    108777.69    9141.80  115683.00
-  Latency        0.90ms   321.09us     5.30ms
+  Reqs/sec    101042.86    8074.88  107524.29
+  Latency        0.97ms   308.09us     3.74ms
   Latency Distribution
-     50%   829.00us
-     75%     1.11ms
-     90%     1.42ms
-     99%     2.27ms
+     50%     0.90ms
+     75%     1.20ms
+     90%     1.54ms
+     99%     2.37ms
 ### Simple APIView POST (/cbv-simple)
-  Reqs/sec    108054.99    6378.76  114500.95
-  Latency        0.91ms   276.73us     3.85ms
+  Reqs/sec    105457.25    7573.23  113547.62
+  Latency        0.92ms   255.86us     4.33ms
   Latency Distribution
-     50%   844.00us
-     75%     1.11ms
-     90%     1.43ms
-     99%     2.18ms
+     50%     0.88ms
+     75%     1.13ms
+     90%     1.42ms
+     99%     2.02ms
 ### Items100 ViewSet GET (/cbv-items100)
-  Reqs/sec     71144.79    6621.37   83675.75
-  Latency        1.42ms   347.24us     4.41ms
+  Reqs/sec     66022.63    4482.97   69664.27
+  Latency        1.49ms   472.98us     5.45ms
   Latency Distribution
-     50%     1.35ms
-     75%     1.63ms
-     90%     2.02ms
-     99%     2.89ms
+     50%     1.37ms
+     75%     1.84ms
+     90%     2.34ms
+     99%     3.69ms
 
 ## CBV Items - Basic Operations
 ### CBV Items GET (Retrieve) (/cbv-items/1)
-  Reqs/sec    106119.86    8093.90  112035.86
-  Latency        0.92ms   299.61us     4.90ms
+  Reqs/sec    104669.61   17764.10  137262.08
+  Latency        1.00ms   325.64us     4.61ms
   Latency Distribution
-     50%     0.86ms
-     75%     1.13ms
-     90%     1.40ms
-     99%     2.08ms
+     50%     0.95ms
+     75%     1.23ms
+     90%     1.54ms
+     99%     2.50ms
 ### CBV Items PUT (Update) (/cbv-items/1)
-  Reqs/sec    103297.30    5588.74  107429.71
-  Latency        0.95ms   303.56us     4.19ms
+  Reqs/sec    100802.87    8247.73  106563.34
+  Latency        0.98ms   349.36us     5.49ms
   Latency Distribution
-     50%     0.88ms
-     75%     1.17ms
-     90%     1.49ms
-     99%     2.34ms
+     50%     0.90ms
+     75%     1.22ms
+     90%     1.55ms
+     99%     2.39ms
 
 ## CBV Additional Benchmarks
 ### CBV Bench Parse (POST /cbv-bench-parse)
-  Reqs/sec    103859.55    7332.08  109815.81
-  Latency        0.94ms   294.38us     4.41ms
+  Reqs/sec    105607.78    9230.33  111260.35
+  Latency        0.93ms   316.79us     4.79ms
   Latency Distribution
      50%     0.87ms
-     75%     1.17ms
+     75%     1.16ms
      90%     1.45ms
-     99%     2.19ms
+     99%     2.23ms
 ### CBV Response Types (/cbv-response)
-  Reqs/sec    109067.69    5861.10  113356.97
-  Latency        0.90ms   285.76us     4.79ms
+  Reqs/sec    112853.32   11057.13  122369.44
+  Latency        0.88ms   288.93us     4.59ms
   Latency Distribution
-     50%   845.00us
-     75%     1.12ms
-     90%     1.39ms
-     99%     1.94ms
+     50%   828.00us
+     75%     1.07ms
+     90%     1.31ms
+     99%     1.96ms
 
 ## ORM Performance with CBV
 Seeding 1000 users for CBV benchmark...
 Successfully seeded users
 Validated: 10 users exist in database
 ### Users CBV Mini10 (List) (/users/cbv-mini10)
-  Reqs/sec     16725.47    1208.37   18054.52
-  Latency        5.95ms     1.68ms    14.55ms
+  Reqs/sec     16662.08    1801.29   22802.32
+  Latency        6.03ms     1.43ms    16.91ms
   Latency Distribution
-     50%     5.78ms
-     75%     7.29ms
-     90%     8.56ms
-     99%    11.01ms
+     50%     5.83ms
+     75%     7.12ms
+     90%     8.22ms
+     99%    10.73ms
 Cleaning up test users...
 
 
 ## Form and File Upload Performance
 ### Form Data (POST /form)
-  Reqs/sec    130986.66    9333.73  138692.24
-  Latency      732.38us   276.19us     5.26ms
+  Reqs/sec    130198.02   15641.78  144273.17
+  Latency      744.44us   311.40us     5.11ms
   Latency Distribution
-     50%   644.00us
-     75%     0.88ms
-     90%     1.34ms
-     99%     1.93ms
+     50%   655.00us
+     75%     0.93ms
+     90%     1.19ms
+     99%     2.26ms
 ### File Upload (POST /upload)
-  Reqs/sec    116971.54    9220.70  122702.59
-  Latency      833.04us   248.79us     4.49ms
+  Reqs/sec    111208.56    6240.72  117078.69
+  Latency        0.87ms   307.42us     5.46ms
   Latency Distribution
-     50%   787.00us
-     75%     1.00ms
-     90%     1.22ms
-     99%     1.84ms
-### Mixed Form with Files (POST /mixed-form)
-  Reqs/sec    112451.02    7925.45  119557.84
-  Latency        0.87ms   250.35us     4.11ms
-  Latency Distribution
-     50%     0.85ms
-     75%     1.07ms
+     50%   825.00us
+     75%     1.06ms
      90%     1.31ms
-     99%     1.90ms
+     99%     2.00ms
+### Mixed Form with Files (POST /mixed-form)
+  Reqs/sec    110506.88   11094.49  118746.57
+  Latency        0.89ms   356.56us     5.81ms
+  Latency Distribution
+     50%     0.89ms
+     75%     1.05ms
+     90%     1.32ms
+     99%     2.12ms
 
 ## Django Middleware Performance
 ### Django Middleware + Messages Framework (/middleware/demo)
 Tests: SessionMiddleware, AuthenticationMiddleware, MessageMiddleware, custom middleware, template rendering
-  Reqs/sec      9902.23     950.72   13257.58
-  Latency       10.09ms     1.84ms    20.54ms
+  Reqs/sec      9654.82    1323.43   15772.65
+  Latency       10.42ms     3.25ms    22.59ms
   Latency Distribution
-     50%    10.15ms
-     75%    11.38ms
-     90%    12.60ms
-     99%    15.86ms
+     50%    10.28ms
+     75%    13.50ms
+     90%    15.05ms
+     99%    19.22ms
 
 ## Django Ninja-style Benchmarks
 ### JSON Parse/Validate (POST /bench/parse)
-  Reqs/sec    147336.90   18313.81  159151.03
-  Latency      667.26us   279.34us     5.70ms
+  Reqs/sec    141924.57   13582.88  159034.36
+  Latency      666.33us   337.02us     7.11ms
   Latency Distribution
-     50%   619.00us
-     75%   777.00us
-     90%     0.98ms
-     99%     1.91ms
+     50%   580.00us
+     75%   762.00us
+     90%     1.05ms
+     99%     1.94ms
 
 ## Serializer Performance Benchmarks
 ### Raw msgspec Serializer (POST /bench/serializer-raw)
-  Reqs/sec    103678.55    9009.08  108659.10
-  Latency        0.95ms   359.40us     5.46ms
+  Reqs/sec     95705.14    8794.07  105981.11
+  Latency        1.02ms   339.13us     4.99ms
   Latency Distribution
-     50%     0.87ms
-     75%     1.18ms
-     90%     1.50ms
-     99%     2.47ms
-### Django-Bolt Serializer with Validators (POST /bench/serializer-validated)
-  Reqs/sec     96704.52    8745.98  106555.46
-  Latency        1.04ms   366.94us     5.83ms
-  Latency Distribution
-     50%     0.95ms
-     75%     1.26ms
+     50%     0.94ms
+     75%     1.28ms
      90%     1.61ms
-     99%     2.48ms
-### Users msgspec Serializer (POST /users/bench/msgspec)
-  Reqs/sec    104853.84    6786.62  109088.29
-  Latency        0.94ms   299.52us     5.87ms
+     99%     2.39ms
+### Django-Bolt Serializer with Validators (POST /bench/serializer-validated)
+  Reqs/sec     82497.67    8881.85   91438.51
+  Latency        1.19ms   491.43us     5.24ms
   Latency Distribution
-     50%     0.88ms
-     75%     1.15ms
-     90%     1.42ms
-     99%     1.98ms
+     50%     1.08ms
+     75%     1.50ms
+     90%     1.99ms
+     99%     3.40ms
+### Users msgspec Serializer (POST /users/bench/msgspec)
+  Reqs/sec    100074.17    7966.91  105418.73
+  Latency        0.98ms   292.98us     4.38ms
+  Latency Distribution
+     50%     0.93ms
+     75%     1.22ms
+     90%     1.53ms
+     99%     2.18ms
 
 ## Multi-Response Performance
 
 ### Multi-response tuple return (/bench/multi/tuple)
-  Reqs/sec    110363.09    6650.22  115808.21
-  Latency        0.88ms   255.13us     5.45ms
+  Reqs/sec    104536.52    7443.97  110226.21
+  Latency        0.94ms   272.52us     4.72ms
   Latency Distribution
-     50%   828.00us
-     75%     1.07ms
-     90%     1.35ms
-     99%     1.97ms
+     50%     0.88ms
+     75%     1.15ms
+     90%     1.43ms
+     99%     2.06ms
 
 ### Multi-response bare dict (/bench/multi/dict)
-  Reqs/sec    111087.19    9766.90  117257.20
-  Latency        0.89ms   290.09us     5.25ms
+  Reqs/sec    105462.51    8015.75  109712.09
+  Latency        0.94ms   261.31us     4.09ms
   Latency Distribution
-     50%   823.00us
-     75%     1.08ms
-     90%     1.36ms
-     99%     2.09ms
+     50%     0.87ms
+     75%     1.16ms
+     90%     1.47ms
+     99%     2.11ms
 
 ## Latency Percentile Benchmarks
 Measures p50/p75/p90/p99 latency for type coercion overhead analysis
 
 ### Baseline - No Parameters (/)
-  Reqs/sec    180126.03   11669.83  189094.84
-  Latency      542.71us   291.87us     5.03ms
+  Reqs/sec    177093.25   15530.89  187728.72
+  Latency      547.83us   259.39us     6.14ms
   Latency Distribution
-     50%   489.00us
-     75%   589.00us
-     90%   777.00us
-     99%     1.58ms
+     50%   508.00us
+     75%   661.00us
+     90%   846.00us
+     99%     1.77ms
 
 ### Path Parameter - int (/items/12345)
-  Reqs/sec    152031.30   13845.73  166130.49
-  Latency      636.38us   274.35us     5.71ms
+  Reqs/sec    151037.20   11113.15  164068.41
+  Latency      632.15us   228.37us     3.50ms
   Latency Distribution
-     50%   582.00us
-     75%   773.00us
-     90%     0.99ms
-     99%     1.83ms
+     50%   563.00us
+     75%   801.00us
+     90%     0.97ms
+     99%     1.79ms
 
 ### Path + Query Parameters (/items/12345?q=hello)
-  Reqs/sec    145538.85    8579.79  152675.47
-  Latency      668.21us   305.59us     5.64ms
+  Reqs/sec    149258.31   11998.76  158296.09
+  Latency      654.58us   267.54us     5.25ms
   Latency Distribution
-     50%   631.00us
-     75%   804.00us
-     90%     1.03ms
-     99%     1.65ms
+     50%   595.00us
+     75%   767.00us
+     90%     1.00ms
+     99%     1.72ms
 
 ### Header Parameter (/header)
-  Reqs/sec    102013.76    7342.16  106203.28
-  Latency        0.96ms   326.16us     5.08ms
+  Reqs/sec    102926.87    8902.22  111030.76
+  Latency        0.95ms   339.80us     4.80ms
   Latency Distribution
-     50%     0.90ms
-     75%     1.20ms
-     90%     1.50ms
-     99%     2.36ms
+     50%     0.86ms
+     75%     1.19ms
+     90%     1.56ms
+     99%     2.37ms
 
 ### Cookie Parameter (/cookie)
-  Reqs/sec    101603.23    7588.00  106427.72
-  Latency        0.96ms   311.63us     4.70ms
+  Reqs/sec     93843.28   11324.04  103163.45
+  Latency        1.04ms   450.79us     7.07ms
   Latency Distribution
-     50%     0.90ms
-     75%     1.21ms
-     90%     1.54ms
-     99%     2.24ms
+     50%     0.95ms
+     75%     1.27ms
+     90%     1.61ms
+     99%     2.78ms
 
 ### Auth Context - JWT validated, no DB (/auth/context)
-  Reqs/sec     87614.19    5702.34   91616.18
-  Latency        1.12ms   319.02us     5.13ms
+  Reqs/sec     84658.51    7144.54   90097.12
+  Latency        1.16ms   368.90us     5.00ms
   Latency Distribution
-     50%     1.06ms
-     75%     1.38ms
-     90%     1.68ms
-     99%     2.43ms
+     50%     1.07ms
+     75%     1.43ms
+     90%     1.80ms
+     99%     2.80ms

--- a/python/django_bolt/admin/static_routes.py
+++ b/python/django_bolt/admin/static_routes.py
@@ -16,6 +16,7 @@ from django_bolt.middleware.compiler import (
     add_optimization_flags_to_metadata,
     compile_middleware_meta,
 )
+from django_bolt.serialization import compile_response_handlers
 from django_bolt.typing import FieldDefinition
 
 if TYPE_CHECKING:
@@ -121,12 +122,16 @@ class StaticRouteRegistrar:
         meta["_stream_info"] = (False, None)
         meta["is_multi_response"] = False
         meta["default_status_code"] = 200
+        meta["validate_response"] = False
         meta["_router_middleware"] = []
         meta["_route_middleware"] = []
         meta["_has_route_python_middleware"] = False
         meta["has_file_uploads"] = False
 
         self.api._handler_meta[handler_id] = meta
+
+        # Compile response handlers (required by serialize_response).
+        compile_response_handlers(meta)
 
         # Compile the handler executor (required by _dispatch for both fast
         # path and middleware path).  Must happen after meta is stored because

--- a/python/django_bolt/api.py
+++ b/python/django_bolt/api.py
@@ -37,7 +37,7 @@ from .analysis import analyze_handler, warn_blocking_handler
 from .auth import get_default_authentication_classes, register_auth_backend
 from .auth.user_loader import load_user_sync
 from .concurrency import sync_to_thread
-from .decorators import ActionHandler
+from .decorators import _RESPONSE_MODEL_UNSET, ActionHandler
 from .error_handlers import handle_exception
 from .exceptions import HTTPException
 from .logging.middleware import LoggingMiddleware, create_logging_middleware
@@ -66,10 +66,11 @@ from .serialization import (
     ResponseWireV1,
     _convert_serializers,
     _extract_stream_item_type,
+    _infer_wire_response_type,
     _wire_bytes,
+    compile_response_handlers,
     serialize_json_data,
     serialize_json_data_sync,
-    serialize_json_response,
     serialize_response,
     serialize_response_sync,
 )
@@ -264,18 +265,6 @@ def _rewrite_django_mount_redirect_message(message: dict[str, Any], root_path: s
 def _wire_from_error_parts(status: int, headers: list[tuple[str, str]], body: bytes) -> ResponseWireV1:
     """Convert error-handler parts into ResponseWireV1."""
 
-    def _infer_response_type(content_type: str | None) -> str:
-        if not content_type:
-            return "octetstream"
-        normalized = content_type.split(";", 1)[0].strip().lower()
-        if normalized == "application/json" or normalized.endswith("+json"):
-            return "json"
-        if normalized == "text/plain":
-            return "plaintext"
-        if normalized == "text/html":
-            return "html"
-        return "octetstream"
-
     custom_content_type = None
     custom_headers: list[tuple[str, str]] = []
 
@@ -286,7 +275,7 @@ def _wire_from_error_parts(status: int, headers: list[tuple[str, str]], body: by
             custom_headers.append((key, value))
 
     meta = (
-        _infer_response_type(custom_content_type),
+        _infer_wire_response_type(custom_content_type) if custom_content_type else "octetstream",
         custom_content_type,
         custom_headers or None,
         None,
@@ -305,6 +294,7 @@ class BoltAPI:
         logging_config: Any | None = None,
         compression: Any | None = None,
         openapi_config: Any | None = None,
+        validate_response: bool = True,
     ) -> None:
         """
         Initialize a BoltAPI instance.
@@ -326,6 +316,7 @@ class BoltAPI:
             logging_config: Custom logging configuration
             compression: Compression configuration (CompressionConfig or False to disable)
             openapi_config: OpenAPI documentation configuration
+            validate_response: Default response validation policy for registered routes
         """
         self._routes: list[tuple[str, str, int, Callable]] = []
         self._websocket_routes: list[tuple[str, int, Callable]] = []  # (path, handler_id, handler)
@@ -337,6 +328,7 @@ class BoltAPI:
         self._next_handler_id = 0
         self.prefix = prefix.rstrip("/")  # Remove trailing slash from prefix
         self.trailing_slash = trailing_slash  # Mode: "strip", "append", or "keep"
+        self._validate_response_default = validate_response
 
         # Build middleware list: Django middleware first, then custom middleware
         self._middleware = []
@@ -460,8 +452,9 @@ class BoltAPI:
         self,
         path: str,
         *,
-        response_model: Any | None = None,
+        response_model: Any = _RESPONSE_MODEL_UNSET,
         status_code: int | None = None,
+        validate_response: bool | None = None,
         guards: list[Any] | None = None,
         auth: list[Any] | None = None,
         tags: list[str] | None = None,
@@ -473,6 +466,7 @@ class BoltAPI:
             path,
             response_model=response_model,
             status_code=status_code,
+            validate_response=validate_response,
             guards=guards,
             auth=auth,
             tags=tags,
@@ -484,8 +478,9 @@ class BoltAPI:
         self,
         path: str,
         *,
-        response_model: Any | None = None,
+        response_model: Any = _RESPONSE_MODEL_UNSET,
         status_code: int | None = None,
+        validate_response: bool | None = None,
         guards: list[Any] | None = None,
         auth: list[Any] | None = None,
         tags: list[str] | None = None,
@@ -497,6 +492,7 @@ class BoltAPI:
             path,
             response_model=response_model,
             status_code=status_code,
+            validate_response=validate_response,
             guards=guards,
             auth=auth,
             tags=tags,
@@ -508,8 +504,9 @@ class BoltAPI:
         self,
         path: str,
         *,
-        response_model: Any | None = None,
+        response_model: Any = _RESPONSE_MODEL_UNSET,
         status_code: int | None = None,
+        validate_response: bool | None = None,
         guards: list[Any] | None = None,
         auth: list[Any] | None = None,
         tags: list[str] | None = None,
@@ -521,6 +518,7 @@ class BoltAPI:
             path,
             response_model=response_model,
             status_code=status_code,
+            validate_response=validate_response,
             guards=guards,
             auth=auth,
             tags=tags,
@@ -532,8 +530,9 @@ class BoltAPI:
         self,
         path: str,
         *,
-        response_model: Any | None = None,
+        response_model: Any = _RESPONSE_MODEL_UNSET,
         status_code: int | None = None,
+        validate_response: bool | None = None,
         guards: list[Any] | None = None,
         auth: list[Any] | None = None,
         tags: list[str] | None = None,
@@ -545,6 +544,7 @@ class BoltAPI:
             path,
             response_model=response_model,
             status_code=status_code,
+            validate_response=validate_response,
             guards=guards,
             auth=auth,
             tags=tags,
@@ -556,8 +556,9 @@ class BoltAPI:
         self,
         path: str,
         *,
-        response_model: Any | None = None,
+        response_model: Any = _RESPONSE_MODEL_UNSET,
         status_code: int | None = None,
+        validate_response: bool | None = None,
         guards: list[Any] | None = None,
         auth: list[Any] | None = None,
         tags: list[str] | None = None,
@@ -569,6 +570,7 @@ class BoltAPI:
             path,
             response_model=response_model,
             status_code=status_code,
+            validate_response=validate_response,
             guards=guards,
             auth=auth,
             tags=tags,
@@ -580,8 +582,9 @@ class BoltAPI:
         self,
         path: str,
         *,
-        response_model: Any | None = None,
+        response_model: Any = _RESPONSE_MODEL_UNSET,
         status_code: int | None = None,
+        validate_response: bool | None = None,
         guards: list[Any] | None = None,
         auth: list[Any] | None = None,
         tags: list[str] | None = None,
@@ -593,6 +596,7 @@ class BoltAPI:
             path,
             response_model=response_model,
             status_code=status_code,
+            validate_response=validate_response,
             guards=guards,
             auth=auth,
             tags=tags,
@@ -604,8 +608,9 @@ class BoltAPI:
         self,
         path: str,
         *,
-        response_model: Any | None = None,
+        response_model: Any = _RESPONSE_MODEL_UNSET,
         status_code: int | None = None,
+        validate_response: bool | None = None,
         guards: list[Any] | None = None,
         auth: list[Any] | None = None,
         tags: list[str] | None = None,
@@ -617,6 +622,7 @@ class BoltAPI:
             path,
             response_model=response_model,
             status_code=status_code,
+            validate_response=validate_response,
             guards=guards,
             auth=auth,
             tags=tags,
@@ -730,6 +736,7 @@ class BoltAPI:
         guards: list[Any] | None = None,
         auth: list[Any] | None = None,
         status_code: int | None = None,
+        validate_response: bool | None = None,
         tags: list[str] | None = None,
     ):
         """
@@ -802,12 +809,19 @@ class BoltAPI:
                 if merged_status_code is None and hasattr(handler, "__bolt_status_code__"):
                     merged_status_code = handler.__bolt_status_code__
 
+                merged_validate_response = validate_response
+                if merged_validate_response is None:
+                    merged_validate_response = getattr(handler, "validate_response", None)
+                if merged_validate_response is None and hasattr(handler, "__bolt_validate_response__"):
+                    merged_validate_response = handler.__bolt_validate_response__
+
                 # Register using existing route decorator
                 route_decorator = self._route_decorator(
                     method_upper,
                     path,
-                    response_model=None,  # Use method's return annotation
+                    response_model=_RESPONSE_MODEL_UNSET,  # Use method's return annotation
                     status_code=merged_status_code,
+                    validate_response=merged_validate_response,
                     guards=merged_guards,
                     auth=merged_auth,
                     tags=tags,
@@ -832,6 +846,7 @@ class BoltAPI:
         guards: list[Any] | None = None,
         auth: list[Any] | None = None,
         status_code: int | None = None,
+        validate_response: bool | None = None,
         lookup_field: str = "pk",
         tags: list[str] | None = None,
     ):
@@ -927,11 +942,21 @@ class BoltAPI:
                     merged_status_code = action_status_code
 
                 # Check for response_model on the method or original handler
-                method_response_model = getattr(action_method, "response_model", None)
-                if method_response_model is None:
+                method_response_model = getattr(action_method, "response_model", _RESPONSE_MODEL_UNSET)
+                if method_response_model is _RESPONSE_MODEL_UNSET:
                     original = getattr(handler, "__original_handler__", None)
                     if original is not None:
-                        method_response_model = getattr(original, "response_model", None)
+                        method_response_model = getattr(original, "response_model", _RESPONSE_MODEL_UNSET)
+
+                merged_validate_response = validate_response
+                if merged_validate_response is None:
+                    merged_validate_response = getattr(action_method, "validate_response", None)
+                if merged_validate_response is None:
+                    original = getattr(handler, "__original_handler__", None)
+                    if original is not None:
+                        merged_validate_response = getattr(original, "validate_response", None)
+                if merged_validate_response is None and hasattr(handler, "__bolt_validate_response__"):
+                    merged_validate_response = handler.__bolt_validate_response__
 
                 # Register the route
                 route_decorator = self._route_decorator(
@@ -939,6 +964,7 @@ class BoltAPI:
                     route_path,
                     response_model=method_response_model,
                     status_code=merged_status_code,
+                    validate_response=merged_validate_response,
                     guards=merged_guards,
                     auth=merged_auth,
                     tags=tags,
@@ -967,6 +993,7 @@ class BoltAPI:
         # Get class-level auth and guards (if any)
         class_auth = getattr(view_cls, "auth", None)
         class_guards = getattr(view_cls, "guards", None)
+        class_validate_response = getattr(view_cls, "validate_response", None)
 
         # Scan all attributes in the class
         for name in dir(view_cls):
@@ -1038,6 +1065,9 @@ class BoltAPI:
                     # Action-specific takes precedence if explicitly set
                     final_auth = attr.auth if attr.auth is not None else class_auth
                     final_guards = attr.guards if attr.guards is not None else class_guards
+                    final_validate_response = (
+                        attr.validate_response if attr.validate_response is not None else class_validate_response
+                    )
 
                     # Register the custom action
                     decorator = self._route_decorator(
@@ -1045,6 +1075,7 @@ class BoltAPI:
                         action_path,
                         response_model=attr.response_model,
                         status_code=attr.status_code,
+                        validate_response=final_validate_response,
                         guards=final_guards,
                         auth=final_auth,
                         tags=attr.tags,
@@ -1058,8 +1089,9 @@ class BoltAPI:
         method: str,
         path: str,
         *,
-        response_model: Any | None = None,
+        response_model: Any = _RESPONSE_MODEL_UNSET,
         status_code: int | None = None,
+        validate_response: bool | None = None,
         guards: list[Any] | None = None,
         auth: list[Any] | None = None,
         tags: list[str] | None = None,
@@ -1120,8 +1152,14 @@ class BoltAPI:
             # assignment below when is_multi_response=True.
             effective_status: int | None = None
             default_code: int = 0
-            if response_model is not None:
-                if isinstance(response_model, dict):
+            route_validate_response = (
+                self._validate_response_default if validate_response is None else validate_response
+            )
+            if response_model is not _RESPONSE_MODEL_UNSET:
+                if response_model is None:
+                    meta["is_multi_response"] = False
+                    final_response_type = None
+                elif isinstance(response_model, dict):
                     # Dict mode: per-status-code response schemas
                     int_codes = sorted(c for c in response_model if isinstance(c, int))
                     if not int_codes:
@@ -1175,6 +1213,7 @@ class BoltAPI:
                 meta.update(response_meta)
             else:
                 meta["response_type"] = None
+            meta["validate_response"] = route_validate_response
             # Pre-compute stream annotation analysis (registration time only)
             meta["_stream_info"] = _extract_stream_item_type(meta["response_type"])
 
@@ -1215,12 +1254,18 @@ class BoltAPI:
                     entry: dict = {
                         "response_type": resp_type,
                         "default_status_code": code if isinstance(code, int) else handler_default_status,
+                        "validate_response": route_validate_response,
                         "_stream_info": _extract_stream_item_type(resp_type),
                     }
                     if code in field_names_map:
                         entry["response_field_names"] = field_names_map[code]
                     resolved_metas[code] = entry
                 meta["_resolved_metas"] = resolved_metas
+
+            compile_response_handlers(meta)
+            if meta["is_multi_response"]:
+                for entry in meta["_resolved_metas"].values():
+                    compile_response_handlers(entry)
 
             # Compile optimized argument injector (once at registration time)
             # This pre-compiles all parameter extraction logic for maximum performance
@@ -1353,20 +1398,17 @@ class BoltAPI:
                         response_type = entry["response_type"]
                         if response_type is None or data is None:
                             return _wire_bytes(code, _RESPONSE_META_EMPTY, b"")
-                        if isinstance(data, (dict, list)):
+                        if isinstance(data, (dict, list)) and not entry["_has_response_validation"]:
                             if isinstance(data, list):
                                 data = _convert_serializers(data)
-                            return await serialize_json_data(data, response_type, entry, status_code=code)
-                        # Non-dict/list: adjust status code if entry is a shared ellipsis entry.
-                        if entry["default_status_code"] != code:
-                            entry = {**entry, "default_status_code": code}
-                        return await serialize_response(data, entry)
+                            return await serialize_json_data(data, entry, status_code=code)
+                        return await entry["_default_response_handler"](data, status_code=code)
 
                 # JSON() with explicit status: pick schema by its status_code.
                 if isinstance(result, _JSONResponse):
                     entry = resolved_metas.get(result.status_code) or resolved_metas.get(...)
                     if entry is not None:
-                        return await serialize_json_response(result, entry["response_type"], entry)
+                        return await entry["_response_type_handler"](result)
 
                 # Bare dict/list or any other type: use the default status schema.
                 return await serialize_response(result, default_entry)
@@ -1379,19 +1421,17 @@ class BoltAPI:
                         response_type = entry["response_type"]
                         if response_type is None or data is None:
                             return _wire_bytes(code, _RESPONSE_META_EMPTY, b"")
-                        if isinstance(data, (dict, list)):
+                        if isinstance(data, (dict, list)) and not entry["_has_response_validation"]:
                             if isinstance(data, list):
                                 data = _convert_serializers(data)
-                            return serialize_json_data_sync(data, response_type, entry, status_code=code)
-                        if entry["default_status_code"] != code:
-                            entry = {**entry, "default_status_code": code}
-                        return serialize_response_sync(data, entry)
+                            return serialize_json_data_sync(data, entry, status_code=code)
+                        return entry["_default_response_handler_sync"](data, status_code=code)
 
                 # JSON() with explicit status: pick schema by its status_code.
                 if isinstance(result, _JSONResponse):
                     entry = resolved_metas.get(result.status_code) or resolved_metas.get(...)
                     if entry is not None:
-                        return serialize_response_sync(result, entry)
+                        return entry["_response_type_handler_sync"](result)
 
                 return serialize_response_sync(result, default_entry)
 
@@ -1420,8 +1460,8 @@ class BoltAPI:
         # Fast path: async handler without rust-prebound args (most common pattern).
         # Eliminates: state.setdefault, 2×state.pop, has_prebound check.
         if mode != "request_only" and is_async and not is_blocking and not has_rust_prebound and not injector_is_async:
-            response_type = meta["response_type"]
             default_status = meta["default_status_code"]
+            has_response_validation = meta["_has_response_validation"]
 
             # Detect trivially-async handlers: async def with no await statements.
             # These can be dispatched synchronously by driving the coroutine inline
@@ -1438,13 +1478,13 @@ class BoltAPI:
                 except (AttributeError, TypeError):
                     pass
 
-            # Super-fast path: no response_type validation → inline dict/list serialization
+            # Super-fast path: no compiled response validation → inline dict/list serialization
             # directly into the executor. Eliminates 2 async function call overheads
             # (serialize_response + serialize_json_data are both async but never suspend
             # for dict returns with no response model).
             _is_no_params = meta.get("handler_pattern") is HandlerPattern.NO_PARAMS
 
-            if response_type is None:
+            if not has_response_validation:
                 _encode = _json.encode
                 _meta_json = _RESPONSE_META_JSON
 
@@ -1525,11 +1565,11 @@ class BoltAPI:
 
         # Fast path for sync non-blocking handler without rust-prebound args.
         if mode != "request_only" and not is_async and not is_blocking and not has_rust_prebound and not injector_is_async:
-            response_type = meta["response_type"]
             default_status = meta["default_status_code"]
+            has_response_validation = meta["_has_response_validation"]
             _is_no_params_sync = meta.get("handler_pattern") is HandlerPattern.NO_PARAMS
 
-            if response_type is None:
+            if not has_response_validation:
                 _encode = _json.encode
                 _meta_json = _RESPONSE_META_JSON
 

--- a/python/django_bolt/decorators.py
+++ b/python/django_bolt/decorators.py
@@ -7,6 +7,8 @@ Provides decorators for ViewSet custom actions similar to Django REST Framework'
 from collections.abc import Callable
 from typing import Any
 
+_RESPONSE_MODEL_UNSET = object()
+
 
 class ActionHandler:
     """
@@ -38,6 +40,7 @@ class ActionHandler:
         "guards",
         "response_model",
         "status_code",
+        "validate_response",
         "tags",
         "summary",
         "description",
@@ -51,8 +54,9 @@ class ActionHandler:
         path: str | None = None,
         auth: list[Any] | None = None,
         guards: list[Any] | None = None,
-        response_model: Any | None = None,
+        response_model: Any = _RESPONSE_MODEL_UNSET,
         status_code: int | None = None,
+        validate_response: bool | None = None,
         tags: list[str] | None = None,
         summary: str | None = None,
         description: str | None = None,
@@ -65,6 +69,7 @@ class ActionHandler:
         self.guards = guards
         self.response_model = response_model
         self.status_code = status_code
+        self.validate_response = validate_response
         self.tags = tags
         self.summary = summary
         self.description = description
@@ -86,8 +91,9 @@ def action(
     *,
     auth: list[Any] | None = None,
     guards: list[Any] | None = None,
-    response_model: Any | None = None,
+    response_model: Any = _RESPONSE_MODEL_UNSET,
     status_code: int | None = None,
+    validate_response: bool | None = None,
     tags: list[str] | None = None,
     summary: str | None = None,
     description: str | None = None,
@@ -174,6 +180,7 @@ def action(
             guards=guards,
             response_model=response_model,
             status_code=status_code,
+            validate_response=validate_response,
             tags=tags,
             summary=summary,
             description=description,

--- a/python/django_bolt/middleware_response.py
+++ b/python/django_bolt/middleware_response.py
@@ -17,6 +17,7 @@ from .serialization import (
     _BODY_FILE,
     _BODY_STREAM,
     _RESPONSE_META_EMPTY,
+    _RESPONSE_META_HTML,
     _RESPONSE_META_JSON,
     _RESPONSE_META_OCTETSTREAM,
     _RESPONSE_META_PLAINTEXT,
@@ -28,6 +29,7 @@ _META_TAG_TO_RESPONSE_TYPE = {
     _RESPONSE_META_PLAINTEXT: "plaintext",
     _RESPONSE_META_OCTETSTREAM: "octetstream",
     _RESPONSE_META_EMPTY: "empty",
+    _RESPONSE_META_HTML: "html",
 }
 
 # Raw cookie tuple type (matches serialization.py CookieTuple)

--- a/python/django_bolt/serialization.py
+++ b/python/django_bolt/serialization.py
@@ -7,12 +7,23 @@ import mimetypes
 import types
 from collections.abc import (
     AsyncGenerator as AsyncGeneratorABC,
+)
+from collections.abc import (
     AsyncIterable as AsyncIterableABC,
+)
+from collections.abc import (
     AsyncIterator as AsyncIteratorABC,
+)
+from collections.abc import (
     Generator as GeneratorABC,
+)
+from collections.abc import (
     Iterable as IterableABC,
+)
+from collections.abc import (
     Iterator as IteratorABC,
 )
+from functools import cache
 from typing import TYPE_CHECKING, Any, Literal, Union, get_args, get_origin
 
 import msgspec
@@ -50,7 +61,7 @@ _BODY_STREAM: int = 1
 _BODY_FILE: int = 2
 
 BodyKind = Literal[0, 1, 2]
-ResponseWireV1 = tuple[int, ResponseMetaTuple, BodyKind, bytes | StreamingResponse | str]
+ResponseWireV1 = tuple[int, ResponseMetaTuple | int, BodyKind, bytes | StreamingResponse | str]
 
 
 def _build_response_meta(
@@ -111,6 +122,7 @@ _RESPONSE_META_JSON: int = 0
 _RESPONSE_META_PLAINTEXT: int = 1
 _RESPONSE_META_OCTETSTREAM: int = 2
 _RESPONSE_META_EMPTY: int = 3
+_RESPONSE_META_HTML: int = 4
 _TYPED_STREAM_MEDIA_TYPE = "application/x-ndjson"
 _RAW_STREAM_CHUNK_TYPES = (bytes, bytearray, memoryview, str)
 _STREAM_ANNOTATION_ORIGINS = {
@@ -151,6 +163,153 @@ def _convert_serializers(result: Any) -> Any:
     return result
 
 
+_RESPONSE_INSTANCE_TYPES = (
+    JSON,
+    PlainText,
+    HTML,
+    Redirect,
+    File,
+    FileResponse,
+    StreamingResponse,
+    ResponseClass,
+    DjangoHttpResponse,
+)
+_STATIC_RESPONSE_META = {
+    "json": _RESPONSE_META_JSON,
+    "plaintext": _RESPONSE_META_PLAINTEXT,
+    "octetstream": _RESPONSE_META_OCTETSTREAM,
+    "html": _RESPONSE_META_HTML,
+}
+_VALIDATION_NOOP_TYPES = {
+    dict,
+    list,
+    str,
+    int,
+    float,
+    bool,
+    bytes,
+    bytearray,
+    type(None),
+}
+
+
+def _response_validation_error(exc: Exception) -> ResponseWireV1:
+    err = f"Response validation error: {exc}"
+    return _wire_bytes(
+        500,
+        _build_response_meta(
+            "plaintext",
+            {"content-type": "text/plain; charset=utf-8"},
+            None,
+        ),
+        err.encode(),
+    )
+
+
+def _build_wire_meta(
+    response_type: str,
+    custom_headers: dict[str, str] | None,
+    cookies: list[Cookie] | None,
+) -> ResponseMetaTuple | int:
+    if not custom_headers and not cookies:
+        static_meta = _STATIC_RESPONSE_META.get(response_type)
+        if static_meta is not None:
+            return static_meta
+    return _build_response_meta(response_type, custom_headers, cookies)
+
+
+@cache
+def _infer_wire_response_type(media_type: str) -> str:
+    normalized = media_type.split(";", 1)[0].strip().lower()
+    if normalized == "application/json" or normalized.endswith("+json"):
+        return "json"
+    if normalized == "text/plain":
+        return "plaintext"
+    if normalized == "text/html":
+        return "html"
+    return "octetstream"
+
+
+@cache
+def _is_json_media_type(media_type: str) -> bool:
+    normalized = media_type.split(";", 1)[0].strip().lower()
+    return normalized == "application/json" or normalized.endswith("+json")
+
+
+def _render_response_body(content: Any, media_type: str) -> bytes:
+    if _is_json_media_type(media_type):
+        return _json.encode(content)
+    if isinstance(content, memoryview):
+        return content.tobytes()
+    if isinstance(content, (bytes, bytearray)):
+        return bytes(content)
+    if isinstance(content, str):
+        return content.encode()
+    return str(content).encode()
+
+
+def _ensure_content_type_header(headers: dict[str, str] | None, media_type: str) -> dict[str, str]:
+    normalized = headers.copy() if headers else {}
+    if not any(k.lower() == "content-type" for k in normalized):
+        normalized["content-type"] = media_type
+    return normalized
+
+
+def _response_validation_is_required(annotation: Any) -> bool:
+    if annotation is None:
+        return False
+    return annotation not in _VALIDATION_NOOP_TYPES
+
+
+def _compile_response_validator(meta: HandlerMetadata | dict[str, Any]) -> tuple[Any, Any]:
+    response_type = meta.get("response_type")
+    if not meta.get("validate_response", True) or not _response_validation_is_required(response_type):
+        return None, None
+
+    def validate_sync(value: Any) -> Any:
+        return coerce_to_response_type(value, response_type, meta=meta)
+
+    async def validate_async(value: Any) -> Any:
+        return await coerce_to_response_type_async(value, response_type, meta=meta)
+
+    return validate_sync, validate_async
+
+
+def _compile_stream_item_validators(meta: HandlerMetadata | dict[str, Any]) -> tuple[Any, Any]:
+    is_stream_annotation, item_type = meta.get("_stream_info", (False, None))
+    if (
+        not is_stream_annotation
+        or item_type is None
+        or item_type in _RAW_STREAM_CHUNK_TYPES
+        or not meta.get("validate_response", True)
+        or not _response_validation_is_required(item_type)
+    ):
+        return None, None
+
+    def validate_sync(value: Any) -> Any:
+        return coerce_to_response_type(value, item_type, meta=meta)
+
+    async def validate_async(value: Any) -> Any:
+        return await coerce_to_response_type_async(value, item_type, meta=meta)
+
+    return validate_sync, validate_async
+
+
+def _compile_queryset_serializers(meta: HandlerMetadata | dict[str, Any]) -> tuple[Any, Any]:
+    field_names = meta.get("response_field_names")
+    if not field_names:
+        return None, None
+
+    def serialize_sync(queryset: QuerySet) -> list[Any]:
+        return list(queryset.values(*field_names))
+
+    async def serialize_async(queryset: QuerySet) -> list[Any]:
+        values_qs = queryset.values(*field_names)
+        return await sync_to_async(list, thread_sensitive=True)(values_qs)
+
+    return serialize_sync, serialize_async
+
+
 def _extract_stream_item_type(annotation: Any) -> tuple[bool, Any | None]:
     """Return (is_stream_annotation, item_type) for streaming return annotations."""
     if annotation is None:
@@ -185,38 +344,42 @@ def _is_stream_protocol_instance(value: Any) -> bool:
     )
 
 
-def _serialize_stream_chunk_sync(chunk: Any, item_type: Any | None, meta: HandlerMetadata) -> bytes | str | bytearray | memoryview:
+def _serialize_stream_chunk_sync(
+    chunk: Any, validator: Any | None,
+) -> bytes | str | bytearray | memoryview:
     """Serialize one stream chunk for sync generators."""
     if isinstance(chunk, _RAW_STREAM_CHUNK_TYPES):
         return chunk
 
     chunk = _convert_serializers(chunk)
-    if item_type is not None:
-        chunk = coerce_to_response_type(chunk, item_type, meta=meta)
+    if validator is not None:
+        chunk = validator(chunk)
     return _json.encode(chunk) + b"\n"
 
 
 async def _serialize_stream_chunk_async(
-    chunk: Any, item_type: Any | None, meta: HandlerMetadata
+    chunk: Any, validator: Any | None,
 ) -> bytes | str | bytearray | memoryview:
     """Serialize one stream chunk for async generators."""
     if isinstance(chunk, _RAW_STREAM_CHUNK_TYPES):
         return chunk
 
     chunk = _convert_serializers(chunk)
-    if item_type is not None:
-        chunk = await coerce_to_response_type_async(chunk, item_type, meta=meta)
+    if validator is not None:
+        chunk = await validator(chunk)
     return _json.encode(chunk) + b"\n"
 
 
 def _wrap_sync_stream_chunks(content: Any, item_type: Any | None, meta: HandlerMetadata):
+    validator = meta.get("_stream_item_validator")
     for chunk in content:
-        yield _serialize_stream_chunk_sync(chunk, item_type, meta)
+        yield _serialize_stream_chunk_sync(chunk, validator)
 
 
 async def _wrap_async_stream_chunks(content: Any, item_type: Any | None, meta: HandlerMetadata):
+    validator = meta.get("_stream_item_validator_async")
     async for chunk in content:
-        yield await _serialize_stream_chunk_async(chunk, item_type, meta)
+        yield await _serialize_stream_chunk_async(chunk, validator)
 
 
 def _to_stream_wire(stream_response: StreamingResponse) -> ResponseWireV1:
@@ -231,7 +394,7 @@ def _to_stream_wire(stream_response: StreamingResponse) -> ResponseWireV1:
 def _build_auto_streaming_response(
     result: Any,
     stream_info: tuple[bool, Any | None],
-    meta: HandlerMetadata,
+    meta: HandlerMetadata | dict[str, Any],
     status_code: int,
 ) -> StreamingResponse | None:
     """Auto-wrap generator/iterator return values into StreamingResponse."""
@@ -255,273 +418,225 @@ def _build_auto_streaming_response(
     return StreamingResponse(result, status_code=status_code)
 
 
-def _resolve_response_type(status_code: int, meta: HandlerMetadata) -> tuple[Any, HandlerMetadata]:
-    """Resolve the response type for a status code in multi-response mode.
+def compile_response_handlers(meta: HandlerMetadata | dict[str, Any]) -> None:
+    validator_sync, validator_async = _compile_response_validator(meta)
+    stream_validator_sync, stream_validator_async = _compile_stream_item_validators(meta)
+    queryset_serializer_sync, queryset_serializer_async = _compile_queryset_serializers(meta)
 
-    Returns a pre-built meta dict with the resolved ``response_type``.
-    """
-    resolved_metas = meta["_resolved_metas"]
-    if status_code in resolved_metas:
-        resolved_meta = resolved_metas[status_code]
-    elif ... in resolved_metas:
-        resolved_meta = resolved_metas[...]
-    else:
-        response_map = meta["response_map"]
+    meta["_response_validator"] = validator_sync
+    meta["_response_validator_async"] = validator_async
+    meta["_stream_item_validator"] = stream_validator_sync
+    meta["_stream_item_validator_async"] = stream_validator_async
+    meta["_queryset_serializer"] = queryset_serializer_sync
+    meta["_queryset_serializer_async"] = queryset_serializer_async
+    meta["_has_response_validation"] = validator_sync is not None or validator_async is not None
+
+    default_status_code = meta["default_status_code"]
+    stream_info = meta.get("_stream_info", (False, None))
+
+    async def data_handler(result: Any, status_code: int | None = None) -> ResponseWireV1:
+        current_status = default_status_code if status_code is None else status_code
+
+        if result is None and current_status == 204:
+            return _wire_bytes(204, _RESPONSE_META_EMPTY, b"")
+
+        if isinstance(result, dict):
+            return await _serialize_json_payload_async(result, current_status, validator_async)
+        if isinstance(result, list):
+            return await _serialize_json_payload_async(_convert_serializers(result), current_status, validator_async)
+        if isinstance(result, (bytes, bytearray)):
+            return _wire_bytes(current_status, _RESPONSE_META_OCTETSTREAM, bytes(result))
+        if isinstance(result, str):
+            return _wire_bytes(current_status, _RESPONSE_META_PLAINTEXT, result.encode())
+
+        auto_stream = _build_auto_streaming_response(result, stream_info, meta, current_status)
+        if auto_stream is not None:
+            return _to_stream_wire(auto_stream)
+
+        original = result
+        result = _convert_serializers(result)
+        if result is not original:
+            return await _serialize_json_payload_async(result, current_status, validator_async)
+
+        if isinstance(result, QuerySet):
+            if queryset_serializer_async is not None:
+                result = await queryset_serializer_async(result)
+            else:
+                result = await sync_to_async(list, thread_sensitive=True)(result)
+            return await _serialize_json_payload_async(result, current_status, validator_async)
+
+        if isinstance(result, msgspec.Struct) or validator_async is not None:
+            return await _serialize_json_payload_async(result, current_status, validator_async)
+
         raise TypeError(
-            f"Status {status_code} has no response schema. "
-            f"Defined: {sorted(c for c in response_map if c is not ...)}"
+            f"Handler returned unsupported type {type(result).__name__!r}. "
+            f"Return dict, list, or a Bolt response type (JSON, PlainText, HTML, Redirect, etc.)"
         )
 
-    return resolved_meta["response_type"], resolved_meta
+    def data_handler_sync(result: Any, status_code: int | None = None) -> ResponseWireV1:
+        current_status = default_status_code if status_code is None else status_code
+
+        if result is None and current_status == 204:
+            return _wire_bytes(204, _RESPONSE_META_EMPTY, b"")
+
+        if isinstance(result, dict):
+            return _serialize_json_payload_sync(result, current_status, validator_sync)
+        if isinstance(result, list):
+            return _serialize_json_payload_sync(_convert_serializers(result), current_status, validator_sync)
+        if isinstance(result, (bytes, bytearray)):
+            return _wire_bytes(current_status, _RESPONSE_META_OCTETSTREAM, bytes(result))
+        if isinstance(result, str):
+            return _wire_bytes(current_status, _RESPONSE_META_PLAINTEXT, result.encode())
+
+        auto_stream = _build_auto_streaming_response(result, stream_info, meta, current_status)
+        if auto_stream is not None:
+            return _to_stream_wire(auto_stream)
+
+        original = result
+        result = _convert_serializers(result)
+        if result is not original:
+            return _serialize_json_payload_sync(result, current_status, validator_sync)
+
+        if isinstance(result, QuerySet):
+            result = queryset_serializer_sync(result) if queryset_serializer_sync is not None else list(result)
+            return _serialize_json_payload_sync(result, current_status, validator_sync)
+
+        if isinstance(result, msgspec.Struct) or validator_sync is not None:
+            return _serialize_json_payload_sync(result, current_status, validator_sync)
+
+        raise TypeError(
+            f"Handler returned unsupported type {type(result).__name__!r}. "
+            f"Return dict, list, or a Bolt response type (JSON, PlainText, HTML, Redirect, etc.)"
+        )
+
+    async def response_type_handler(result: Any) -> ResponseWireV1:
+        if isinstance(result, JSON):
+            if validator_async is not None:
+                try:
+                    data_bytes = _json.encode(await validator_async(result.data))
+                except Exception as exc:
+                    return _response_validation_error(exc)
+            else:
+                data_bytes = result.to_bytes()
+            cookies = getattr(result, "_cookies", None)
+            return _wire_bytes(result.status_code, _build_wire_meta("json", result.headers, cookies), data_bytes)
+        if isinstance(result, StreamingResponse):
+            return _to_stream_wire(result)
+        if isinstance(result, PlainText):
+            return serialize_plaintext_response(result)
+        if isinstance(result, HTML):
+            return serialize_html_response(result)
+        if isinstance(result, Redirect):
+            return serialize_redirect_response(result)
+        if isinstance(result, File):
+            return serialize_file_response(result)
+        if isinstance(result, FileResponse):
+            return serialize_file_streaming_response(result)
+        if isinstance(result, ResponseClass):
+            if validator_async is not None:
+                try:
+                    body = _render_response_body(await validator_async(result.content), result.media_type)
+                except Exception as exc:
+                    return _response_validation_error(exc)
+            else:
+                body = _render_response_body(result.content, result.media_type)
+            rt = _infer_wire_response_type(result.media_type)
+            hdrs = _ensure_content_type_header(result.headers, result.media_type)
+            cookies = getattr(result, "_cookies", None)
+            return _wire_bytes(result.status_code, _build_wire_meta(rt, hdrs, cookies), body)
+        if isinstance(result, DjangoHttpResponse):
+            return serialize_django_response(result)
+        raise TypeError(f"Unsupported response type {type(result).__name__!r}")
+
+    def response_type_handler_sync(result: Any) -> ResponseWireV1:
+        if isinstance(result, JSON):
+            if validator_sync is not None:
+                try:
+                    data_bytes = _json.encode(validator_sync(result.data))
+                except Exception as exc:
+                    return _response_validation_error(exc)
+            else:
+                data_bytes = result.to_bytes()
+            cookies = getattr(result, "_cookies", None)
+            return _wire_bytes(result.status_code, _build_wire_meta("json", result.headers, cookies), data_bytes)
+        if isinstance(result, StreamingResponse):
+            return _to_stream_wire(result)
+        if isinstance(result, PlainText):
+            return serialize_plaintext_response(result)
+        if isinstance(result, HTML):
+            return serialize_html_response(result)
+        if isinstance(result, Redirect):
+            return serialize_redirect_response(result)
+        if isinstance(result, File):
+            return serialize_file_response(result)
+        if isinstance(result, FileResponse):
+            return serialize_file_streaming_response(result)
+        if isinstance(result, ResponseClass):
+            if validator_sync is not None:
+                try:
+                    body = _render_response_body(validator_sync(result.content), result.media_type)
+                except Exception as exc:
+                    return _response_validation_error(exc)
+            else:
+                body = _render_response_body(result.content, result.media_type)
+            rt = _infer_wire_response_type(result.media_type)
+            hdrs = _ensure_content_type_header(result.headers, result.media_type)
+            cookies = getattr(result, "_cookies", None)
+            return _wire_bytes(result.status_code, _build_wire_meta(rt, hdrs, cookies), body)
+        if isinstance(result, DjangoHttpResponse):
+            return serialize_django_response(result)
+        raise TypeError(f"Unsupported response type {type(result).__name__!r}")
+
+    meta["_default_response_handler"] = data_handler
+    meta["_default_response_handler_sync"] = data_handler_sync
+    meta["_response_type_handler"] = response_type_handler
+    meta["_response_type_handler_sync"] = response_type_handler_sync
 
 
-def _dispatch_non_json_type(
-    result: Any, response_type: Any | None, meta: HandlerMetadata, status_code: int
-) -> ResponseWireV1 | None:
-    """Shared type dispatch for non-dict/list response types.
-
-    Returns ResponseWireV1 for handled types, or None if type needs async handling.
-    """
-    # Handle different response types (ordered by frequency for performance)
-    if isinstance(result, JSON):
-        return None  # JSON needs async/sync-specific handling
-    if isinstance(result, StreamingResponse):
-        return _to_stream_wire(result)
-
-    auto_stream = _build_auto_streaming_response(result, meta["_stream_info"], meta, status_code)
-    if auto_stream is not None:
-        return _to_stream_wire(auto_stream)
-
-    if isinstance(result, PlainText):
-        return serialize_plaintext_response(result)
-    if isinstance(result, HTML):
-        return serialize_html_response(result)
-    if isinstance(result, (bytes, bytearray)):
-        return _wire_bytes(status_code, _RESPONSE_META_OCTETSTREAM, bytes(result))
-    if isinstance(result, str):
-        return _wire_bytes(status_code, _RESPONSE_META_PLAINTEXT, result.encode())
-    if isinstance(result, Redirect):
-        return serialize_redirect_response(result)
-    if isinstance(result, File):
-        return serialize_file_response(result)
-    if isinstance(result, FileResponse):
-        return serialize_file_streaming_response(result)
-    if isinstance(result, ResponseClass):
-        return None  # ResponseClass needs async/sync-specific handling
-    if isinstance(result, msgspec.Struct):
-        return None  # Struct needs async/sync-specific JSON handling
-    if isinstance(result, QuerySet):
-        return None  # QuerySet needs async/sync-specific handling
-    if isinstance(result, DjangoHttpResponse):
-        return serialize_django_response(result)
-    return None  # Signal unhandled type
+def is_response_instance(value: Any) -> bool:
+    return isinstance(value, _RESPONSE_INSTANCE_TYPES)
 
 
-async def serialize_response(result: Any, meta: HandlerMetadata) -> ResponseWireV1:
+async def serialize_response(result: Any, meta: HandlerMetadata | dict[str, Any]) -> ResponseWireV1:
     """Serialize handler result to HTTP response."""
-    # Direct access -- keys guaranteed at registration time
-    status_code = meta["default_status_code"]
-    response_type = meta["response_type"]
-
-    # Handle 204 No Content
-    if result is None and status_code == 204:
-        return _wire_bytes(204, _RESPONSE_META_EMPTY, b"")
-
-    # Fast path: dict/list are the most common response types (90%+ of handlers)
-    if isinstance(result, dict):
-        return await serialize_json_data(result, response_type, meta)
-    if isinstance(result, list):
-        result = _convert_serializers(result)
-        return await serialize_json_data(result, response_type, meta)
-
-    # Convert Serializer instances to dicts (handles write_only, computed_field)
-    original = result
-    result = _convert_serializers(result)
-
-    # If _convert_serializers changed the value, it IS dict/list -- skip isinstance re-check
-    if result is not original:
-        return await serialize_json_data(result, response_type, meta)
-
-    # Try shared dispatch first (handles most non-JSON types)
-    shared_result = _dispatch_non_json_type(result, response_type, meta, status_code)
-    if shared_result is not None:
-        return shared_result
-
-    # Async-specific handling for types that need await
-    if isinstance(result, JSON):
-        return await serialize_json_response(result, response_type, meta)
-    if isinstance(result, ResponseClass):
-        return await serialize_generic_response(result, response_type, meta)
-    if isinstance(result, msgspec.Struct):
-        return await serialize_json_data(result, response_type, meta)
-    if isinstance(result, QuerySet):
-        result_list = await sync_to_async(list, thread_sensitive=True)(result)
-        return await serialize_json_data(result_list, response_type, meta)
-
-    raise TypeError(
-        f"Handler returned unsupported type {type(result).__name__!r}. "
-        f"Return dict, list, or a Bolt response type (JSON, PlainText, HTML, Redirect, etc.)"
-    )
+    if is_response_instance(result):
+        return await meta["_response_type_handler"](result)
+    return await meta["_default_response_handler"](result)
 
 
-def serialize_response_sync(result: Any, meta: HandlerMetadata) -> ResponseWireV1:
+def serialize_response_sync(result: Any, meta: HandlerMetadata | dict[str, Any]) -> ResponseWireV1:
     """Serialize handler result to HTTP response (sync version for sync handlers)."""
-    # Direct access -- keys guaranteed at registration time
-    status_code = meta["default_status_code"]
-    response_type = meta["response_type"]
-
-    # Handle 204 No Content
-    if result is None and status_code == 204:
-        return _wire_bytes(204, _RESPONSE_META_EMPTY, b"")
-
-    # Fast path: dict/list are the most common response types (90%+ of handlers)
-    if isinstance(result, dict):
-        return serialize_json_data_sync(result, response_type, meta)
-    if isinstance(result, list):
-        result = _convert_serializers(result)
-        return serialize_json_data_sync(result, response_type, meta)
-
-    # Convert Serializer instances
-    original = result
-    result = _convert_serializers(result)
-
-    # If _convert_serializers changed the value, skip isinstance re-check
-    if result is not original:
-        return serialize_json_data_sync(result, response_type, meta)
-
-    # Try shared dispatch first (handles most non-JSON types)
-    shared_result = _dispatch_non_json_type(result, response_type, meta, status_code)
-    if shared_result is not None:
-        return shared_result
-
-    # Sync-specific handling
-    if isinstance(result, JSON):
-        if response_type is not None:
-            try:
-                validated = coerce_to_response_type(result.data, response_type, meta=meta)
-                data_bytes = _json.encode(validated)
-            except Exception as e:
-                err = f"Response validation error: {e}"
-                return _wire_bytes(
-                    500,
-                    _build_response_meta(
-                        "plaintext",
-                        {"content-type": "text/plain; charset=utf-8"},
-                        None,
-                    ),
-                    err.encode(),
-                )
-        else:
-            data_bytes = result.to_bytes()
-        cookies = getattr(result, "_cookies", None)
-        resp_meta = _build_response_meta("json", result.headers, cookies)
-        return _wire_bytes(result.status_code, resp_meta, data_bytes)
-    elif isinstance(result, ResponseClass):
-        if response_type is not None:
-            try:
-                validated = coerce_to_response_type(result.content, response_type, meta=meta)
-                data_bytes = _json.encode(validated) if result.media_type == "application/json" else result.to_bytes()
-            except Exception as e:
-                err = f"Response validation error: {e}"
-                return _wire_bytes(
-                    500,
-                    _build_response_meta(
-                        "plaintext",
-                        {"content-type": "text/plain; charset=utf-8"},
-                        None,
-                    ),
-                    err.encode(),
-                )
-        else:
-            data_bytes = result.to_bytes()
-
-        response_type = "json" if result.media_type == "application/json" else "octetstream"
-        headers = result.headers.copy() if result.headers else {}
-        has_custom_content_type = any(k.lower() == "content-type" for k in headers)
-        if not has_custom_content_type:
-            headers["content-type"] = result.media_type
-
-        cookies = getattr(result, "_cookies", None)
-        resp_meta = _build_response_meta(response_type, headers, cookies)
-        return _wire_bytes(result.status_code, resp_meta, data_bytes)
-    elif isinstance(result, msgspec.Struct):
-        return serialize_json_data_sync(result, response_type, meta)
-    elif isinstance(result, QuerySet):
-        return serialize_json_data_sync(list(result), response_type, meta)
-
-    raise TypeError(
-        f"Handler returned unsupported type {type(result).__name__!r}. "
-        f"Return dict, list, or a Bolt response type (JSON, PlainText, HTML, Redirect, etc.)"
-    )
+    if is_response_instance(result):
+        return meta["_response_type_handler_sync"](result)
+    return meta["_default_response_handler_sync"](result)
 
 
-async def serialize_generic_response(
-    result: ResponseClass, response_tp: Any | None, meta: HandlerMetadata | None = None
+async def _serialize_json_payload_async(
+    result: Any,
+    status_code: int,
+    validator: Any = None,
 ) -> ResponseWireV1:
-    """Serialize generic Response object with custom headers.
-
-    Uses the new ResponseMeta tuple format for Rust-side header building.
-    """
-    if response_tp is not None:
+    if validator is not None:
         try:
-            validated = await coerce_to_response_type_async(result.content, response_tp, meta=meta)
-            data_bytes = _json.encode(validated) if result.media_type == "application/json" else result.to_bytes()
-        except Exception as e:
-            err = f"Response validation error: {e}"
-            return _wire_bytes(
-                500,
-                _build_response_meta(
-                    "plaintext",
-                    {"content-type": "text/plain; charset=utf-8"},
-                    None,
-                ),
-                err.encode(),
-            )
-    else:
-        data_bytes = result.to_bytes()
+            result = await validator(result)
+        except Exception as exc:
+            return _response_validation_error(exc)
 
-    # Determine response type based on media_type
-    response_type = "json" if result.media_type == "application/json" else "octetstream"
-
-    # Build headers dict with media_type as content-type if not already provided
-    headers = result.headers.copy() if result.headers else {}
-    has_custom_content_type = any(k.lower() == "content-type" for k in headers)
-    if not has_custom_content_type:
-        headers["content-type"] = result.media_type
-
-    cookies = getattr(result, "_cookies", None)
-    resp_meta = _build_response_meta(response_type, headers, cookies)
-    return _wire_bytes(result.status_code, resp_meta, data_bytes)
+    return _wire_bytes(status_code, _RESPONSE_META_JSON, _json.encode(result))
 
 
-async def serialize_json_response(
-    result: JSON, response_tp: Any | None, meta: HandlerMetadata | None = None
+def _serialize_json_payload_sync(
+    result: Any,
+    status_code: int,
+    validator: Any = None,
 ) -> ResponseWireV1:
-    """Serialize JSON response object.
-
-    Uses the new ResponseMeta tuple format for Rust-side header building.
-    """
-    if response_tp is not None:
+    if validator is not None:
         try:
-            validated = await coerce_to_response_type_async(result.data, response_tp, meta=meta)
-            data_bytes = _json.encode(validated)
-        except Exception as e:
-            err = f"Response validation error: {e}"
-            return _wire_bytes(
-                500,
-                _build_response_meta(
-                    "plaintext",
-                    {"content-type": "text/plain; charset=utf-8"},
-                    None,
-                ),
-                err.encode(),
-            )
-    else:
-        data_bytes = result.to_bytes()
+            result = validator(result)
+        except Exception as exc:
+            return _response_validation_error(exc)
 
-    cookies = getattr(result, "_cookies", None)
-    resp_meta = _build_response_meta("json", result.headers, cookies)
-    return _wire_bytes(result.status_code, resp_meta, data_bytes)
+    return _wire_bytes(status_code, _RESPONSE_META_JSON, _json.encode(result))
 
 
 def serialize_plaintext_response(result: PlainText) -> ResponseWireV1:
@@ -530,7 +645,7 @@ def serialize_plaintext_response(result: PlainText) -> ResponseWireV1:
     Uses the new ResponseMeta tuple format for Rust-side header building.
     """
     cookies = getattr(result, "_cookies", None)
-    resp_meta = _build_response_meta("plaintext", result.headers, cookies)
+    resp_meta = _build_wire_meta("plaintext", result.headers, cookies)
     return _wire_bytes(result.status_code, resp_meta, result.to_bytes())
 
 
@@ -540,7 +655,7 @@ def serialize_html_response(result: HTML) -> ResponseWireV1:
     Uses the new ResponseMeta tuple format for Rust-side header building.
     """
     cookies = getattr(result, "_cookies", None)
-    resp_meta = _build_response_meta("html", result.headers, cookies)
+    resp_meta = _build_wire_meta("html", result.headers, cookies)
     return _wire_bytes(result.status_code, resp_meta, result.to_bytes())
 
 
@@ -555,7 +670,7 @@ def serialize_redirect_response(result: Redirect) -> ResponseWireV1:
         custom_headers.update(result.headers)
 
     cookies = getattr(result, "_cookies", None)
-    resp_meta = _build_response_meta("redirect", custom_headers, cookies)
+    resp_meta = _build_wire_meta("redirect", custom_headers, cookies)
     return _wire_bytes(result.status_code, resp_meta, b"")
 
 
@@ -571,12 +686,12 @@ def serialize_django_response(result: DjangoHttpResponse) -> ResponseWireV1:
         for key, value in result.items():
             if key.lower() != "location":
                 headers[key] = value
-        return _wire_bytes(result.status_code, _build_response_meta("redirect", headers, None), b"")
+        return _wire_bytes(result.status_code, _build_wire_meta("redirect", headers, None), b"")
 
     # Generic Django HttpResponse - extract content and headers
     headers = dict(result.items())
     content = result.content if isinstance(result.content, bytes) else result.content.encode()
-    return _wire_bytes(result.status_code, _build_response_meta("octetstream", headers, None), content)
+    return _wire_bytes(result.status_code, _build_wire_meta("octetstream", headers, None), content)
 
 
 def serialize_file_response(result: File) -> ResponseWireV1:
@@ -595,7 +710,7 @@ def serialize_file_response(result: File) -> ResponseWireV1:
         custom_headers.update(result.headers)
 
     cookies = getattr(result, "_cookies", None)
-    resp_meta = _build_response_meta("file", custom_headers, cookies)
+    resp_meta = _build_wire_meta("file", custom_headers, cookies)
     return _wire_bytes(result.status_code, resp_meta, data)
 
 
@@ -616,63 +731,22 @@ def serialize_file_streaming_response(result: FileResponse) -> ResponseWireV1:
         custom_headers.update(result.headers)
 
     cookies = getattr(result, "_cookies", None)
-    resp_meta = _build_response_meta("file", custom_headers, cookies)
+    resp_meta = _build_wire_meta("file", custom_headers, cookies)
     return _wire_file(result.status_code, resp_meta, result.path)
 
 
 async def serialize_json_data(
-    result: Any, response_tp: Any | None, meta: HandlerMetadata, *, status_code: int | None = None
+    result: Any, meta: HandlerMetadata | dict[str, Any], *, status_code: int | None = None
 ) -> ResponseWireV1:
-    """Serialize dict/list/other data as JSON.
-
-    Uses the new ResponseMeta tuple format for Rust-side header building.
-    """
-    if response_tp is not None:
-        try:
-            validated = await coerce_to_response_type_async(result, response_tp, meta=meta)
-            data = _json.encode(validated)
-        except Exception as e:
-            err = f"Response validation error: {e}"
-            return _wire_bytes(
-                500,
-                _build_response_meta(
-                    "plaintext",
-                    {"content-type": "text/plain; charset=utf-8"},
-                    None,
-                ),
-                err.encode(),
-            )
-    else:
-        data = _json.encode(result)
-
+    """Serialize dict/list/other data as JSON."""
     status = status_code if status_code is not None else meta["default_status_code"]
-    return _wire_bytes(status, _RESPONSE_META_JSON, data)
+    return _wire_bytes(status, _RESPONSE_META_JSON, _json.encode(result))
 
 
 def serialize_json_data_sync(
-    result: Any, response_tp: Any | None, meta: HandlerMetadata, *, status_code: int | None = None
+    result: Any, meta: HandlerMetadata | dict[str, Any], *, status_code: int | None = None
 ) -> ResponseWireV1:
-    """Serialize dict/list/other data as JSON (sync version for sync handlers).
-
-    Uses the new ResponseMeta tuple format for Rust-side header building.
-    """
-    if response_tp is not None:
-        try:
-            validated = coerce_to_response_type(result, response_tp, meta=meta)
-            data = _json.encode(validated)
-        except Exception as e:
-            err = f"Response validation error: {e}"
-            return _wire_bytes(
-                500,
-                _build_response_meta(
-                    "plaintext",
-                    {"content-type": "text/plain; charset=utf-8"},
-                    None,
-                ),
-                err.encode(),
-            )
-    else:
-        data = _json.encode(result)
-
+    """Serialize dict/list/other data as JSON (sync version)."""
     status = status_code if status_code is not None else meta["default_status_code"]
-    return _wire_bytes(status, _RESPONSE_META_JSON, data)
+    return _wire_bytes(status, _RESPONSE_META_JSON, _json.encode(result))
+

--- a/python/django_bolt/typing.py
+++ b/python/django_bolt/typing.py
@@ -98,6 +98,9 @@ class HandlerMetadata(TypedDict, total=False):
     default_status_code: int
     """Default HTTP status code for successful responses"""
 
+    validate_response: bool
+    """Whether schema-driven response validation/coercion runs at runtime"""
+
     # QuerySet serialization optimization (pre-computed at registration)
     response_field_names: list[str]
     """Pre-computed field names for QuerySet.values() call"""
@@ -116,6 +119,39 @@ class HandlerMetadata(TypedDict, total=False):
     _resolved_metas: dict[int | type, dict]
     """Pre-built per-status-code meta dicts for O(1) lookup at request time.
     Keys mirror ``response_map`` (int codes + optional ``...``)."""
+
+    _response_validator: Callable[[Any], Any] | None
+    """Compiled sync response validator/coercer"""
+
+    _response_validator_async: Callable[[Any], Any] | None
+    """Compiled async response validator/coercer"""
+
+    _stream_item_validator: Callable[[Any], Any] | None
+    """Compiled sync validator for typed stream items"""
+
+    _stream_item_validator_async: Callable[[Any], Any] | None
+    """Compiled async validator for typed stream items"""
+
+    _queryset_serializer: Callable[[Any], Any] | None
+    """Compiled sync queryset projection serializer"""
+
+    _queryset_serializer_async: Callable[[Any], Any] | None
+    """Compiled async queryset projection serializer"""
+
+    _has_response_validation: bool
+    """Whether this route has a compiled response validator"""
+
+    _default_response_handler: Callable[..., Any]
+    """Compiled async data-response handler"""
+
+    _default_response_handler_sync: Callable[..., Any]
+    """Compiled sync data-response handler"""
+
+    _response_type_handler: Callable[..., Any]
+    """Compiled async explicit-response handler"""
+
+    _response_type_handler_sync: Callable[..., Any]
+    """Compiled sync explicit-response handler"""
 
     # Performance optimizations
     needs_form_parsing: bool

--- a/python/django_bolt/views.py
+++ b/python/django_bolt/views.py
@@ -41,6 +41,7 @@ class APIView:
     guards: list[Any] | None = None
     auth: list[Any] | None = None
     status_code: int | None = None
+    validate_response: bool | None = None
 
     def __init__(self, **kwargs):
         """
@@ -169,6 +170,11 @@ class APIView:
             view_handler.__bolt_auth__ = cls.auth
         if cls.status_code is not None:
             view_handler.__bolt_status_code__ = cls.status_code
+        if cls.validate_response is not None:
+            view_handler.__bolt_validate_response__ = cls.validate_response
+
+        if getattr(method_handler, "validate_response", None) is not None:
+            view_handler.validate_response = method_handler.validate_response
 
         # Copy pagination attributes from method handler (for @paginate decorator)
         if hasattr(method_handler, "__paginated__"):

--- a/python/example/testproject/api.py
+++ b/python/example/testproject/api.py
@@ -390,9 +390,17 @@ async def read_10k():
     """
     return test_data.JSON_10K
 
-
-@api.get("/1k-json")
-async def read_1k():
+class ItemSchema(msgspec.Struct):
+    id: int
+    name: str
+    description: str
+    price: float
+    category: str
+    in_stock: bool
+    tags: list[str]
+    
+@api.get("/1k-json", validate_response=False)
+async def read_1k() -> list[ItemSchema]:
     """
     Endpoint that returns 10k JSON objects.
 

--- a/python/example/testproject/views.py
+++ b/python/example/testproject/views.py
@@ -1,12 +1,11 @@
 import asyncio
 import time
 
+import test_data
 from django.contrib.auth import authenticate, login, logout
 from django.http import JsonResponse, StreamingHttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse
-
-import test_data
 
 
 async def index(request):

--- a/python/tests/test_cookies.py
+++ b/python/tests/test_cookies.py
@@ -347,13 +347,15 @@ class TestAsyncSerializationWithCookies:
 
     async def test_json_async_serialization_includes_cookies(self):
         """Test that JSON async serialization includes raw cookie tuples for Rust."""
-        from django_bolt.serialization import serialize_json_response
+        from django_bolt.serialization import compile_response_handlers, serialize_response
 
+        meta = {"response_type": None, "validate_response": False, "default_status_code": 200, "_stream_info": (False, None)}
+        compile_response_handlers(meta)
         response = JSON({"ok": True}).set_cookie("api_token", "secret123", httponly=True)
-        status, meta, body_kind, body = await serialize_json_response(response, None, None)
+        status, meta_out, body_kind, body = await serialize_response(response, meta)
         assert body_kind == 0  # _BODY_BYTES
-        assert isinstance(meta, tuple)
-        response_type, custom_ct, custom_headers, cookies = meta
+        assert isinstance(meta_out, tuple)
+        response_type, custom_ct, custom_headers, cookies = meta_out
         assert response_type == "json"
         assert cookies is not None
         assert len(cookies) == 1
@@ -364,13 +366,15 @@ class TestAsyncSerializationWithCookies:
 
     async def test_response_async_serialization_includes_cookies(self):
         """Test that Response async serialization includes raw cookie tuples for Rust."""
-        from django_bolt.serialization import serialize_generic_response
+        from django_bolt.serialization import compile_response_handlers, serialize_response
 
+        meta = {"response_type": None, "validate_response": False, "default_status_code": 200, "_stream_info": (False, None)}
+        compile_response_handlers(meta)
         response = Response({"status": "logged_in"}).set_cookie("session", "xyz", secure=True)
-        status, meta, body_kind, body = await serialize_generic_response(response, None, None)
+        status, meta_out, body_kind, body = await serialize_response(response, meta)
         assert body_kind == 0  # _BODY_BYTES
-        assert isinstance(meta, tuple)
-        response_type, custom_ct, custom_headers, cookies = meta
+        assert isinstance(meta_out, tuple)
+        response_type, custom_ct, custom_headers, cookies = meta_out
         assert cookies is not None
         assert len(cookies) == 1
         assert cookies[0][0] == "session"

--- a/python/tests/test_multi_response_integration.py
+++ b/python/tests/test_multi_response_integration.py
@@ -12,7 +12,6 @@ from django_bolt.responses import JSON
 from django_bolt.serializers import Serializer
 from django_bolt.testing import TestClient
 
-
 # ============================================================================
 # Test schemas
 # ============================================================================

--- a/python/tests/test_pagination_serializers.py
+++ b/python/tests/test_pagination_serializers.py
@@ -10,13 +10,12 @@ from __future__ import annotations
 import msgspec
 import pytest
 
-from django_bolt import BoltAPI, PageNumberPagination, LimitOffsetPagination, CursorPagination, paginate
+from django_bolt import BoltAPI, CursorPagination, LimitOffsetPagination, PageNumberPagination, paginate
 from django_bolt.serializers import Serializer
 from django_bolt.testing import TestClient
 from django_bolt.views import ViewSet
 
 from .test_models import Article
-
 
 # ============================================================================
 # Serializers for Testing

--- a/python/tests/test_static_files.py
+++ b/python/tests/test_static_files.py
@@ -21,7 +21,6 @@ from django_bolt.admin.static import find_static_file
 from django_bolt.shortcuts import render
 from django_bolt.testing import TestClient
 
-
 # Create test static files directory
 TEST_STATIC_DIR = tempfile.mkdtemp(prefix="django_bolt_static_")
 
@@ -618,6 +617,7 @@ class TestContentSecurityPolicy:
     def test_csp_header_applied_when_configured(self):
         """Test that CSP header is applied when BOLT_STATIC_CSP is set."""
         from django.conf import settings
+
         from django_bolt.admin.static import register_static_routes
 
         # Configure CSP
@@ -639,6 +639,7 @@ class TestContentSecurityPolicy:
     def test_no_csp_header_when_not_configured(self):
         """Test that no CSP header is added when not configured."""
         from django.conf import settings
+
         from django_bolt.admin.static import register_static_routes
 
         settings.STATIC_ROOT = TEST_STATIC_DIR

--- a/python/tests/test_validate_response.py
+++ b/python/tests/test_validate_response.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import msgspec
+
+from django_bolt import BoltAPI
+from django_bolt.decorators import action
+from django_bolt.testing import TestClient
+from django_bolt.views import APIView, ViewSet
+
+
+class Item(msgspec.Struct):
+    name: str
+    price: float
+
+
+def _get_meta(api: BoltAPI, path: str, method: str = "GET"):
+    for route_method, route_path, handler_id, _handler in api._routes:
+        if route_method == method and route_path == path:
+            return api._handler_meta[handler_id]
+    raise AssertionError(f"Route not found: {method} {path}")
+
+
+def test_validate_response_route_and_api_defaults():
+    api = BoltAPI(validate_response=False)
+
+    @api.get("/default-off")
+    async def default_off() -> list[Item]:
+        return [{"name": "missing-price"}]
+
+    @api.get("/override-on", validate_response=True)
+    async def override_on() -> list[Item]:
+        return [{"name": "missing-price"}]
+
+    @api.get("/model-default-off", response_model=list[Item])
+    async def model_default_off():
+        return [{"name": "missing-price"}]
+
+    @api.get("/model-override-on", response_model=list[Item], validate_response=True)
+    async def model_override_on():
+        return [{"name": "missing-price"}]
+
+    assert _get_meta(api, "/default-off")["_has_response_validation"] is False
+    assert _get_meta(api, "/override-on")["_has_response_validation"] is True
+    assert _get_meta(api, "/model-default-off")["_has_response_validation"] is False
+    assert _get_meta(api, "/model-override-on")["_has_response_validation"] is True
+
+    with TestClient(api) as client:
+        assert client.get("/default-off").json() == [{"name": "missing-price"}]
+        assert client.get("/model-default-off").json() == [{"name": "missing-price"}]
+
+        strict_response = client.get("/override-on")
+        assert strict_response.status_code == 500
+        assert b"Response validation error" in strict_response.content
+
+        strict_model_response = client.get("/model-override-on")
+        assert strict_model_response.status_code == 500
+        assert b"Response validation error" in strict_model_response.content
+
+
+def test_response_model_none_skips_return_annotation_validation():
+    api = BoltAPI()
+
+    @api.get("/explicit-none", response_model=None)
+    async def explicit_none() -> list[Item]:
+        return [{"name": "missing-price"}]
+
+    meta = _get_meta(api, "/explicit-none")
+    assert meta["response_type"] is None
+    assert meta["_has_response_validation"] is False
+
+    with TestClient(api) as client:
+        response = client.get("/explicit-none")
+        assert response.status_code == 200
+        assert response.json() == [{"name": "missing-price"}]
+
+
+def test_validate_response_view_and_viewset_inheritance():
+    api = BoltAPI()
+
+    @api.view("/loose")
+    class LooseView(APIView):
+        validate_response = False
+
+        async def get(self, request) -> list[Item]:
+            return [{"name": "missing-price"}]
+
+    @api.view("/strict", validate_response=True)
+    class StrictView(APIView):
+        validate_response = False
+
+        async def get(self, request) -> list[Item]:
+            return [{"name": "missing-price"}]
+
+    @api.viewset("/widgets")
+    class WidgetViewSet(ViewSet):
+        validate_response = False
+
+        async def list(self, request) -> list[Item]:
+            return [{"name": "missing-price"}]
+
+        @action(methods=["GET"], detail=False, path="strict", validate_response=True)
+        async def strict_action(self, request) -> list[Item]:
+            return [{"name": "missing-price"}]
+
+    assert _get_meta(api, "/loose")["_has_response_validation"] is False
+    assert _get_meta(api, "/strict")["_has_response_validation"] is True
+    assert _get_meta(api, "/widgets")["_has_response_validation"] is False
+    assert _get_meta(api, "/widgets/strict")["_has_response_validation"] is True
+
+    with TestClient(api) as client:
+        assert client.get("/loose").status_code == 200
+        assert client.get("/loose").json() == [{"name": "missing-price"}]
+
+        strict_view = client.get("/strict")
+        assert strict_view.status_code == 500
+        assert b"Response validation error" in strict_view.content
+
+        assert client.get("/widgets").status_code == 200
+        assert client.get("/widgets").json() == [{"name": "missing-price"}]
+
+        strict_action = client.get("/widgets/strict")
+        assert strict_action.status_code == 500
+        assert b"Response validation error" in strict_action.content

--- a/src/response_meta.rs
+++ b/src/response_meta.rs
@@ -110,6 +110,13 @@ pub static STATIC_META_EMPTY: ResponseMeta = ResponseMeta {
     cookies: None,
 };
 
+pub static STATIC_META_HTML: ResponseMeta = ResponseMeta {
+    response_type: ResponseType::Html,
+    custom_content_type: None,
+    custom_headers: None,
+    cookies: None,
+};
+
 impl ResponseMeta {
     /// Fast-path: resolve integer meta tag to static ResponseMeta.
     /// Returns None if the tag is not a known constant.
@@ -120,6 +127,7 @@ impl ResponseMeta {
             1 => Some(&STATIC_META_PLAINTEXT),
             2 => Some(&STATIC_META_OCTETSTREAM),
             3 => Some(&STATIC_META_EMPTY),
+            4 => Some(&STATIC_META_HTML),
             _ => None,
         }
     }

--- a/uv.lock
+++ b/uv.lock
@@ -88,7 +88,7 @@ wheels = [
 
 [[package]]
 name = "django-bolt"
-version = "0.6.5"
+version = "0.6.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
  Description:

  Move response type dispatch, validation, queryset serialization, and
  stream-item coercion from per-request isinstance chains to closures
  compiled once at route registration via `compile_response_handlers()`.

  Key changes:
  - Add `compile_response_handlers()` that pre-builds `_default_response_handler`, `_response_type_handler`, response validators, queryset serializers, and stream-item validators as closures stored in handler metadata
  - Add `validate_response` parameter to route decorators, BoltAPI constructor, ViewSet, APIView, and action decorators to allow opting out of response validation per-route or globally
  - Use `_RESPONSE_MODEL_UNSET` sentinel to distinguish "no model specified" from `response_model=None` (explicitly no validation)
  - Add `_RESPONSE_META_HTML` (tag 4) static constant in both Python and Rust for zero-alloc HTML response meta
  - Add `_build_wire_meta()` helper that returns integer meta tags when no custom headers/cookies are present, avoiding tuple allocation
  - Cache `_infer_wire_response_type()` with `@functools.cache`
  - Simplify `serialize_response` / `serialize_response_sync` to single dispatch calls into pre-compiled handlers
  - Remove `serialize_json_response`, `serialize_generic_response`, `_dispatch_non_json_type`, and `_resolve_response_type` (logic folded into compiled closures)