### PR TITLE
Fix: Surface ASGI mount exception details in HTTP 500 responses

### DIFF
--- a/python/tests/test_asgi_mount.py
+++ b/python/tests/test_asgi_mount.py
@@ -408,3 +408,32 @@ def test_runbolt_allows_prefix_overlap_without_exact_collision():
 
     # Exact collisions are forbidden; prefix overlap is allowed.
     command.validate_asgi_mount_conflicts(routes, asgi_mounts)
+
+
+class _CustomConfigError(Exception):
+    pass
+
+
+@pytest.mark.parametrize(
+    ("exc_class", "exc_msg", "expected_fragments"),
+    [
+        (RuntimeError, "SECRET_KEY must not be empty", ["SECRET_KEY must not be empty"]),
+        (_CustomConfigError, "bad config value", ["_CustomConfigError", "bad config value"]),
+    ],
+    ids=["builtin-exception", "custom-exception-type"],
+)
+def test_mount_asgi_exception_surfaces_in_response(exc_class, exc_msg, expected_fragments):
+    """ASGI app exceptions must appear (type + message) in the HTTP 500 response."""
+    api = BoltAPI()
+
+    async def broken_asgi(scope, receive, send):
+        raise exc_class(exc_msg)
+
+    api.mount_asgi("/broken", broken_asgi)
+
+    with TestClient(api) as client:
+        response = client.get("/broken")
+
+    assert response.status_code == 500
+    for fragment in expected_fragments:
+        assert fragment in response.text

--- a/src/asgi_http.rs
+++ b/src/asgi_http.rs
@@ -25,6 +25,8 @@ struct AsgiSendState {
     /// the coroutine finishes before sending, causing `start_rx` to error.
     response_start_tx: Mutex<Option<oneshot::Sender<AsgiResponseStart>>>,
     body_tx: Mutex<Option<mpsc::Sender<Bytes>>>,
+    /// Exception message from the ASGI coroutine, set by `AsgiDoneCallback`.
+    exception_msg: Mutex<Option<String>>,
 }
 
 const ASGI_MOUNT_BODY_CHANNEL_CAPACITY: usize = 32;
@@ -167,7 +169,6 @@ impl AsgiSend {
 struct AsgiDoneCallback {
     state: Arc<AsgiSendState>,
     response_done: Arc<Notify>,
-    debug: bool,
 }
 
 #[pymethods]
@@ -178,15 +179,21 @@ impl AsgiDoneCallback {
                 log::debug!("ASGI mount: coroutine was cancelled");
             }
             Ok(exc) if !exc.is_none() => {
-                let msg = exc
+                let exc_type = exc
+                    .get_type()
+                    .name()
+                    .ok()
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| "Exception".to_string());
+                let exc_str = exc
                     .call_method0("__str__")
                     .ok()
                     .and_then(|s| s.extract::<String>().ok())
                     .unwrap_or_default();
-                if self.debug {
-                    log::error!("ASGI mount: coroutine raised an exception: {}", msg);
-                } else {
-                    log::warn!("ASGI mount: coroutine raised an exception: {}", msg);
+                let msg = format!("{}: {}", exc_type, exc_str);
+                log::error!("ASGI mount: coroutine raised an exception: {}", msg);
+                if let Ok(mut guard) = self.state.exception_msg.lock() {
+                    *guard = Some(msg);
                 }
             }
             Ok(_) => {}
@@ -420,6 +427,7 @@ pub async fn handle_asgi_mount_request(
     let send_state = Arc::new(AsgiSendState {
         response_start_tx: Mutex::new(Some(start_tx)),
         body_tx: Mutex::new(Some(body_tx)),
+        exception_msg: Mutex::new(None),
     });
 
     let py_future: Py<PyAny> = match Python::attach(|py| -> PyResult<Py<PyAny>> {
@@ -445,7 +453,6 @@ pub async fn handle_asgi_mount_request(
             AsgiDoneCallback {
                 state: send_state.clone(),
                 response_done: response_done.clone(),
-                debug,
             },
         )?;
         py_future
@@ -467,9 +474,18 @@ pub async fn handle_asgi_mount_request(
             match result {
                 Ok(start) => start,
                 Err(_) => {
+                    let detail = match send_state.exception_msg.lock() {
+                        Ok(guard) if guard.is_some() => {
+                            format!(
+                                "ASGI app raised an exception: {}",
+                                guard.as_ref().unwrap()
+                            )
+                        }
+                        _ => "ASGI app did not send http.response.start".to_string(),
+                    };
                     return HttpResponse::InternalServerError()
                         .content_type("text/plain; charset=utf-8")
-                        .body("ASGI app did not send http.response.start");
+                        .body(detail);
                 }
             }
         }


### PR DESCRIPTION
When a mounted ASGI app raised an exception before sending
  http.response.start, the 500 response only showed a generic
  "ASGI app did not send http.response.start" message, hiding the
  actual error. Now the exception type and message are captured from
  the AsgiDoneCallback and included in the response body
  (e.g. "ASGI app raised an exception: RuntimeError: ...").

  - Store exception message in AsgiSendState via new exception_msg field
  - Extract both exception type name and str in AsgiDoneCallback
  - Always log at error level (removed debug vs warn distinction)
  - Remove unused `debug` field from AsgiDoneCallback
  - Add parametrized test covering builtin and custom exception types