### PR TITLE
Auto-register OpenAPI SecurityScheme definitions from auth backends

### DIFF
--- a/python/django_bolt/openapi/schema_generator.py
+++ b/python/django_bolt/openapi/schema_generator.py
@@ -17,6 +17,7 @@ from .spec import (
     Reference,
     RequestBody,
     Schema,
+    SecurityScheme,
     Tag,
 )
 
@@ -25,6 +26,12 @@ if TYPE_CHECKING:
     from .config import OpenAPIConfig
 
 __all__ = ("SchemaGenerator",)
+
+# Mapping from auth backend scheme_name to OpenAPI security scheme identifier
+_SCHEME_NAME_MAP: dict[str, str] = {
+    "jwt": "BearerAuth",
+    "api_key": "ApiKeyAuth",
+}
 
 
 class SchemaGenerator:
@@ -48,6 +55,10 @@ class SchemaGenerator:
             OpenAPI schema object.
         """
         openapi = self.config.to_openapi_schema()
+
+        # Track auth schemes seen during _extract_security calls
+        self._seen_schemes: set[str] = set()
+        self._api_key_header: str | None = None
 
         # Generate path items from routes and collect tags
         paths: dict[str, PathItem] = {}
@@ -136,6 +147,9 @@ class SchemaGenerator:
             paths[ws_path].extensions["x-websocket"] = True
 
         openapi.paths = paths
+
+        # Auto-register security schemes from auth backends used on routes
+        self._register_security_schemes(openapi)
 
         # Add component schemas
         if self.schemas:
@@ -593,8 +607,45 @@ class SchemaGenerator:
             required=["detail"],
         )
 
+    def _register_security_schemes(self, openapi: OpenAPI) -> None:
+        """Auto-register SecurityScheme definitions from auth backends collected during generation.
+
+        Uses backend info accumulated by _extract_security calls to register
+        the corresponding SecurityScheme in components.security_schemes,
+        preserving any user-defined schemes.
+        """
+        if not self._seen_schemes:
+            return
+
+        existing = openapi.components.security_schemes or {}
+        needs_jwt = "jwt" in self._seen_schemes and "BearerAuth" not in existing
+        needs_api_key = "api_key" in self._seen_schemes and "ApiKeyAuth" not in existing
+
+        if not needs_jwt and not needs_api_key:
+            return
+
+        schemes = dict(existing)
+
+        if needs_jwt:
+            schemes["BearerAuth"] = SecurityScheme(
+                type="http",
+                scheme="bearer",
+                bearer_format="JWT",
+            )
+
+        if needs_api_key:
+            schemes["ApiKeyAuth"] = SecurityScheme(
+                type="apiKey",
+                name=self._api_key_header,
+                security_scheme_in="header",
+            )
+
+        openapi.components.security_schemes = schemes
+
     def _extract_security(self, handler_id: int) -> list[dict[str, list[str]]] | None:
         """Extract security requirements from handler middleware.
+
+        Also accumulates seen scheme types for _register_security_schemes.
 
         Args:
             handler_id: Handler ID.
@@ -608,15 +659,15 @@ class SchemaGenerator:
         if not auth_config:
             return None
 
-        # Convert auth backends to security requirements
         security: list[dict[str, list[str]]] = []
-        for auth_backend in auth_config:
-            backend_name = auth_backend.__class__.__name__
-
-            if "JWT" in backend_name:
-                security.append({"BearerAuth": []})
-            elif "APIKey" in backend_name:
-                security.append({"ApiKeyAuth": []})
+        for backend in auth_config:
+            scheme = backend.scheme_name
+            openapi_name = _SCHEME_NAME_MAP.get(scheme)
+            if openapi_name:
+                security.append({openapi_name: []})
+                self._seen_schemes.add(scheme)
+                if scheme == "api_key" and self._api_key_header is None:
+                    self._api_key_header = backend.header
 
         return security or None
 

--- a/python/tests/test_openapi_docs.py
+++ b/python/tests/test_openapi_docs.py
@@ -420,5 +420,57 @@ def test_openapi_security_requirements_for_authenticated_routes():
             f"API key route should have ApiKeyAuth security, got: {api_key_security}"
         )
 
-        # Note: securitySchemes in components are populated based on the auth backends used.
-        # The key fix is that security requirements now appear on routes (tested above).
+        # SecuritySchemes MUST be auto-registered in components for Swagger UI
+        # authorize button to work (clicking padlock should open token modal)
+        components = schema.get("components", {})
+        security_schemes = components.get("securitySchemes", {})
+
+        assert "BearerAuth" in security_schemes, (
+            f"BearerAuth must be auto-registered in components.securitySchemes, got: {security_schemes}"
+        )
+        assert security_schemes["BearerAuth"]["type"] == "http"
+        assert security_schemes["BearerAuth"]["scheme"] == "bearer"
+
+        assert "ApiKeyAuth" in security_schemes, (
+            f"ApiKeyAuth must be auto-registered in components.securitySchemes, got: {security_schemes}"
+        )
+        assert security_schemes["ApiKeyAuth"]["type"] == "apiKey"
+        assert security_schemes["ApiKeyAuth"]["name"] == "x-api-key"
+
+
+def test_openapi_security_schemes_preserve_user_defined():
+    """Test that user-defined security schemes are preserved and not overwritten."""
+    from django_bolt.auth import JWTAuthentication, IsAuthenticated
+    from django_bolt.openapi.spec import Components, SecurityScheme
+
+    custom_scheme = SecurityScheme(
+        type="http",
+        scheme="bearer",
+        bearer_format="CustomJWT",
+        description="My custom JWT scheme",
+    )
+
+    api = BoltAPI(
+        openapi_config=OpenAPIConfig(
+            title="Custom Auth API",
+            version="1.0.0",
+            components=Components(
+                security_schemes={"BearerAuth": custom_scheme},
+            ),
+        )
+    )
+
+    @api.get("/protected", auth=[JWTAuthentication(secret="test")], guards=[IsAuthenticated()])
+    async def protected():
+        return {"ok": True}
+
+    api._register_openapi_routes()
+
+    with TestClient(api) as client:
+        response = client.get("/docs/openapi.json")
+        schema = response.json()
+        schemes = schema["components"]["securitySchemes"]
+
+        # User-defined scheme should be preserved, not overwritten
+        assert schemes["BearerAuth"]["bearerFormat"] == "CustomJWT"
+        assert schemes["BearerAuth"]["description"] == "My custom JWT scheme"


### PR DESCRIPTION
When JWTAuthentication or APIKeyAuthentication is used on routes, the
  schema generator now automatically registers the corresponding
  SecurityScheme in components.securitySchemes, making Swagger UI padlock
  buttons functional without manual configuration.