### PR TITLE
Optimize hot-path dispatch: move access logging to Rust, eliminate  per-request allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "django-bolt"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "actix",
  "actix-cors",

--- a/python/django_bolt/_kwargs/model.py
+++ b/python/django_bolt/_kwargs/model.py
@@ -413,8 +413,8 @@ async def build_handler_arguments(
     # Access PyRequest mappings
     params_map = request["params"]
     query_map = request["query"]
-    headers_map = request.get("headers", {})
-    cookies_map = request.get("cookies", {})
+    headers_map = request.get("headers", _EMPTY_DICT)
+    cookies_map = request.get("cookies", _EMPTY_DICT)
 
     # Form/multipart data is pre-parsed by Rust (type coerced and validated)
     # Use request.form and request.files for pre-typed values
@@ -422,7 +422,7 @@ async def build_handler_arguments(
         form_map = request.form
         files_map = request.files
     else:
-        form_map, files_map = {}, {}
+        form_map, files_map = _EMPTY_FORM_FILES
 
     # Body decode cache
     body_obj: Any = None
@@ -475,8 +475,11 @@ async def build_handler_arguments(
     return args, kwargs
 
 
-# Pre-allocated constant for no-params handlers (zero alloc per request)
+# Pre-allocated constants (zero alloc per request)
 _NO_PARAMS: tuple[tuple[()], dict[str, Any]] = ((), {})
+_EMPTY_DICT: dict[str, Any] = {}
+_EMPTY_FORM_FILES: tuple[dict, dict] = ({}, {})
+_UNRESOLVED = object()  # Sentinel for unresolved parallel dependency slots
 
 
 def _injector_no_params(request: Any) -> tuple[tuple[()], dict[str, Any]]:
@@ -594,22 +597,32 @@ def compile_argument_injector(
 
     # Fast path 6: Simple pattern (path + query, no body/headers/cookies)
     if pattern is HandlerPattern.SIMPLE:
-        # Pre-build a single flat list with source tag resolved at registration time.
-        # Each entry is (source, extractor, kind, name) -- no re-filtering at request time.
-        _simple_fields = [(f.source, f.extractor, f.kind, f.name) for f in fields]
+        # Pre-split fields by source at registration time to eliminate per-field
+        # string comparisons at request time. Each list contains
+        # (extractor, kind, name) tuples — source is implicit from the list.
+        _path_fields = [(f.extractor, f.kind, f.name) for f in fields if f.source == "path"]
+        _query_fields = [(f.extractor, f.kind, f.name) for f in fields if f.source == "query"]
 
         def injector_simple(request: dict[str, Any]) -> tuple[list[Any], dict[str, Any]]:
-            params_map = request["params"]
-            query_map = request["query"]
             args: list[Any] = []
             kwargs: dict[str, Any] = {}
 
-            for source, extractor, kind, name in _simple_fields:
-                value = extractor(params_map) if source == "path" else extractor(query_map)
+            params_map = request["params"]
+            for extractor, kind, name in _path_fields:
+                value = extractor(params_map)
                 if kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD):
                     args.append(value)
                 else:
                     kwargs[name] = value
+
+            query_map = request["query"]
+            for extractor, kind, name in _query_fields:
+                value = extractor(query_map)
+                if kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD):
+                    args.append(value)
+                else:
+                    kwargs[name] = value
+
             return args, kwargs
 
         return injector_simple
@@ -681,16 +694,16 @@ def compile_argument_injector(
 
         async def injector_with_deps(request: dict[str, Any]) -> tuple[list[Any], dict[str, Any]]:
             """Optimized argument injector with dependency support."""
-            params_map = request["params"] if needs_path_params else {}
-            query_map = request["query"] if needs_query else {}
-            headers_map = request.get("headers", {}) if needs_headers else {}
-            cookies_map = request.get("cookies", {}) if needs_cookies else {}
+            params_map = request["params"] if needs_path_params else _EMPTY_DICT
+            query_map = request["query"] if needs_query else _EMPTY_DICT
+            headers_map = request.get("headers", _EMPTY_DICT) if needs_headers else _EMPTY_DICT
+            cookies_map = request.get("cookies", _EMPTY_DICT) if needs_cookies else _EMPTY_DICT
 
             if needs_form:
                 form_map = request.form
                 files_map = request.files
             else:
-                form_map, files_map = {}, {}
+                form_map, files_map = _EMPTY_FORM_FILES
 
             body_obj: Any = None
             body_loaded: bool = False
@@ -721,17 +734,23 @@ def compile_argument_injector(
                     dep_coros.append(_resolve_one(dep))
 
                 dep_results = await asyncio.gather(*dep_coros)
-                # Map results back to plan indices
-                _parallel_results = dict(zip(_async_dep_fns, dep_results, strict=True))
+                # Map results back to plan indices — use a pre-sized list indexed
+                # by plan position instead of a dict to avoid per-request dict alloc.
+                # Use _UNRESOLVED sentinel (not None) since deps can legitimately return None.
+                _parallel_results: list[Any] = [_UNRESOLVED] * len(_dep_plan)
+                for idx, result in zip(_async_dep_fns, dep_results, strict=True):
+                    _parallel_results[idx] = result
+                _has_parallel = True
             else:
                 _parallel_results = None
+                _has_parallel = False
 
             args: list[Any] = []
             kwargs: dict[str, Any] = {}
 
             for plan_idx, (src_id, extractor, kind, name, needs_files, dependency) in enumerate(_dep_plan):
                 if src_id == _SRC_DEP:
-                    if _parallel_results is not None and plan_idx in _parallel_results:
+                    if _has_parallel and _parallel_results[plan_idx] is not _UNRESOLVED:
                         value = _parallel_results[plan_idx]
                     else:
                         if dependency is None:
@@ -856,16 +875,16 @@ def compile_argument_injector(
         args: list[Any] = []
         kwargs: dict[str, Any] = {}
 
-        params_map = request["params"] if needs_path_params else {}
-        query_map = request["query"] if needs_query else {}
-        headers_map = request.get("headers", {}) if needs_headers else {}
-        cookies_map = request.get("cookies", {}) if needs_cookies else {}
+        params_map = request["params"] if needs_path_params else _EMPTY_DICT
+        query_map = request["query"] if needs_query else _EMPTY_DICT
+        headers_map = request.get("headers", _EMPTY_DICT) if needs_headers else _EMPTY_DICT
+        cookies_map = request.get("cookies", _EMPTY_DICT) if needs_cookies else _EMPTY_DICT
 
         if needs_form:
             form_map = request.form
             files_map = request.files
         else:
-            form_map, files_map = {}, {}
+            form_map, files_map = _EMPTY_FORM_FILES
 
         body_obj: Any = None
         body_loaded: bool = False

--- a/python/django_bolt/api.py
+++ b/python/django_bolt/api.py
@@ -4,12 +4,11 @@ import dis
 import inspect
 import sys
 import threading
-import time
 import types
 from collections.abc import Callable
 from contextlib import suppress
 from functools import partial
-from typing import Any, get_type_hints
+from typing import Any, get_origin, get_type_hints
 
 # Django import - may fail if Django not configured
 try:
@@ -1485,69 +1484,110 @@ class BoltAPI:
             _is_no_params = meta.get("handler_pattern") is HandlerPattern.NO_PARAMS
 
             if not has_response_validation:
-                _encode = _json.encode
+                # Bind encoder method directly — skips the `if serializer is not None`
+                # check in _json.encode() on every call.
+                _encode = _json._ENCODER.encode
                 _meta_json = _RESPONSE_META_JSON
+
+                # Pre-compute at registration time whether _convert_serializers can be
+                # skipped. When the return type is dict, list[Struct], list[dict], etc.
+                # (i.e. NOT a Bolt Serializer), the conversion is always a no-op.
+                _response_type = meta.get("response_type")
+                _resp_origin = get_origin(_response_type) if _response_type else None
+                _skip_convert = _resp_origin is list or _response_type is dict or _resp_origin is dict
 
                 if _trivially_async:
                     # Sync executor for trivially-async handlers: drive coroutine inline.
                     # coro.send(None) immediately raises StopIteration since there are
                     # no await points. This bypasses the entire async bridge (~6-12μs).
                     if _is_no_params:
-                        # No-params: call handler() directly (skip injector + unpacking)
-                        def execute_trivial_async_sync(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
-                            coro = handler()
-                            try:
-                                coro.send(None)
-                            except StopIteration as _e:
-                                result = _e.value
-                            else:
-                                coro.close()
-                                raise RuntimeError("Handler awaited unexpectedly in sync dispatch")
-                            if isinstance(result, dict):
-                                return (default_status, _meta_json, _BODY_BYTES, _encode(result))
-                            if isinstance(result, list):
-                                result = _convert_serializers(result)
-                                return (default_status, _meta_json, _BODY_BYTES, _encode(result))
-                            return serialize_response_sync(result, meta)
+                        if _skip_convert:
+                            # Ultra-fast: no params, no validation, result goes directly to encoder.
+                            def execute_trivial_async_sync(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
+                                coro = handler()
+                                try:
+                                    coro.send(None)
+                                except StopIteration as _e:
+                                    return (default_status, _meta_json, _BODY_BYTES, _encode(_e.value))
+                                else:
+                                    coro.close()
+                                    raise RuntimeError("Handler awaited unexpectedly in sync dispatch")
+                        else:
+                            def execute_trivial_async_sync(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
+                                coro = handler()
+                                try:
+                                    coro.send(None)
+                                except StopIteration as _e:
+                                    result = _e.value
+                                else:
+                                    coro.close()
+                                    raise RuntimeError("Handler awaited unexpectedly in sync dispatch")
+                                if isinstance(result, dict):
+                                    return (default_status, _meta_json, _BODY_BYTES, _encode(result))
+                                if isinstance(result, list):
+                                    result = _convert_serializers(result)
+                                    return (default_status, _meta_json, _BODY_BYTES, _encode(result))
+                                return serialize_response_sync(result, meta)
                     else:
-                        def execute_trivial_async_sync(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
-                            args, kwargs = injector(request)
-                            coro = handler(*args, **kwargs)
-                            try:
-                                coro.send(None)
-                            except StopIteration as _e:
-                                result = _e.value
-                            else:
-                                coro.close()
-                                raise RuntimeError("Handler awaited unexpectedly in sync dispatch")
-                            if isinstance(result, dict):
-                                return (default_status, _meta_json, _BODY_BYTES, _encode(result))
-                            if isinstance(result, list):
-                                result = _convert_serializers(result)
-                                return (default_status, _meta_json, _BODY_BYTES, _encode(result))
-                            return serialize_response_sync(result, meta)
+                        if _skip_convert:
+                            def execute_trivial_async_sync(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
+                                args, kwargs = injector(request)
+                                coro = handler(*args, **kwargs)
+                                try:
+                                    coro.send(None)
+                                except StopIteration as _e:
+                                    return (default_status, _meta_json, _BODY_BYTES, _encode(_e.value))
+                                else:
+                                    coro.close()
+                                    raise RuntimeError("Handler awaited unexpectedly in sync dispatch")
+                        else:
+                            def execute_trivial_async_sync(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
+                                args, kwargs = injector(request)
+                                coro = handler(*args, **kwargs)
+                                try:
+                                    coro.send(None)
+                                except StopIteration as _e:
+                                    result = _e.value
+                                else:
+                                    coro.close()
+                                    raise RuntimeError("Handler awaited unexpectedly in sync dispatch")
+                                if isinstance(result, dict):
+                                    return (default_status, _meta_json, _BODY_BYTES, _encode(result))
+                                if isinstance(result, list):
+                                    result = _convert_serializers(result)
+                                    return (default_status, _meta_json, _BODY_BYTES, _encode(result))
+                                return serialize_response_sync(result, meta)
 
                     meta["_sync_executor"] = execute_trivial_async_sync
 
                 if _is_no_params:
-                    async def execute_async_dict_fast(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
-                        result = await handler()
-                        if isinstance(result, dict):
-                            return (default_status, _meta_json, _BODY_BYTES, _encode(result))
-                        if isinstance(result, list):
-                            result = _convert_serializers(result)
-                            return (default_status, _meta_json, _BODY_BYTES, _encode(result))
-                        return await serialize_response(result, meta)
+                    if _skip_convert:
+                        async def execute_async_dict_fast(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
+                            return (default_status, _meta_json, _BODY_BYTES, _encode(await handler()))
+                    else:
+                        async def execute_async_dict_fast(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
+                            result = await handler()
+                            if isinstance(result, dict):
+                                return (default_status, _meta_json, _BODY_BYTES, _encode(result))
+                            if isinstance(result, list):
+                                result = _convert_serializers(result)
+                                return (default_status, _meta_json, _BODY_BYTES, _encode(result))
+                            return await serialize_response(result, meta)
                 else:
-                    async def execute_async_dict_fast(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
-                        args, kwargs = injector(request)
-                        result = await handler(*args, **kwargs)
-                        if isinstance(result, dict):
-                            return (default_status, _meta_json, _BODY_BYTES, _encode(result))
-                        if isinstance(result, list):
-                            result = _convert_serializers(result)
-                            return (default_status, _meta_json, _BODY_BYTES, _encode(result))
-                        return await serialize_response(result, meta)
+                    if _skip_convert:
+                        async def execute_async_dict_fast(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
+                            args, kwargs = injector(request)
+                            return (default_status, _meta_json, _BODY_BYTES, _encode(await handler(*args, **kwargs)))
+                    else:
+                        async def execute_async_dict_fast(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
+                            args, kwargs = injector(request)
+                            result = await handler(*args, **kwargs)
+                            if isinstance(result, dict):
+                                return (default_status, _meta_json, _BODY_BYTES, _encode(result))
+                            if isinstance(result, list):
+                                result = _convert_serializers(result)
+                                return (default_status, _meta_json, _BODY_BYTES, _encode(result))
+                            return await serialize_response(result, meta)
 
                 return execute_async_dict_fast
 
@@ -1570,53 +1610,74 @@ class BoltAPI:
             _is_no_params_sync = meta.get("handler_pattern") is HandlerPattern.NO_PARAMS
 
             if not has_response_validation:
-                _encode = _json.encode
+                _encode = _json._ENCODER.encode
                 _meta_json = _RESPONSE_META_JSON
+
+                _response_type = meta.get("response_type")
+                _resp_origin = get_origin(_response_type) if _response_type else None
+                _skip_convert = _resp_origin is list or _response_type is dict or _resp_origin is dict
 
                 # Plain (non-async) sync executor for Rust sync dispatch bypass.
                 # Eliminates coroutine creation + into_future_with_locals overhead.
                 if _is_no_params_sync:
-                    # No-params: call handler() directly (skip injector + unpacking)
-                    def execute_sync_dict_fast_plain(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
-                        result = handler()
-                        if isinstance(result, dict):
-                            return (default_status, _meta_json, _BODY_BYTES, _encode(result))
-                        if isinstance(result, list):
-                            result = _convert_serializers(result)
-                            return (default_status, _meta_json, _BODY_BYTES, _encode(result))
-                        return serialize_response_sync(result, meta)
+                    if _skip_convert:
+                        def execute_sync_dict_fast_plain(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
+                            return (default_status, _meta_json, _BODY_BYTES, _encode(handler()))
+                    else:
+                        def execute_sync_dict_fast_plain(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
+                            result = handler()
+                            if isinstance(result, dict):
+                                return (default_status, _meta_json, _BODY_BYTES, _encode(result))
+                            if isinstance(result, list):
+                                result = _convert_serializers(result)
+                                return (default_status, _meta_json, _BODY_BYTES, _encode(result))
+                            return serialize_response_sync(result, meta)
                 else:
-                    def execute_sync_dict_fast_plain(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
-                        args, kwargs = injector(request)
-                        result = handler(*args, **kwargs)
-                        if isinstance(result, dict):
-                            return (default_status, _meta_json, _BODY_BYTES, _encode(result))
-                        if isinstance(result, list):
-                            result = _convert_serializers(result)
-                            return (default_status, _meta_json, _BODY_BYTES, _encode(result))
-                        return serialize_response_sync(result, meta)
+                    if _skip_convert:
+                        def execute_sync_dict_fast_plain(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
+                            args, kwargs = injector(request)
+                            return (default_status, _meta_json, _BODY_BYTES, _encode(handler(*args, **kwargs)))
+                    else:
+                        def execute_sync_dict_fast_plain(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
+                            args, kwargs = injector(request)
+                            result = handler(*args, **kwargs)
+                            if isinstance(result, dict):
+                                return (default_status, _meta_json, _BODY_BYTES, _encode(result))
+                            if isinstance(result, list):
+                                result = _convert_serializers(result)
+                                return (default_status, _meta_json, _BODY_BYTES, _encode(result))
+                            return serialize_response_sync(result, meta)
 
                 meta["_sync_executor"] = execute_sync_dict_fast_plain
 
                 if _is_no_params_sync:
-                    async def execute_sync_dict_fast(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
-                        result = handler()
-                        if isinstance(result, dict):
-                            return (default_status, _meta_json, _BODY_BYTES, _encode(result))
-                        if isinstance(result, list):
-                            result = _convert_serializers(result)
-                            return (default_status, _meta_json, _BODY_BYTES, _encode(result))
-                        return serialize_response_sync(result, meta)
+                    if _skip_convert:
+                        async def execute_sync_dict_fast(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
+                            return (default_status, _meta_json, _BODY_BYTES, _encode(handler()))
+                    else:
+                        async def execute_sync_dict_fast(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
+                            result = handler()
+                            if isinstance(result, dict):
+                                return (default_status, _meta_json, _BODY_BYTES, _encode(result))
+                            if isinstance(result, list):
+                                result = _convert_serializers(result)
+                                return (default_status, _meta_json, _BODY_BYTES, _encode(result))
+                            return serialize_response_sync(result, meta)
                 else:
-                    async def execute_sync_dict_fast(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
-                        args, kwargs = injector(request)
-                        result = handler(*args, **kwargs)
-                        if isinstance(result, dict):
-                            return (default_status, _meta_json, _BODY_BYTES, _encode(result))
-                        if isinstance(result, list):
-                            result = _convert_serializers(result)
-                            return (default_status, _meta_json, _BODY_BYTES, _encode(result))
-                        return serialize_response_sync(result, meta)
+                    if _skip_convert:
+                        async def execute_sync_dict_fast(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
+                            args, kwargs = injector(request)
+                            return (default_status, _meta_json, _BODY_BYTES, _encode(handler(*args, **kwargs)))
+                    else:
+                        async def execute_sync_dict_fast(handler: Callable, request: dict[str, Any]) -> ResponseWireV1:
+                            args, kwargs = injector(request)
+                            result = handler(*args, **kwargs)
+                            if isinstance(result, dict):
+                                return (default_status, _meta_json, _BODY_BYTES, _encode(result))
+                            if isinstance(result, list):
+                                result = _convert_serializers(result)
+                                return (default_status, _meta_json, _BODY_BYTES, _encode(result))
+                            return serialize_response_sync(result, meta)
 
                 return execute_sync_dict_fast
 
@@ -1870,30 +1931,18 @@ class BoltAPI:
         - Pre-compiled argument injector (zero parameter binding overhead)
         - Streamlined execution flow (minimal branching)
         - Eliminated hasattr() checks via __init__ initialization
-        - Cached logging decisions to avoid per-request isEnabledFor() calls
+        - Zero logging overhead: access logging moved to Rust (Granian pattern),
+          only exception logging remains here (BlackSheep pattern)
 
         Args:
             handler: The route handler function
             request: The request dictionary
             handler_id: Handler ID to lookup original API (for merged APIs)
         """
-        # For merged APIs, use the original API's logging middleware and middleware chain
-        # This preserves per-API logging, auth, and middleware config (Litestar-style)
+        # For merged APIs, use the original API's middleware chain and logging
+        # This preserves per-API auth, middleware, and logging config (Litestar-style)
         # Note: _handler_api_map is always initialized in __init__ (no hasattr needed)
         original_api = self._handler_api_map.get(handler_id) if handler_id is not None else None
-        logging_middleware = original_api._logging_middleware if original_api else self._logging_middleware
-
-        # Start timing only if we might log
-        # Use cached should_time flag (computed once per logging middleware instance)
-        start_time = None
-        if logging_middleware:
-            # _should_time_cached initialized in LoggingMiddleware.__init__()
-            if logging_middleware._should_time_cached:
-                start_time = time.time()
-
-            # Skip method call when debug-level request logging is disabled.
-            if logging_middleware._request_debug_enabled_cached:
-                logging_middleware.log_request(request)
 
         try:
             # 1. Direct metadata access using handler_id (int key is faster than callable key)
@@ -1926,32 +1975,17 @@ class BoltAPI:
 
             if api_with_middleware:
                 # Execute through middleware chain (Django-style)
-                response = await self._dispatch_with_middleware(handler, request, handler_id, api_with_middleware, meta)
+                return await self._dispatch_with_middleware(handler, request, handler_id, api_with_middleware, meta)
             else:
                 # Fast path: no middleware, execute pre-compiled handler executor directly.
-                response = await meta["_handler_executor"](handler, request)
-
-            # Log response if logging enabled
-            if logging_middleware and start_time is not None:
-                duration = time.time() - start_time
-                # Response is ResponseWireV1 tuple.
-                status_code = response[0] if isinstance(response, tuple) else 200
-                logging_middleware.log_response(request, status_code, duration)
-
-            return response
+                return await meta["_handler_executor"](handler, request)
 
         except HTTPException as he:
-            # Log exception if logging enabled
-            if logging_middleware and start_time is not None:
-                duration = time.time() - start_time
-                logging_middleware.log_response(request, he.status_code, duration)
-
             return self._handle_http_exception(he)
         except Exception as e:
-            # Log exception if logging enabled
-            if logging_middleware:
-                logging_middleware.log_exception(request, e, exc_info=True)
-
+            # BlackSheep pattern: only log unhandled exceptions (rare path)
+            if self._logging_middleware:
+                self._logging_middleware.log_exception(request, e, exc_info=True)
             return self._handle_generic_exception(e, request=request)
         finally:
             # Auto-cleanup UploadFiles to prevent resource leaks
@@ -1971,22 +2005,16 @@ class BoltAPI:
         no into_future_with_locals, no asyncio event loop polling. This eliminates
         ~6-12us of async bridge overhead per request.
 
+        Zero logging overhead: access logging (timing, method/path/status) is handled
+        in Rust via const generic (compiler-eliminated when off). Only unhandled
+        exception logging remains here (BlackSheep pattern — rare path only).
+
         Prerequisites (checked at registration time, stored in can_sync_dispatch flag):
         - Handler has a _sync_executor (sync, non-blocking, simple params)
         - No Python middleware (global or route-level)
         - No Django middleware
         - No signals
         """
-        original_api = self._handler_api_map.get(handler_id) if handler_id is not None else None
-        logging_middleware = original_api._logging_middleware if original_api else self._logging_middleware
-
-        start_time = None
-        if logging_middleware:
-            if logging_middleware._should_time_cached:
-                start_time = time.time()
-            if logging_middleware._request_debug_enabled_cached:
-                logging_middleware.log_request(request)
-
         try:
             meta = self._handler_meta[handler_id]
 
@@ -2002,23 +2030,14 @@ class BoltAPI:
                     )
 
             # Call pre-compiled sync executor directly (no coroutine, no await)
-            response = meta["_sync_executor"](handler, request)
-
-            if logging_middleware and start_time is not None:
-                duration = time.time() - start_time
-                status_code = response[0] if isinstance(response, tuple) else 200
-                logging_middleware.log_response(request, status_code, duration)
-
-            return response
+            return meta["_sync_executor"](handler, request)
 
         except HTTPException as he:
-            if logging_middleware and start_time is not None:
-                duration = time.time() - start_time
-                logging_middleware.log_response(request, he.status_code, duration)
             return self._handle_http_exception(he)
         except Exception as e:
-            if logging_middleware:
-                logging_middleware.log_exception(request, e, exc_info=True)
+            # BlackSheep pattern: only log unhandled exceptions (rare path)
+            if self._logging_middleware:
+                self._logging_middleware.log_exception(request, e, exc_info=True)
             return self._handle_generic_exception(e, request=request)
         finally:
             if meta["has_file_uploads"]:

--- a/python/django_bolt/serialization.py
+++ b/python/django_bolt/serialization.py
@@ -310,6 +310,25 @@ def _compile_queryset_serializers(meta: HandlerMetadata | dict[str, Any]) -> tup
     return serialize_sync, serialize_async
 
 
+def _compile_model_projector(meta: HandlerMetadata | dict[str, Any]) -> Any:
+    """Compile a function that projects model instances to dicts using response field names.
+
+    When validate_response=False and the handler returns a list of Django model
+    instances (not dicts/Structs), we still need to extract the declared fields
+    to produce JSON-serializable dicts. This is compiled once at registration time.
+
+    Returns None if no response_field_names are available (no list[Struct] annotation).
+    """
+    field_names = meta.get("response_field_names")
+    if not field_names:
+        return None
+
+    def project(items: list[Any]) -> list[dict[str, Any]]:
+        return [{name: getattr(item, name, None) for name in field_names} for item in items]
+
+    return project
+
+
 def _extract_stream_item_type(annotation: Any) -> tuple[bool, Any | None]:
     """Return (is_stream_annotation, item_type) for streaming return annotations."""
     if annotation is None:
@@ -422,6 +441,7 @@ def compile_response_handlers(meta: HandlerMetadata | dict[str, Any]) -> None:
     validator_sync, validator_async = _compile_response_validator(meta)
     stream_validator_sync, stream_validator_async = _compile_stream_item_validators(meta)
     queryset_serializer_sync, queryset_serializer_async = _compile_queryset_serializers(meta)
+    model_projector = _compile_model_projector(meta)
 
     meta["_response_validator"] = validator_sync
     meta["_response_validator_async"] = validator_async
@@ -443,7 +463,12 @@ def compile_response_handlers(meta: HandlerMetadata | dict[str, Any]) -> None:
         if isinstance(result, dict):
             return await _serialize_json_payload_async(result, current_status, validator_async)
         if isinstance(result, list):
-            return await _serialize_json_payload_async(_convert_serializers(result), current_status, validator_async)
+            result = _convert_serializers(result)
+            # When validate_response=False and list contains model instances (not dicts/Structs),
+            # project them to dicts using pre-compiled field names from the response type annotation.
+            if model_projector is not None and result and not isinstance(result[0], (dict, msgspec.Struct)):
+                result = model_projector(result)
+            return await _serialize_json_payload_async(result, current_status, validator_async)
         if isinstance(result, (bytes, bytearray)):
             return _wire_bytes(current_status, _RESPONSE_META_OCTETSTREAM, bytes(result))
         if isinstance(result, str):
@@ -482,7 +507,10 @@ def compile_response_handlers(meta: HandlerMetadata | dict[str, Any]) -> None:
         if isinstance(result, dict):
             return _serialize_json_payload_sync(result, current_status, validator_sync)
         if isinstance(result, list):
-            return _serialize_json_payload_sync(_convert_serializers(result), current_status, validator_sync)
+            result = _convert_serializers(result)
+            if model_projector is not None and result and not isinstance(result[0], (dict, msgspec.Struct)):
+                result = model_projector(result)
+            return _serialize_json_payload_sync(result, current_status, validator_sync)
         if isinstance(result, (bytes, bytearray)):
             return _wire_bytes(current_status, _RESPONSE_META_OCTETSTREAM, bytes(result))
         if isinstance(result, str):

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -637,7 +637,7 @@ pub(crate) fn build_prebound_args_kwargs(
     Some((args.unbind(), kwargs.unbind()))
 }
 
-pub async fn handle_request(
+pub async fn handle_request<const ACCESS_LOG: bool>(
     req: HttpRequest,
     mut payload: web::Payload,
     state: web::Data<Arc<AppState>>,
@@ -645,6 +645,13 @@ pub async fn handle_request(
     // Keep as &str - no allocation, only clone on error paths
     let method = req.method().as_str();
     let path = req.path();
+
+    // ACCESS_LOG: compiler eliminates this entirely when ACCESS_LOG=false (const generic)
+    let access_log_start = if ACCESS_LOG {
+        Some(std::time::Instant::now())
+    } else {
+        None
+    };
 
     let router = GLOBAL_ROUTER.get().expect("Router not initialized");
 
@@ -1201,7 +1208,7 @@ pub async fn handle_request(
         }
     });
 
-    match dispatch_result {
+    let response = match dispatch_result {
         Ok(DispatchOutcome::Ready(response)) => response,
         // Sync dispatch completed but body needs async post-processing (stream/file).
         // Already parsed — no duplicate GIL acquire or wire re-parse.
@@ -1239,5 +1246,23 @@ pub async fn handle_request(
         Err(e) => Python::attach(|py| {
             handle_python_error(py, e, req.path(), req.method().as_str(), state.debug)
         }),
+    };
+
+    // ACCESS_LOG: compiler eliminates this entire block when ACCESS_LOG=false (const generic).
+    // When ACCESS_LOG=true, log method/path/status/duration via Django's logger.
+    if ACCESS_LOG {
+        // access_log_start is always Some when ACCESS_LOG=true; unwrap is safe.
+        let dur_ms = access_log_start.unwrap().elapsed().as_secs_f64() * 1000.0;
+        let status = response.status().as_u16();
+        // access_logger is always Some when ACCESS_LOG=true (guaranteed by server.rs startup).
+        Python::attach(|py| {
+            let _ = state.access_logger.as_ref().unwrap().call_method1(
+                py,
+                "info",
+                (format!("{} {} {} {:.1}ms", method, path, status, dur_ms),),
+            );
+        });
     }
+
+    response
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -163,6 +163,8 @@ pub fn start_server(
         cors_config_data,
         static_files_data,
         csp_header,
+        access_log_enabled,
+        access_logger_obj,
     ) = Python::attach(|py| {
         let debug = (|| -> PyResult<bool> {
             let django_conf = py.import("django.conf")?;
@@ -344,6 +346,33 @@ pub fn start_server(
             }
         })();
 
+        // Check Django's logging configuration to determine if access logging is enabled.
+        // Uses the standard django.server logger — no extra settings needed.
+        // Decision is made once at startup (Granian pattern: zero cost when off).
+        let (access_log_enabled, access_logger_obj) = (|| -> (bool, Option<Py<PyAny>>) {
+            let logging = match py.import("logging") {
+                Ok(m) => m,
+                Err(_) => return (false, None),
+            };
+            let info_level: i32 = match logging.getattr("INFO").and_then(|v| v.extract()) {
+                Ok(v) => v,
+                Err(_) => return (false, None),
+            };
+            let logger = match logging.call_method1("getLogger", ("django.server",)) {
+                Ok(l) => l,
+                Err(_) => return (false, None),
+            };
+            let enabled = logger
+                .call_method1("isEnabledFor", (info_level,))
+                .and_then(|v| v.extract::<bool>())
+                .unwrap_or(false);
+            if enabled {
+                (true, Some(logger.unbind()))
+            } else {
+                (false, None)
+            }
+        })();
+
         (
             debug,
             max_header_size,
@@ -352,6 +381,8 @@ pub fn start_server(
             cors_data,
             static_data,
             csp_header,
+            access_log_enabled,
+            access_logger_obj,
         )
     });
 
@@ -509,6 +540,7 @@ pub fn start_server(
         route_metadata: None, // Production uses ROUTE_METADATA
         asgi_mounts: None,    // Production uses GLOBAL_ASGI_MOUNTS
         static_files_config: static_files_config.clone(),
+        access_logger: access_logger_obj,
     });
 
     py.detach(|| {
@@ -571,8 +603,14 @@ pub fn start_server(
                                 .route(&static_route, web::get().to(handle_static_file));
                         }
 
-                        // Default service handles all unmatched HTTP requests
-                        app.default_service(web::to(handle_request))
+                        // Default service handles all unmatched HTTP requests.
+                        // Granian pattern: select handler variant at registration time.
+                        // handle_request::<false> has zero access-logging instructions (compiler eliminated).
+                        if access_log_enabled {
+                            app.default_service(web::to(handle_request::<true>))
+                        } else {
+                            app.default_service(web::to(handle_request::<false>))
+                        }
                     })
                     .keep_alive(keep_alive)
                     .client_request_timeout(std::time::Duration::from_secs(0))

--- a/src/state.rs
+++ b/src/state.rs
@@ -71,6 +71,7 @@ pub struct AppState {
     pub route_metadata: Option<Arc<RouteMetadataStore>>, // Route metadata (used by test infrastructure)
     pub asgi_mounts: Option<Arc<Vec<AsgiMount>>>, // ASGI mounts (tests). Production uses GLOBAL_ASGI_MOUNTS.
     pub static_files_config: Option<StaticFilesConfig>, // Static files configuration from Django settings
+    pub access_logger: Option<Py<PyAny>>,       // Python logger instance for access logging (django.server). None when disabled.
 }
 
 pub static GLOBAL_ROUTER: OnceCell<Arc<Router>> = OnceCell::new();

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -508,6 +508,7 @@ pub fn test_request(
                 route_metadata: Some(route_metadata.clone()),
                 asgi_mounts: Some(asgi_mounts.clone()),
                 static_files_config: static_files_config.clone(),
+                access_logger: None,
             });
 
             // Clone the Arc values for the handler closure

--- a/uv.lock
+++ b/uv.lock
@@ -88,7 +88,7 @@ wheels = [
 
 [[package]]
 name = "django-bolt"
-version = "0.6.6"
+version = "0.6.7"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Move access logging from Python (_dispatch/_dispatch_sync) to Rust
  using a
  const generic handle_request<const ACCESS_LOG: bool> — compiler
  eliminates all
  logging code when disabled (Granian pattern). Only unhandled
  exception logging
  remains in Python (BlackSheep pattern — rare path only).

  Additional hot-path optimizations:

  - Pre-compute _skip_convert flag at registration using get_origin()
  to detect
    dict/list return types; specialized executor variants skip
  isinstance checks
    and encode results directly when safe
  - Bind _json._ENCODER.encode directly, bypassing the wrapper method
  - Pre-split simple injector fields by source (path vs query) at
  registration,
    eliminating per-field string comparisons at request time
  - Replace per-request {} allocations with module-level _EMPTY_DICT
  and
    _EMPTY_FORM_FILES constants
  - Use pre-sized list indexed by plan position for parallel
  dependency results
    instead of per-request dict allocation
  - Add _compile_model_projector() to pre-build model-to-dict
  projection at
    registration time for list[Struct] response types