### PR TITLE
feat: add lifecycle hooks (on_startup/on_shutdown) - closes #96

### DIFF
--- a/bench/BENCHMARK_BASELINE.md
+++ b/bench/BENCHMARK_BASELINE.md
@@ -1,391 +1,390 @@
 # Django-Bolt Benchmark
-Generated: Sun 08 Mar 2026 07:32:13 AM PKT
+Generated: Mon 16 Mar 2026 01:52:53 PM PKT
 Config: 8 processes × 1 workers | C=100 N=10000
 
 ## Root Endpoint Performance
-  Reqs/sec    145540.35   23801.14  162626.85
-  Latency      680.10us   448.16us     5.20ms
+  Reqs/sec    173209.02   15350.21  185024.21
+  Latency      557.65us   327.83us     4.90ms
   Latency Distribution
-     50%   542.00us
-     75%   779.00us
-     90%     1.16ms
-     99%     3.15ms
+     50%   491.00us
+     75%   614.00us
+     90%   835.00us
+     99%     2.09ms
 
 ## 10kb JSON Response Performance
 ### 10kb JSON (Async) (/10k-json)
-  Reqs/sec    106235.76   11356.28  119844.76
-  Latency        0.90ms   372.81us     5.72ms
+  Reqs/sec    113963.50   12048.13  121575.28
+  Latency        0.86ms   415.63us     7.00ms
   Latency Distribution
-     50%   802.00us
-     75%     1.09ms
-     90%     1.47ms
-     99%     2.50ms
+     50%   784.00us
+     75%     1.01ms
+     90%     1.35ms
+     99%     2.56ms
 ### 10kb JSON (Sync) (/sync-10k-json)
-  Reqs/sec    106010.79   12072.64  118362.65
-  Latency        0.92ms   418.66us     5.93ms
+  Reqs/sec    126633.53    7358.64  130704.62
+  Latency      768.27us   320.51us     8.25ms
   Latency Distribution
-     50%     0.88ms
-     75%     1.13ms
-     90%     1.52ms
-     99%     2.58ms
+     50%   724.00us
+     75%     0.92ms
+     90%     1.16ms
+     99%     2.03ms
 
 ## Response Type Endpoints
 ### Header Endpoint (/header)
-  Reqs/sec    110248.81   13537.15  122671.18
-  Latency        0.90ms   374.60us     7.11ms
+  Reqs/sec    107420.36    9773.28  113609.81
+  Latency        0.91ms   277.72us     5.22ms
   Latency Distribution
-     50%   823.00us
-     75%     1.10ms
-     90%     1.43ms
-     99%     2.36ms
+     50%   843.00us
+     75%     1.11ms
+     90%     1.40ms
+     99%     2.12ms
 ### Cookie Endpoint (/cookie)
-  Reqs/sec    112534.88   10087.47  118402.50
-  Latency        0.88ms   348.15us     6.02ms
+  Reqs/sec    108999.39    6967.58  113960.10
+  Latency        0.90ms   333.57us     6.00ms
   Latency Distribution
-     50%   775.00us
-     75%     1.09ms
-     90%     1.47ms
-     99%     2.28ms
+     50%   839.00us
+     75%     1.08ms
+     90%     1.35ms
+     99%     2.16ms
 ### Exception Endpoint (/exc)
-  Reqs/sec    134089.71    9157.84  147122.04
-  Latency      730.21us   523.33us     7.76ms
+  Reqs/sec    140356.59   14617.22  148524.28
+  Latency      690.39us   314.25us     5.85ms
   Latency Distribution
-     50%   557.00us
-     75%     0.91ms
-     90%     1.49ms
-     99%     3.40ms
+     50%   625.00us
+     75%   813.00us
+     90%     1.12ms
+     99%     2.17ms
 ### HTML Response (/html)
-  Reqs/sec    161651.23   16896.39  173160.33
-  Latency      607.55us   431.11us     5.60ms
+  Reqs/sec    167573.72   13960.77  175647.42
+  Latency      573.93us   343.12us     7.14ms
   Latency Distribution
-     50%   463.00us
-     75%   785.00us
-     90%     1.20ms
-     99%     2.94ms
+     50%   500.00us
+     75%   664.00us
+     90%     0.89ms
+     99%     2.15ms
 ### Redirect Response (/redirect)
 ### File Static via FileResponse (/file-static)
-  Reqs/sec     34338.70    8302.10   40916.97
-  Latency        2.90ms     2.17ms    33.42ms
+  Reqs/sec     37099.77    8654.04   42301.57
+  Latency        2.70ms     1.51ms    22.33ms
   Latency Distribution
      50%     2.42ms
-     75%     3.55ms
-     90%     4.88ms
-     99%    10.16ms
+     75%     3.21ms
+     90%     4.17ms
+     99%     8.91ms
 
 ## Authentication & Authorization Performance
 ### Auth NO User Access (/auth/no-user-access) - lazy loading, no DB query
-  Reqs/sec     86912.67    6221.65   92844.80
-  Latency        1.12ms   431.63us     5.86ms
+  Reqs/sec     77813.37    4919.91   81787.79
+  Latency        1.27ms   393.72us     7.93ms
   Latency Distribution
-     50%     1.02ms
-     75%     1.37ms
-     90%     1.77ms
-     99%     3.05ms
+     50%     1.19ms
+     75%     1.53ms
+     90%     1.91ms
+     99%     2.91ms
 ### Get Authenticated User (/auth/me) - accesses request.user, triggers DB query
- 7890 / 10000 [======================================================================================================================>-------------------------------]  78.90% 19687/s
-  Reqs/sec     18520.43    3536.74   22705.90
-  Latency        5.37ms     2.44ms    28.21ms
+  Reqs/sec     17601.22    1608.83   20987.31
+  Latency        5.67ms     1.64ms    14.87ms
   Latency Distribution
-     50%     4.90ms
-     75%     6.55ms
-     90%     8.54ms
-     99%    14.23ms
+     50%     5.45ms
+     75%     7.05ms
+     90%     8.13ms
+     99%    10.70ms
 ### Get User via Dependency (/auth/me-dependency)
-  Reqs/sec     19138.98    2030.21   25236.52
-  Latency        5.24ms     2.01ms    18.52ms
+  Reqs/sec     15835.97     993.90   17672.89
+  Latency        6.29ms     1.60ms    14.59ms
   Latency Distribution
-     50%     4.83ms
-     75%     6.51ms
-     90%     8.33ms
-     99%    12.12ms
+     50%     6.10ms
+     75%     7.45ms
+     90%     8.80ms
+     99%    11.34ms
 ### Get Auth Context (/auth/context) validated jwt no db
-  Reqs/sec     90360.83    8098.56   98846.76
-  Latency        1.09ms   361.43us     6.28ms
+  Reqs/sec     84965.01    7413.46   91095.50
+  Latency        1.16ms   402.15us     6.84ms
   Latency Distribution
-     50%     1.03ms
-     75%     1.36ms
-     90%     1.71ms
-     99%     2.55ms
+     50%     1.08ms
+     75%     1.44ms
+     90%     1.83ms
+     99%     2.81ms
 
 ## Items GET Performance (/items/1?q=hello)
-  Reqs/sec    150525.83   11505.05  157797.21
-  Latency      654.87us   514.25us     5.98ms
+  Reqs/sec    145784.38   20980.98  163903.98
+  Latency      631.08us   302.74us     6.02ms
   Latency Distribution
-     50%   482.00us
-     75%   799.00us
-     90%     1.31ms
-     99%     3.22ms
+     50%   613.00us
+     75%   733.00us
+     90%     0.87ms
+     99%     1.79ms
 
 ## Items PUT JSON Performance (/items/1)
-  Reqs/sec    139842.07   14437.12  147820.44
-  Latency      694.26us   444.94us     5.33ms
+  Reqs/sec    146751.20   15048.61  157735.96
+  Latency      670.25us   364.69us     7.39ms
   Latency Distribution
-     50%   580.00us
-     75%     0.87ms
-     90%     1.26ms
-     99%     3.00ms
+     50%   645.00us
+     75%   775.00us
+     90%     0.92ms
+     99%     2.09ms
 
 ## ORM Performance
 Seeding 1000 users for benchmark...
 Successfully seeded users
 Validated: 10 users exist in database
 ### Users Full10 (Async) (/users/full10)
-  Reqs/sec     14894.89    1187.09   17929.88
-  Latency        6.70ms     1.75ms    16.99ms
+  Reqs/sec     14730.29    2011.73   16992.58
+  Latency        6.76ms     2.51ms    24.88ms
   Latency Distribution
-     50%     6.79ms
-     75%     7.96ms
-     90%     9.11ms
-     99%    11.63ms
+     50%     6.30ms
+     75%     8.08ms
+     90%    10.10ms
+     99%    16.25ms
 ### Users Full10 (Sync) (/users/sync-full10)
-  Reqs/sec     10426.82    1141.33   13243.64
-  Latency        9.59ms     3.83ms    32.22ms
+  Reqs/sec     11323.96    1463.31   14263.19
+  Latency        8.82ms     3.59ms    28.98ms
   Latency Distribution
-     50%     8.94ms
-     75%    11.93ms
-     90%    15.18ms
-     99%    21.90ms
+     50%     8.08ms
+     75%    10.94ms
+     90%    14.11ms
+     99%    20.74ms
 ### Users Mini10 (Async) (/users/mini10)
-  Reqs/sec     18233.43    1279.73   21240.75
-  Latency        5.48ms     1.36ms    13.33ms
+  Reqs/sec     18610.84    1427.71   21194.24
+  Latency        5.36ms     1.75ms    14.74ms
   Latency Distribution
-     50%     5.21ms
-     75%     6.57ms
-     90%     7.78ms
-     99%     9.83ms
+     50%     5.19ms
+     75%     6.76ms
+     90%     8.16ms
+     99%    10.70ms
 ### Users Mini10 (Sync) (/users/sync-mini10)
-  Reqs/sec     11943.45     960.07   13542.88
-  Latency        8.35ms     2.77ms    24.95ms
+  Reqs/sec     12399.44    1093.32   16032.98
+  Latency        8.02ms     2.83ms    23.57ms
   Latency Distribution
-     50%     7.89ms
-     75%    10.05ms
-     90%    12.62ms
-     99%    17.22ms
+     50%     7.54ms
+     75%     9.73ms
+     90%    12.25ms
+     99%    17.50ms
 Cleaning up test users...
 
 ## Class-Based Views (CBV) Performance
 ### Simple APIView GET (/cbv-simple)
-  Reqs/sec    106514.54   10373.99  114763.59
-  Latency        0.93ms   370.33us     5.33ms
+  Reqs/sec    100104.07   28116.78  119384.22
+  Latency        1.02ms     1.03ms    13.98ms
   Latency Distribution
-     50%   847.00us
-     75%     1.14ms
-     90%     1.43ms
-     99%     2.44ms
+     50%     0.85ms
+     75%     1.15ms
+     90%     1.51ms
+     99%     3.29ms
 ### Simple APIView POST (/cbv-simple)
-  Reqs/sec    102073.12    8472.94  111538.88
-  Latency        0.95ms   329.65us     4.89ms
+  Reqs/sec    104226.81    9238.13  113182.76
+  Latency        0.94ms   416.11us     5.57ms
   Latency Distribution
-     50%     0.88ms
-     75%     1.20ms
-     90%     1.54ms
-     99%     2.35ms
+     50%     0.85ms
+     75%     1.13ms
+     90%     1.46ms
+     99%     2.97ms
 ### Items100 ViewSet GET (/cbv-items100)
-  Reqs/sec     58203.31   12809.52   69713.48
-  Latency        1.61ms   672.10us     9.04ms
+  Reqs/sec     66466.78    5988.92   71618.76
+  Latency        1.48ms   486.11us     6.65ms
   Latency Distribution
-     50%     1.49ms
-     75%     1.92ms
-     90%     2.54ms
-     99%     4.75ms
+     50%     1.38ms
+     75%     1.75ms
+     90%     2.20ms
+     99%     3.80ms
 
 ## CBV Items - Basic Operations
 ### CBV Items GET (Retrieve) (/cbv-items/1)
-  Reqs/sec    104092.71    6994.28  108839.88
-  Latency        0.94ms   341.89us     4.87ms
+  Reqs/sec     88544.77   22803.51  107039.87
+  Latency        1.00ms   334.11us     4.94ms
   Latency Distribution
-     50%     0.86ms
-     75%     1.18ms
-     90%     1.50ms
-     99%     2.46ms
+     50%     0.94ms
+     75%     1.27ms
+     90%     1.60ms
+     99%     2.42ms
 ### CBV Items PUT (Update) (/cbv-items/1)
-  Reqs/sec    102849.92    7448.25  109924.96
-  Latency        0.96ms   261.86us     4.08ms
+  Reqs/sec     99707.61    8714.18  105890.17
+  Latency        0.98ms   302.41us     5.51ms
   Latency Distribution
-     50%     0.90ms
-     75%     1.19ms
-     90%     1.48ms
-     99%     2.08ms
+     50%     0.92ms
+     75%     1.22ms
+     90%     1.53ms
+     99%     2.22ms
 
 ## CBV Additional Benchmarks
 ### CBV Bench Parse (POST /cbv-bench-parse)
-  Reqs/sec    103218.29   11026.88  110322.59
-  Latency        0.95ms   313.46us     5.09ms
+  Reqs/sec     99395.70   10111.20  107675.08
+  Latency        0.99ms   372.50us     4.84ms
   Latency Distribution
-     50%     0.89ms
-     75%     1.17ms
-     90%     1.49ms
-     99%     2.18ms
+     50%     0.91ms
+     75%     1.25ms
+     90%     1.61ms
+     99%     2.79ms
 ### CBV Response Types (/cbv-response)
-  Reqs/sec    109237.39    8645.92  115419.40
-  Latency        0.90ms   292.92us     3.74ms
+  Reqs/sec    106509.18    9567.02  113927.26
+  Latency        0.92ms   306.09us     4.57ms
   Latency Distribution
-     50%   829.00us
-     75%     1.12ms
-     90%     1.46ms
-     99%     2.23ms
+     50%     0.85ms
+     75%     1.17ms
+     90%     1.47ms
+     99%     2.17ms
 
 ## ORM Performance with CBV
 Seeding 1000 users for CBV benchmark...
 Successfully seeded users
 Validated: 10 users exist in database
 ### Users CBV Mini10 (List) (/users/cbv-mini10)
-  Reqs/sec     16586.52    1122.38   17438.62
-  Latency        5.98ms     1.56ms    14.10ms
+  Reqs/sec     16705.53    1579.51   18276.42
+  Latency        5.95ms     1.80ms    19.18ms
   Latency Distribution
-     50%     5.79ms
-     75%     7.21ms
-     90%     8.41ms
-     99%    11.09ms
+     50%     5.66ms
+     75%     7.11ms
+     90%     8.60ms
+     99%    11.89ms
 Cleaning up test users...
 
 
 ## Form and File Upload Performance
 ### Form Data (POST /form)
-  Reqs/sec    131861.35    9320.14  138786.36
-  Latency      729.86us   297.08us     5.50ms
+  Reqs/sec    118506.27    9414.06  125018.15
+  Latency      822.81us   407.87us     6.48ms
   Latency Distribution
-     50%   671.00us
-     75%     0.86ms
-     90%     1.11ms
-     99%     2.07ms
+     50%   745.00us
+     75%     1.02ms
+     90%     1.33ms
+     99%     2.80ms
 ### File Upload (POST /upload)
-  Reqs/sec    113844.41    9279.55  123771.38
-  Latency        0.87ms   342.89us     6.05ms
+  Reqs/sec    107082.08    7417.15  114999.61
+  Latency        0.91ms   376.83us     6.66ms
   Latency Distribution
-     50%   849.00us
-     75%     1.03ms
-     90%     1.29ms
-     99%     2.22ms
-### Mixed Form with Files (POST /mixed-form)
-  Reqs/sec    107645.66    7856.10  112697.59
-  Latency        0.91ms   307.88us     5.83ms
-  Latency Distribution
-     50%     0.87ms
+     50%   827.00us
      75%     1.12ms
-     90%     1.43ms
-     99%     2.16ms
+     90%     1.47ms
+     99%     2.35ms
+### Mixed Form with Files (POST /mixed-form)
+  Reqs/sec    110827.10    9002.91  116730.06
+  Latency        0.88ms   338.73us     6.43ms
+  Latency Distribution
+     50%   797.00us
+     75%     1.07ms
+     90%     1.39ms
+     99%     2.17ms
 
 ## Django Middleware Performance
 ### Django Middleware + Messages Framework (/middleware/demo)
 Tests: SessionMiddleware, AuthenticationMiddleware, MessageMiddleware, custom middleware, template rendering
-  Reqs/sec      9659.03     895.59   10769.54
-  Latency       10.31ms     3.18ms    26.87ms
+  Reqs/sec      9962.13    1148.71   13959.92
+  Latency       10.06ms     2.53ms    22.14ms
   Latency Distribution
-     50%     9.81ms
-     75%    12.90ms
-     90%    15.23ms
-     99%    19.31ms
+     50%     9.86ms
+     75%    11.96ms
+     90%    13.73ms
+     99%    17.60ms
 
 ## Django Ninja-style Benchmarks
 ### JSON Parse/Validate (POST /bench/parse)
-  Reqs/sec    147510.50    9461.00  153222.42
-  Latency      663.88us   271.00us     5.05ms
+  Reqs/sec    142798.24   10822.93  152393.99
+  Latency      682.30us   325.88us     6.64ms
   Latency Distribution
-     50%   607.00us
-     75%   814.00us
-     90%     1.03ms
-     99%     1.71ms
+     50%   580.00us
+     75%     0.86ms
+     90%     1.11ms
+     99%     1.92ms
 
 ## Serializer Performance Benchmarks
 ### Raw msgspec Serializer (POST /bench/serializer-raw)
-  Reqs/sec    100507.26    9721.69  106415.60
-  Latency        0.98ms   370.13us     6.21ms
+  Reqs/sec    106706.19   22889.01  151162.79
+  Latency        1.00ms   353.43us     4.76ms
   Latency Distribution
-     50%     0.90ms
-     75%     1.18ms
-     90%     1.52ms
-     99%     2.40ms
+     50%     0.93ms
+     75%     1.20ms
+     90%     1.56ms
+     99%     2.44ms
 ### Django-Bolt Serializer with Validators (POST /bench/serializer-validated)
-  Reqs/sec     90943.55    8100.27  100696.20
-  Latency        1.09ms   363.17us     4.90ms
+  Reqs/sec     89087.04    6727.46   95024.71
+  Latency        1.10ms   383.55us     5.39ms
   Latency Distribution
-     50%     1.01ms
-     75%     1.32ms
-     90%     1.64ms
-     99%     2.75ms
+     50%     1.02ms
+     75%     1.33ms
+     90%     1.70ms
+     99%     2.69ms
 ### Users msgspec Serializer (POST /users/bench/msgspec)
-  Reqs/sec    100783.63    8738.54  106373.07
-  Latency        0.97ms   342.69us     5.65ms
+  Reqs/sec     98471.39    8037.75  104493.79
+  Latency        0.99ms   310.32us     4.32ms
   Latency Distribution
-     50%     0.89ms
-     75%     1.19ms
-     90%     1.52ms
+     50%     0.93ms
+     75%     1.24ms
+     90%     1.57ms
      99%     2.34ms
 
 ## Multi-Response Performance
 
 ### Multi-response tuple return (/bench/multi/tuple)
-  Reqs/sec    107012.25    9247.74  112984.56
-  Latency        0.92ms   342.73us     5.18ms
+  Reqs/sec    103695.99    9207.58  111725.35
+  Latency        0.95ms   326.11us     4.31ms
   Latency Distribution
-     50%   846.00us
-     75%     1.13ms
-     90%     1.45ms
-     99%     2.22ms
+     50%     0.87ms
+     75%     1.17ms
+     90%     1.53ms
+     99%     2.48ms
 
 ### Multi-response bare dict (/bench/multi/dict)
-  Reqs/sec    109534.34    8911.31  115545.32
-  Latency        0.90ms   293.86us     5.16ms
+  Reqs/sec     84385.36   18323.44  111351.16
+  Latency        1.16ms   557.93us     7.39ms
   Latency Distribution
-     50%   835.00us
-     75%     1.08ms
-     90%     1.35ms
-     99%     2.10ms
+     50%     0.99ms
+     75%     1.38ms
+     90%     1.96ms
+     99%     3.79ms
 
 ## Latency Percentile Benchmarks
 Measures p50/p75/p90/p99 latency for type coercion overhead analysis
 
 ### Baseline - No Parameters (/)
-  Reqs/sec    175410.97   16473.34  184997.83
-  Latency      549.94us   244.48us     4.39ms
+  Reqs/sec    177897.69   15327.33  189514.90
+  Latency      544.92us   300.47us     5.69ms
   Latency Distribution
-     50%   486.00us
-     75%   660.00us
-     90%   827.00us
-     99%     1.80ms
+     50%   481.00us
+     75%   636.00us
+     90%     0.87ms
+     99%     1.94ms
 
 ### Path Parameter - int (/items/12345)
-  Reqs/sec    149157.00   10634.98  155134.21
-  Latency      656.46us   311.51us     5.13ms
+  Reqs/sec    156941.34   14272.58  170951.00
+  Latency      618.05us   276.17us     4.97ms
   Latency Distribution
-     50%   564.00us
-     75%   806.00us
-     90%     1.10ms
-     99%     2.11ms
+     50%   569.00us
+     75%   712.00us
+     90%     0.90ms
+     99%     2.05ms
 
 ### Path + Query Parameters (/items/12345?q=hello)
-  Reqs/sec    145882.12   11594.28  159655.89
-  Latency      669.22us   328.67us     5.83ms
+  Reqs/sec    153128.44   13955.24  167465.19
+  Latency      644.50us   315.02us     5.67ms
   Latency Distribution
-     50%   600.00us
-     75%   812.00us
-     90%     1.08ms
-     99%     1.98ms
+     50%   588.00us
+     75%   758.00us
+     90%     0.98ms
+     99%     1.76ms
 
 ### Header Parameter (/header)
-  Reqs/sec    104410.38   10472.93  113659.34
-  Latency        0.94ms   379.04us     5.47ms
+  Reqs/sec    104893.06    7912.09  110943.74
+  Latency        0.94ms   348.71us     5.78ms
   Latency Distribution
-     50%     0.85ms
-     75%     1.14ms
+     50%     0.86ms
+     75%     1.16ms
      90%     1.48ms
-     99%     2.47ms
+     99%     2.42ms
 
 ### Cookie Parameter (/cookie)
-  Reqs/sec    108463.91    7864.38  114499.39
-  Latency        0.91ms   290.26us     4.77ms
+  Reqs/sec    104280.46    8614.43  112417.50
+  Latency        0.94ms   316.57us     5.58ms
   Latency Distribution
-     50%   847.00us
-     75%     1.10ms
-     90%     1.44ms
-     99%     2.30ms
+     50%     0.87ms
+     75%     1.15ms
+     90%     1.48ms
+     99%     2.25ms
 
 ### Auth Context - JWT validated, no DB (/auth/context)
-  Reqs/sec     87105.46    6017.51   92194.75
-  Latency        1.13ms   384.65us     6.11ms
+  Reqs/sec     84795.93    5950.36   89882.96
+  Latency        1.15ms   406.66us     5.23ms
   Latency Distribution
-     50%     1.06ms
-     75%     1.39ms
-     90%     1.73ms
-     99%     2.61ms
+     50%     1.05ms
+     75%     1.41ms
+     90%     1.88ms
+     99%     2.92ms

--- a/bench/BENCHMARK_DEV.md
+++ b/bench/BENCHMARK_DEV.md
@@ -1,390 +1,392 @@
 # Django-Bolt Benchmark
-Generated: Mon 09 Mar 2026 08:09:45 AM PKT
+Generated: Mon 16 Mar 2026 01:55:21 PM PKT
 Config: 8 processes × 1 workers | C=100 N=10000
 
 ## Root Endpoint Performance
-  Reqs/sec    167179.92   14003.43  182452.23
-  Latency      582.56us   279.40us     4.79ms
+  Reqs/sec    171169.55   16056.50  185896.20
+  Latency      564.00us   303.04us     5.43ms
   Latency Distribution
-     50%   520.00us
-     75%   694.00us
+     50%   470.00us
+     75%   674.00us
      90%     0.95ms
-     99%     1.92ms
+     99%     1.94ms
 
 ## 10kb JSON Response Performance
 ### 10kb JSON (Async) (/10k-json)
-  Reqs/sec    118095.17   14710.48  140242.99
-  Latency        0.86ms   430.13us     6.82ms
+  Reqs/sec    116400.10   12126.23  128467.12
+  Latency      818.78us   331.64us     5.50ms
   Latency Distribution
-     50%   756.00us
+     50%   735.00us
      75%     1.00ms
-     90%     1.32ms
-     99%     3.19ms
+     90%     1.28ms
+     99%     2.25ms
 ### 10kb JSON (Sync) (/sync-10k-json)
-  Reqs/sec    123174.34    7222.23  129515.80
-  Latency      797.53us   373.37us     5.61ms
+  Reqs/sec    121763.55   10057.24  131016.21
+  Latency      799.02us   337.57us     5.27ms
   Latency Distribution
-     50%   730.00us
-     75%     1.00ms
+     50%   709.00us
+     75%     0.97ms
      90%     1.29ms
-     99%     2.34ms
+     99%     2.26ms
 
 ## Response Type Endpoints
 ### Header Endpoint (/header)
-  Reqs/sec    102167.58    8645.47  106540.70
-  Latency        0.96ms   389.08us     5.01ms
+  Reqs/sec    100342.30    8413.64  106140.17
+  Latency        0.98ms   353.02us     5.02ms
   Latency Distribution
-     50%     0.88ms
+     50%     0.92ms
      75%     1.19ms
-     90%     1.54ms
-     99%     2.69ms
+     90%     1.47ms
+     99%     2.36ms
 ### Cookie Endpoint (/cookie)
-  Reqs/sec    106415.97    8572.07  114141.62
-  Latency        0.93ms   324.99us     5.29ms
+  Reqs/sec     94216.40    6879.64  102200.52
+  Latency        1.05ms   376.90us     5.04ms
   Latency Distribution
-     50%     0.86ms
-     75%     1.12ms
-     90%     1.43ms
-     99%     2.20ms
+     50%     0.97ms
+     75%     1.30ms
+     90%     1.66ms
+     99%     2.71ms
 ### Exception Endpoint (/exc)
-  Reqs/sec    140893.44   10564.46  151175.64
-  Latency      694.31us   286.99us     5.01ms
+  Reqs/sec    135710.25   12626.48  143277.56
+  Latency      721.08us   304.87us     6.46ms
   Latency Distribution
-     50%   657.00us
-     75%     0.86ms
-     90%     1.08ms
-     99%     1.98ms
+     50%   658.00us
+     75%     0.88ms
+     90%     1.14ms
+     99%     1.99ms
 ### HTML Response (/html)
-  Reqs/sec    163096.49   12317.19  175525.46
-  Latency      587.36us   328.15us     5.51ms
+  Reqs/sec    150435.91   14115.04  161285.26
+  Latency      643.31us   411.33us     6.22ms
   Latency Distribution
-     50%   547.00us
-     75%   667.00us
-     90%     0.88ms
-     99%     2.20ms
+     50%   539.00us
+     75%   735.00us
+     90%     1.13ms
+     99%     3.02ms
 ### Redirect Response (/redirect)
 ### File Static via FileResponse (/file-static)
-  Reqs/sec     37084.08    7457.42   41984.22
-  Latency        2.68ms     1.49ms    20.79ms
+  Reqs/sec     35232.17    7367.40   39461.79
+  Latency        2.84ms     1.45ms    21.66ms
   Latency Distribution
-     50%     2.44ms
-     75%     3.18ms
-     90%     4.10ms
-     99%     9.08ms
+     50%     2.55ms
+     75%     3.42ms
+     90%     4.44ms
+     99%     8.55ms
 
 ## Authentication & Authorization Performance
 ### Auth NO User Access (/auth/no-user-access) - lazy loading, no DB query
-  Reqs/sec     70667.95    7389.24   86339.06
-  Latency        1.44ms   558.54us     5.19ms
+  Reqs/sec     72795.59    5057.83   77449.33
+  Latency        1.35ms   415.92us     5.21ms
   Latency Distribution
-     50%     1.29ms
-     75%     1.77ms
-     90%     2.34ms
-     99%     3.92ms
+     50%     1.26ms
+     75%     1.63ms
+     90%     2.06ms
+     99%     3.19ms
 ### Get Authenticated User (/auth/me) - accesses request.user, triggers DB query
-  Reqs/sec     17250.32    1830.26   19165.40
-  Latency        5.78ms     1.90ms    18.87ms
+  Reqs/sec     16906.09    1443.31   19166.16
+  Latency        5.90ms     1.25ms    13.77ms
   Latency Distribution
-     50%     5.76ms
-     75%     7.32ms
-     90%     8.47ms
-     99%    11.37ms
+     50%     5.82ms
+     75%     6.84ms
+     90%     7.70ms
+     99%    10.07ms
 ### Get User via Dependency (/auth/me-dependency)
-  Reqs/sec     16218.94    1231.52   20199.10
-  Latency        6.18ms     1.48ms    16.52ms
+ 2975 / 10000 [========================>---------------------------------------------------------]  29.75% 14830/s
+ 9075 / 10000 [==========================================================================>-------]  90.75% 15090/s
+  Reqs/sec     15160.46     834.21   16563.58
+  Latency        6.56ms     1.67ms    14.27ms
   Latency Distribution
-     50%     6.02ms
-     75%     7.29ms
-     90%     8.49ms
-     99%    10.91ms
+     50%     6.64ms
+     75%     7.92ms
+     90%     9.05ms
+     99%    11.19ms
 ### Get Auth Context (/auth/context) validated jwt no db
-  Reqs/sec     87511.93    4224.59   91380.38
-  Latency        1.12ms   446.14us     4.74ms
+  Reqs/sec     79429.55    5639.93   86334.60
+  Latency        1.22ms   429.22us     5.35ms
   Latency Distribution
-     50%     1.01ms
-     75%     1.42ms
-     90%     1.91ms
-     99%     3.12ms
+     50%     1.09ms
+     75%     1.56ms
+     90%     2.07ms
+     99%     3.09ms
 
 ## Items GET Performance (/items/1?q=hello)
-  Reqs/sec    166356.76   18431.55  177890.81
-  Latency      582.46us   253.93us     5.55ms
-  Latency Distribution
-     50%   551.00us
-     75%   657.00us
-     90%   787.00us
-     99%     1.60ms
-
-## Items PUT JSON Performance (/items/1)
-  Reqs/sec    147873.63   10965.28  163307.55
-  Latency      648.81us   348.42us     6.10ms
+  Reqs/sec    148366.29   18693.95  167775.79
+  Latency      622.61us   322.11us     5.99ms
   Latency Distribution
      50%   576.00us
-     75%   742.00us
-     90%     0.96ms
-     99%     2.29ms
+     75%   682.00us
+     90%   820.00us
+     99%     2.27ms
+
+## Items PUT JSON Performance (/items/1)
+  Reqs/sec    142994.39   12642.19  154517.37
+  Latency      665.90us   252.83us     5.18ms
+  Latency Distribution
+     50%   615.00us
+     75%   758.00us
+     90%     1.02ms
+     99%     1.81ms
 
 ## ORM Performance
 Seeding 1000 users for benchmark...
 Successfully seeded users
 Validated: 10 users exist in database
 ### Users Full10 (Async) (/users/full10)
-  Reqs/sec     15687.56    1576.03   17828.98
-  Latency        6.35ms     2.16ms    22.09ms
+  Reqs/sec     14801.05    1923.87   23929.10
+  Latency        6.83ms     1.56ms    20.71ms
   Latency Distribution
-     50%     5.96ms
-     75%     7.56ms
-     90%     9.58ms
-     99%    14.36ms
+     50%     6.98ms
+     75%     8.07ms
+     90%     8.94ms
+     99%    11.32ms
 ### Users Full10 (Sync) (/users/sync-full10)
-  Reqs/sec     12443.37    1653.57   15463.94
-  Latency        8.03ms     4.14ms    33.64ms
+  Reqs/sec     10317.50    1098.58   13189.40
+  Latency        9.60ms     4.06ms    30.53ms
   Latency Distribution
-     50%     6.86ms
-     75%    10.14ms
-     90%    14.38ms
-     99%    22.85ms
+     50%     8.75ms
+     75%    12.03ms
+     90%    15.76ms
+     99%    22.38ms
 ### Users Mini10 (Async) (/users/mini10)
-  Reqs/sec     19513.49    2562.60   31212.98
-  Latency        5.21ms     1.47ms    12.53ms
+  Reqs/sec     17433.32    2291.05   20092.78
+  Latency        5.58ms     1.51ms    12.77ms
   Latency Distribution
-     50%     5.10ms
-     75%     6.36ms
-     90%     7.62ms
-     99%     9.56ms
+     50%     5.43ms
+     75%     7.04ms
+     90%     8.06ms
+     99%     9.80ms
 ### Users Mini10 (Sync) (/users/sync-mini10)
-  Reqs/sec     13314.50    1724.69   15947.00
-  Latency        7.39ms     2.83ms    23.57ms
+  Reqs/sec     11989.54     679.38   13447.85
+  Latency        8.31ms     3.56ms    30.98ms
   Latency Distribution
-     50%     6.81ms
-     75%     9.00ms
-     90%    11.46ms
-     99%    17.39ms
+     50%     7.66ms
+     75%    10.21ms
+     90%    13.18ms
+     99%    20.89ms
 Cleaning up test users...
 
 ## Class-Based Views (CBV) Performance
 ### Simple APIView GET (/cbv-simple)
-  Reqs/sec    109707.29   11088.27  119472.89
-  Latency        0.88ms   301.01us     4.20ms
+  Reqs/sec     98740.96    8391.17  109218.61
+  Latency        0.99ms   321.48us     4.86ms
   Latency Distribution
-     50%   814.00us
-     75%     1.07ms
-     90%     1.36ms
-     99%     2.25ms
+     50%     0.93ms
+     75%     1.23ms
+     90%     1.54ms
+     99%     2.36ms
 ### Simple APIView POST (/cbv-simple)
-  Reqs/sec    107473.35    8978.23  118531.37
-  Latency        0.90ms   299.88us     4.36ms
+  Reqs/sec    101381.91    6864.73  108580.08
+  Latency        0.97ms   311.64us     4.44ms
   Latency Distribution
-     50%   844.00us
-     75%     1.09ms
-     90%     1.40ms
-     99%     2.16ms
+     50%     0.91ms
+     75%     1.20ms
+     90%     1.54ms
+     99%     2.25ms
 ### Items100 ViewSet GET (/cbv-items100)
-  Reqs/sec     66948.36    6103.09   72590.82
-  Latency        1.47ms   551.98us     5.67ms
+  Reqs/sec     62061.14    8083.23   68264.80
+  Latency        1.55ms   465.53us     5.87ms
   Latency Distribution
-     50%     1.37ms
-     75%     1.78ms
-     90%     2.28ms
-     99%     4.16ms
+     50%     1.47ms
+     75%     1.86ms
+     90%     2.32ms
+     99%     3.55ms
 
 ## CBV Items - Basic Operations
 ### CBV Items GET (Retrieve) (/cbv-items/1)
-  Reqs/sec     98028.19    6742.68  104232.52
-  Latency        1.00ms   375.63us     4.40ms
-  Latency Distribution
-     50%     0.91ms
-     75%     1.24ms
-     90%     1.63ms
-     99%     2.74ms
-### CBV Items PUT (Update) (/cbv-items/1)
-  Reqs/sec     90430.94    9592.27   98941.23
-  Latency        1.07ms   453.74us     6.83ms
+  Reqs/sec     94215.98    8078.48  100194.58
+  Latency        1.05ms   342.78us     4.75ms
   Latency Distribution
      50%     0.97ms
-     75%     1.33ms
-     90%     1.73ms
-     99%     3.21ms
+     75%     1.32ms
+     90%     1.67ms
+     99%     2.47ms
+### CBV Items PUT (Update) (/cbv-items/1)
+  Reqs/sec    100325.56    7556.51  105825.67
+  Latency        0.98ms   347.79us     6.95ms
+  Latency Distribution
+     50%     0.91ms
+     75%     1.20ms
+     90%     1.52ms
+     99%     2.50ms
 
 ## CBV Additional Benchmarks
 ### CBV Bench Parse (POST /cbv-bench-parse)
-  Reqs/sec    101298.32    8153.47  108144.80
-  Latency        0.96ms   320.88us     5.08ms
+  Reqs/sec    100307.91    8934.32  105465.80
+  Latency        0.98ms   336.91us     4.84ms
   Latency Distribution
-     50%     0.89ms
-     75%     1.19ms
-     90%     1.52ms
-     99%     2.35ms
+     50%     0.90ms
+     75%     1.23ms
+     90%     1.56ms
+     99%     2.47ms
 ### CBV Response Types (/cbv-response)
-  Reqs/sec    104134.78   11234.93  113698.48
-  Latency        0.94ms   301.88us     4.35ms
+  Reqs/sec    109983.00    8781.15  116353.84
+  Latency        0.89ms   269.22us     4.97ms
   Latency Distribution
-     50%     0.88ms
-     75%     1.18ms
-     90%     1.47ms
-     99%     2.21ms
+     50%     0.85ms
+     75%     1.08ms
+     90%     1.34ms
+     99%     1.91ms
 
 ## ORM Performance with CBV
 Seeding 1000 users for CBV benchmark...
 Successfully seeded users
 Validated: 10 users exist in database
 ### Users CBV Mini10 (List) (/users/cbv-mini10)
-  Reqs/sec     17603.39    1340.36   19568.83
-  Latency        5.66ms     1.68ms    16.56ms
+  Reqs/sec     16329.43    1265.38   17812.83
+  Latency        6.08ms     1.89ms    19.04ms
   Latency Distribution
-     50%     5.48ms
-     75%     6.75ms
-     90%     8.13ms
-     99%    11.29ms
+     50%     5.83ms
+     75%     7.21ms
+     90%     9.07ms
+     99%    12.28ms
 Cleaning up test users...
 
 
 ## Form and File Upload Performance
 ### Form Data (POST /form)
-  Reqs/sec    132265.00    9358.68  140202.00
-  Latency      739.46us   291.49us     5.72ms
+  Reqs/sec    132183.23   13325.76  145831.82
+  Latency      735.06us   336.77us     5.75ms
   Latency Distribution
-     50%   683.00us
-     75%     0.89ms
-     90%     1.14ms
-     99%     1.99ms
+     50%   659.00us
+     75%     0.92ms
+     90%     1.15ms
+     99%     2.14ms
 ### File Upload (POST /upload)
-  Reqs/sec    108274.40    7098.29  115907.65
-  Latency        0.88ms   469.61us     5.60ms
+  Reqs/sec    114217.72    7874.02  123498.49
+  Latency        0.85ms   389.74us     7.59ms
   Latency Distribution
-     50%   810.00us
-     75%     1.05ms
-     90%     1.39ms
-     99%     3.36ms
+     50%   768.00us
+     75%     1.03ms
+     90%     1.32ms
+     99%     2.31ms
 ### Mixed Form with Files (POST /mixed-form)
-  Reqs/sec    112150.50   10869.07  120902.26
-  Latency        0.87ms   392.11us     6.26ms
+  Reqs/sec    115074.67   12009.75  129253.02
+  Latency        0.87ms   347.61us     5.62ms
   Latency Distribution
-     50%   800.00us
-     75%     1.00ms
-     90%     1.33ms
-     99%     2.45ms
+     50%   802.00us
+     75%     0.98ms
+     90%     1.31ms
+     99%     2.30ms
 
 ## Django Middleware Performance
 ### Django Middleware + Messages Framework (/middleware/demo)
 Tests: SessionMiddleware, AuthenticationMiddleware, MessageMiddleware, custom middleware, template rendering
-  Reqs/sec      9897.17     952.52   12059.85
-  Latency       10.09ms     3.29ms    24.10ms
+  Reqs/sec      9304.35     956.13   10764.53
+  Latency       10.72ms     2.58ms    25.52ms
   Latency Distribution
-     50%     9.43ms
-     75%    12.62ms
-     90%    15.10ms
-     99%    19.95ms
+     50%    10.71ms
+     75%    12.44ms
+     90%    14.11ms
+     99%    18.67ms
 
 ## Django Ninja-style Benchmarks
 ### JSON Parse/Validate (POST /bench/parse)
-  Reqs/sec    136047.88   10117.43  147099.64
-  Latency      717.04us   486.13us     6.14ms
+  Reqs/sec    146012.25   11713.84  157582.73
+  Latency      650.73us   383.23us     6.11ms
   Latency Distribution
-     50%   602.00us
-     75%   798.00us
-     90%     1.10ms
-     99%     3.49ms
+     50%   582.00us
+     75%   754.00us
+     90%     0.96ms
+     99%     2.23ms
 
 ## Serializer Performance Benchmarks
 ### Raw msgspec Serializer (POST /bench/serializer-raw)
-  Reqs/sec    103090.25    8072.24  109708.03
-  Latency        0.95ms   375.52us     5.54ms
+  Reqs/sec     99654.01   10749.75  116292.59
+  Latency        1.02ms   310.02us     4.97ms
   Latency Distribution
-     50%     0.86ms
-     75%     1.15ms
-     90%     1.53ms
-     99%     2.59ms
+     50%     0.95ms
+     75%     1.25ms
+     90%     1.56ms
+     99%     2.31ms
 ### Django-Bolt Serializer with Validators (POST /bench/serializer-validated)
-  Reqs/sec     93169.00   14168.87  105087.92
-  Latency        1.08ms   495.72us     6.48ms
+  Reqs/sec     86046.42    4837.14   91699.58
+  Latency        1.14ms   371.29us     4.74ms
   Latency Distribution
-     50%     0.97ms
-     75%     1.30ms
-     90%     1.66ms
-     99%     3.45ms
+     50%     1.07ms
+     75%     1.39ms
+     90%     1.76ms
+     99%     2.81ms
 ### Users msgspec Serializer (POST /users/bench/msgspec)
-  Reqs/sec    103065.25    8826.39  109147.56
-  Latency        0.94ms   347.06us     4.73ms
+  Reqs/sec     98333.01    8485.81  103738.50
+  Latency        0.99ms   316.39us     5.03ms
   Latency Distribution
-     50%     0.87ms
-     75%     1.14ms
-     90%     1.44ms
-     99%     2.36ms
+     50%     0.94ms
+     75%     1.21ms
+     90%     1.52ms
+     99%     2.30ms
 
 ## Multi-Response Performance
 
 ### Multi-response tuple return (/bench/multi/tuple)
-  Reqs/sec    107132.76    7216.91  113970.96
-  Latency        0.91ms   304.50us     4.30ms
+  Reqs/sec     99671.12    8316.88  107173.43
+  Latency        0.99ms   345.26us     5.08ms
   Latency Distribution
-     50%     0.85ms
-     75%     1.14ms
-     90%     1.44ms
-     99%     2.17ms
+     50%     0.92ms
+     75%     1.22ms
+     90%     1.53ms
+     99%     2.38ms
 
 ### Multi-response bare dict (/bench/multi/dict)
-  Reqs/sec     94362.75   21562.98  109204.77
-  Latency        1.06ms   626.61us     9.07ms
+  Reqs/sec    104526.13    8500.09  109440.41
+  Latency        0.94ms   307.44us     4.54ms
   Latency Distribution
-     50%     0.93ms
-     75%     1.28ms
-     90%     1.67ms
-     99%     4.16ms
+     50%     0.87ms
+     75%     1.16ms
+     90%     1.45ms
+     99%     2.18ms
 
 ## Latency Percentile Benchmarks
 Measures p50/p75/p90/p99 latency for type coercion overhead analysis
 
 ### Baseline - No Parameters (/)
-  Reqs/sec    164871.54   17816.20  185285.10
-  Latency      614.44us   285.52us     5.16ms
+  Reqs/sec    175552.68   17023.98  185573.53
+  Latency      556.40us   311.83us     5.34ms
   Latency Distribution
-     50%   566.00us
-     75%   722.00us
-     90%     0.91ms
-     99%     1.91ms
+     50%   476.00us
+     75%   666.00us
+     90%     0.92ms
+     99%     2.01ms
 
 ### Path Parameter - int (/items/12345)
-  Reqs/sec    136578.60    9491.80  146390.24
-  Latency      703.73us   316.26us     5.38ms
+  Reqs/sec    158351.48   14701.02  168321.28
+  Latency      614.65us   361.51us     5.47ms
   Latency Distribution
-     50%   648.00us
-     75%   830.00us
-     90%     1.11ms
-     99%     2.11ms
+     50%   553.00us
+     75%   687.00us
+     90%     0.88ms
+     99%     2.16ms
 
 ### Path + Query Parameters (/items/12345?q=hello)
-  Reqs/sec    129069.23    8607.78  136544.45
-  Latency      757.80us   445.04us     5.41ms
+  Reqs/sec    153661.65   13872.43  167005.27
+  Latency      629.98us   308.63us     6.19ms
   Latency Distribution
-     50%   682.00us
-     75%     0.89ms
-     90%     1.14ms
-     99%     3.42ms
+     50%   549.00us
+     75%   754.00us
+     90%     0.99ms
+     99%     1.88ms
 
 ### Header Parameter (/header)
-  Reqs/sec    104172.31    6582.44  112311.04
-  Latency        0.94ms   406.71us     5.62ms
+  Reqs/sec    101234.71    8477.51  107710.37
+  Latency        0.97ms   343.10us     6.07ms
   Latency Distribution
-     50%   848.00us
-     75%     1.13ms
-     90%     1.44ms
-     99%     3.11ms
+     50%     0.90ms
+     75%     1.17ms
+     90%     1.50ms
+     99%     2.28ms
 
 ### Cookie Parameter (/cookie)
-  Reqs/sec    108742.15   11474.36  119460.00
-  Latency        0.90ms   314.51us     5.38ms
+  Reqs/sec    103889.79    9328.12  110016.31
+  Latency        0.94ms   308.42us     4.72ms
   Latency Distribution
-     50%   845.00us
-     75%     1.12ms
-     90%     1.40ms
-     99%     2.17ms
+     50%     0.89ms
+     75%     1.17ms
+     90%     1.46ms
+     99%     2.24ms
 
 ### Auth Context - JWT validated, no DB (/auth/context)
-  Reqs/sec     87523.28    6634.04   92551.35
-  Latency        1.12ms   370.67us     5.78ms
+  Reqs/sec     83544.84    5808.34   87354.81
+  Latency        1.17ms   501.73us     6.02ms
   Latency Distribution
-     50%     1.04ms
-     75%     1.37ms
-     90%     1.78ms
-     99%     2.63ms
+     50%     1.02ms
+     75%     1.40ms
+     90%     1.99ms
+     99%     3.56ms

--- a/docs/src/topics/lifespan.md
+++ b/docs/src/topics/lifespan.md
@@ -1,0 +1,175 @@
+---
+icon: lucide/power
+---
+
+# Lifespan
+
+Django Bolt supports lifespan events for running code during server startup and shutdown. This follows the same pattern as [Starlette's lifespan](https://www.starlette.io/lifespan/), using an async context manager.
+
+Common use cases:
+
+- Initializing database connection pools
+- Warming caches
+- Starting background tasks
+- Cleaning up resources on shutdown
+
+## Basic usage
+
+Pass an async context manager factory to the `lifespan` parameter of `BoltAPI`. Code before `yield` runs on startup, code after runs on shutdown:
+
+```python
+from contextlib import asynccontextmanager
+from django_bolt import BoltAPI
+
+@asynccontextmanager
+async def lifespan(app):
+    # Startup
+    print("Starting up...")
+    yield
+    # Shutdown
+    print("Shutting down...")
+
+api = BoltAPI(lifespan=lifespan)
+```
+
+The `app` argument is the `BoltAPI` instance.
+
+## Resource management
+
+The context manager pattern guarantees cleanup runs even if the server crashes, making it safer than separate startup/shutdown hooks:
+
+```python
+from contextlib import asynccontextmanager
+from django_bolt import BoltAPI
+
+@asynccontextmanager
+async def lifespan(app):
+    # Create resources
+    redis = await aioredis.from_url("redis://localhost")
+    app._redis = redis
+
+    try:
+        yield
+    finally:
+        # Always cleaned up, even on crash
+        await redis.close()
+
+api = BoltAPI(lifespan=lifespan)
+
+@api.get("/cached")
+async def get_cached(request):
+    value = await request.app._redis.get("key")
+    return {"value": value}
+```
+
+## Database connection pools
+
+```python
+from contextlib import asynccontextmanager
+from sqlalchemy.ext.asyncio import create_async_engine
+from django_bolt import BoltAPI
+
+@asynccontextmanager
+async def lifespan(app):
+    engine = create_async_engine("postgresql+asyncpg://localhost/mydb")
+    app._engine = engine
+    try:
+        yield
+    finally:
+        await engine.dispose()
+
+api = BoltAPI(lifespan=lifespan)
+```
+
+## Cache warming
+
+```python
+from contextlib import asynccontextmanager
+from django_bolt import BoltAPI
+
+@asynccontextmanager
+async def lifespan(app):
+    # Load frequently accessed data into memory
+    from myapp.models import Setting
+    app._settings_cache = {
+        s.key: s.value
+        async for s in Setting.objects.all()
+    }
+    print(f"Loaded {len(app._settings_cache)} settings")
+    yield
+    app._settings_cache.clear()
+
+api = BoltAPI(lifespan=lifespan)
+```
+
+## Multiple APIs
+
+When multiple `BoltAPI` instances are autodiscovered (multi-app projects), each API's lifespan runs independently. Startup runs in discovery order; shutdown runs in reverse order (LIFO).
+
+```python
+# blog/api.py
+@asynccontextmanager
+async def blog_lifespan(app):
+    print("Blog API starting")
+    yield
+    print("Blog API stopping")
+
+api = BoltAPI(lifespan=blog_lifespan)
+
+# payments/api.py
+@asynccontextmanager
+async def payments_lifespan(app):
+    print("Payments API starting")
+    yield
+    print("Payments API stopping")
+
+api = BoltAPI(lifespan=payments_lifespan)
+
+# Output on startup:
+#   Blog API starting
+#   Payments API starting
+# Output on shutdown:
+#   Payments API stopping
+#   Blog API stopping
+```
+
+## Testing
+
+The `TestClient` is lifespan-aware. When you enter the `with` block, startup runs. When you exit, shutdown runs. No special setup needed:
+
+```python
+from contextlib import asynccontextmanager
+from django_bolt import BoltAPI
+from django_bolt.testing import TestClient
+
+@asynccontextmanager
+async def lifespan(app):
+    app._cache = {"ready": True}
+    yield
+    app._cache.clear()
+
+api = BoltAPI(lifespan=lifespan)
+
+@api.get("/status")
+async def status(request):
+    return {"ready": request.app._cache.get("ready", False)}
+
+# Lifespan runs automatically
+with TestClient(api) as client:
+    response = client.get("/status")
+    assert response.json() == {"ready": True}
+```
+
+The `AsyncTestClient` also supports lifespan:
+
+```python
+async with AsyncTestClient(api) as client:
+    response = await client.get("/status")
+    assert response.json() == {"ready": True}
+```
+
+## How it works
+
+- **`runbolt` command**: Lifespan enters before the Rust server starts and exits after it stops. The server runs in a thread while the async event loop manages the lifespan context.
+- **`TestClient`**: Lifespan enters on `__enter__` and exits on `__exit__`, using a dedicated event loop that stays alive for the duration of the test.
+- **Multi-process mode**: Each process runs its own lifespan independently.

--- a/docs/src/topics/testing.md
+++ b/docs/src/topics/testing.md
@@ -513,6 +513,36 @@ The `AsyncTestClient` is useful when:
 - You need to await other async operations in the same test
 - You're using `pytest-asyncio`
 
+## Lifespan support
+
+The `TestClient` automatically runs [lifespan](lifespan.md) events. Startup runs when entering the `with` block, shutdown runs when exiting:
+
+```python
+from contextlib import asynccontextmanager
+from django_bolt import BoltAPI
+from django_bolt.testing import TestClient
+
+@asynccontextmanager
+async def lifespan(app):
+    app._cache = {"ready": True}
+    yield
+    app._cache.clear()
+
+api = BoltAPI(lifespan=lifespan)
+
+@api.get("/status")
+async def status(request):
+    return {"ready": request.app._cache.get("ready", False)}
+
+with TestClient(api) as client:
+    # Lifespan startup has already run
+    response = client.get("/status")
+    assert response.json() == {"ready": True}
+# Lifespan shutdown runs here
+```
+
+If no lifespan is configured, `TestClient` works exactly as before.
+
 ## Test isolation
 
 Each `TestClient` context creates isolated state:

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -70,6 +70,7 @@ nav = [
     { "Dependencies" = "topics/dependencies.md" },
     { "Middleware" = "topics/middleware.md" },
     { "Static Files" = "topics/static-files.md" },
+    { "Lifespan" = "topics/lifespan.md" },
     { "Django Signals" = "topics/signals.md" },
     { "Error Handling" = "topics/error-handling.md" },
     { "Logging" = "topics/logging.md" },

--- a/python/django_bolt/api.py
+++ b/python/django_bolt/api.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import dis
 import inspect
 import sys
@@ -282,6 +284,23 @@ def _wire_from_error_parts(status: int, headers: list[tuple[str, str]], body: by
     return int(status), meta, _BODY_BYTES, body
 
 
+async def serve_with_lifespan(
+    source_lifespans: list[tuple[BoltAPI, Callable]],
+    server_fn: Callable,
+) -> None:
+    """Run *server_fn* inside every lifespan context in *source_lifespans*.
+
+    Each ``(api, lifespan_ctx)`` pair is entered in order; teardown runs in
+    reverse order (LIFO) via :class:`contextlib.AsyncExitStack`.
+    *server_fn* is executed in a thread so the async event-loop stays free
+    for lifespan teardown when the server stops.
+    """
+    async with contextlib.AsyncExitStack() as stack:
+        for api, lifespan_ctx in source_lifespans:
+            await stack.enter_async_context(lifespan_ctx(api))
+        await asyncio.to_thread(server_fn)
+
+
 class BoltAPI:
     def __init__(
         self,
@@ -294,6 +313,7 @@ class BoltAPI:
         compression: Any | None = None,
         openapi_config: Any | None = None,
         validate_response: bool = True,
+        lifespan: Callable | None = None,
     ) -> None:
         """
         Initialize a BoltAPI instance.
@@ -316,6 +336,8 @@ class BoltAPI:
             compression: Compression configuration (CompressionConfig or False to disable)
             openapi_config: OpenAPI documentation configuration
             validate_response: Default response validation policy for registered routes
+            lifespan: Async context manager factory for startup/shutdown lifecycle.
+                Receives the BoltAPI instance as argument.
         """
         self._routes: list[tuple[str, str, int, Callable]] = []
         self._websocket_routes: list[tuple[str, int, Callable]] = []  # (path, handler_id, handler)
@@ -419,9 +441,9 @@ class BoltAPI:
         # Signal emission - disabled by default for performance
         # Enable with BOLT_EMIT_SIGNALS = True in Django settings
         self._emit_signals = getattr(django_settings, "BOLT_EMIT_SIGNALS", False) if django_settings else False
-        # Lifecycle hooks
-        self._startup_hooks: list[Callable] = []
-        self._shutdown_hooks: list[Callable] = []
+        # Lifecycle: async context manager for startup/shutdown
+        self._lifespan_context: Callable | None = lifespan
+        self._source_lifespans: list[tuple[BoltAPI, Callable]] | None = None
 
         # Register this instance globally for autodiscovery
         _BOLT_API_REGISTRY.append(self)
@@ -2264,7 +2286,6 @@ class BoltAPI:
             await asgi_app(django_scope, receive, django_send)
 
         self.mount_asgi(path, django_mount_wrapper)
-        
 
     def include_router(self, router: Router, prefix: str = "") -> None:
         """
@@ -2336,21 +2357,8 @@ class BoltAPI:
 
             # Apply decorator to register handler
             decorator(handler)
-    def on_startup(self, func: Callable) -> Callable:
-        """Register a startup lifecycle hook."""
-        self._startup_hooks.append(func)
-        return func
 
-    def on_shutdown(self, func: Callable) -> Callable:
-        """Register a shutdown lifecycle hook."""
-        self._shutdown_hooks.append(func)
-        return func
-
-    async def _run_lifecycle_hooks(self, hooks: list[Callable]) -> None:
-        """Execute lifecycle hooks in order. Supports both sync and async."""
-        import asyncio
-        for hook in hooks:
-            if asyncio.iscoroutinefunction(hook):
-                await hook()
-            else:
-                hook()
+    @property
+    def _has_lifespan(self) -> bool:
+        """Check if this API has a lifespan context manager."""
+        return self._lifespan_context is not None

--- a/python/django_bolt/management/commands/runbolt.py
+++ b/python/django_bolt/management/commands/runbolt.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import asyncio
 import contextlib
 import importlib
 import importlib.metadata
@@ -14,7 +15,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
 from django_bolt import _core
-from django_bolt.api import BoltAPI, _validate_asgi_mount_conflicts
+from django_bolt.api import BoltAPI, _validate_asgi_mount_conflicts, serve_with_lifespan
 
 try:
     from django.utils import autoreload
@@ -464,14 +465,27 @@ class Command(BaseCommand):
                 features=features,
             )
 
+        # Collect lifecycle contexts (merged APIs store them, single APIs check directly)
+        source_lifespans = merged_api._source_lifespans
+        if source_lifespans is None and merged_api._has_lifespan:
+            source_lifespans = [(merged_api, merged_api._lifespan_context)]
+
         # Start the server (all handlers go through async dispatch with thread pool for sync)
-        _core.start_server(
-            merged_api._dispatch,
-            options["host"],
-            options["port"],
-            compression_config,
-            merged_api._dispatch_sync,
-        )
+        if source_lifespans:
+
+            def server_fn():
+                _core.start_server(
+                    merged_api._dispatch, options["host"], options["port"],
+                    compression_config, merged_api._dispatch_sync,
+                )
+
+            with contextlib.suppress(KeyboardInterrupt):
+                asyncio.run(serve_with_lifespan(source_lifespans, server_fn))
+        else:
+            _core.start_server(
+                merged_api._dispatch, options["host"], options["port"],
+                compression_config, merged_api._dispatch_sync,
+            )
 
     # ------------------------------------------------------------------
     # Startup banner
@@ -779,6 +793,13 @@ class Command(BaseCommand):
 
         # Update next handler ID
         merged._next_handler_id = next_handler_id
+
+        # Collect lifecycle contexts from source APIs
+        merged._source_lifespans = [
+            (api, api._lifespan_context)
+            for _, api in apis
+            if api._has_lifespan
+        ]
 
         return merged
 

--- a/python/django_bolt/testing/client.py
+++ b/python/django_bolt/testing/client.py
@@ -405,14 +405,39 @@ class TestClient(httpx.Client):
         self.api = api
 
     def __enter__(self):
-        """Enter context manager."""
-        return super().__enter__()
+        """Enter context manager — runs lifespan startup if configured."""
+        if self.api._has_lifespan:
+            loop = asyncio.new_event_loop()
+            cm = self.api._lifespan_context(self.api)
+            try:
+                loop.run_until_complete(cm.__aenter__())
+            except BaseException:
+                loop.close()
+                raise
+            self._lifespan_loop = loop
+            self._lifespan_cm = cm
+        try:
+            return super().__enter__()
+        except BaseException:
+            if hasattr(self, "_lifespan_cm"):
+                self._lifespan_loop.run_until_complete(
+                    self._lifespan_cm.__aexit__(None, None, None)
+                )
+                self._lifespan_loop.close()
+            raise
 
-    def __exit__(self, *args):
-        """Exit context manager and cleanup test app."""
-        with contextlib.suppress(builtins.BaseException):
-            _core.destroy_test_app(self.app_id)
-        return super().__exit__(*args)
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Exit context manager — runs lifespan shutdown, then cleans up test app."""
+        try:
+            if hasattr(self, "_lifespan_cm"):
+                self._lifespan_loop.run_until_complete(
+                    self._lifespan_cm.__aexit__(exc_type, exc_val, exc_tb)
+                )
+                self._lifespan_loop.close()
+        finally:
+            with contextlib.suppress(builtins.BaseException):
+                _core.destroy_test_app(self.app_id)
+        return super().__exit__(exc_type, exc_val, exc_tb)
 
     # Override HTTP methods to support stream=True
     def _add_streaming_methods(self, response: Response) -> Response:
@@ -633,11 +658,24 @@ class AsyncTestClient(httpx.AsyncClient):
         self.api = api
 
     async def __aenter__(self):
-        """Enter async context manager."""
-        return await super().__aenter__()
+        """Enter async context manager — runs lifespan startup if configured."""
+        if self.api._has_lifespan:
+            cm = self.api._lifespan_context(self.api)
+            await cm.__aenter__()
+            self._lifespan_cm = cm
+        try:
+            return await super().__aenter__()
+        except BaseException:
+            if hasattr(self, "_lifespan_cm"):
+                await self._lifespan_cm.__aexit__(None, None, None)
+            raise
 
-    async def __aexit__(self, *args):
-        """Exit async context manager and cleanup test app."""
-        with contextlib.suppress(builtins.BaseException):
-            _core.destroy_test_app(self.app_id)
-        return await super().__aexit__(*args)
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Exit async context manager — runs lifespan shutdown, then cleans up test app."""
+        try:
+            if hasattr(self, "_lifespan_cm"):
+                await self._lifespan_cm.__aexit__(exc_type, exc_val, exc_tb)
+        finally:
+            with contextlib.suppress(builtins.BaseException):
+                _core.destroy_test_app(self.app_id)
+        return await super().__aexit__(exc_type, exc_val, exc_tb)

--- a/python/example/testproject/api.py
+++ b/python/example/testproject/api.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import time
+from contextlib import asynccontextmanager
 from typing import Annotated, Protocol
 
 import msgspec
@@ -33,6 +34,17 @@ from django_bolt.serializers import Serializer, field_validator
 from django_bolt.types import Request
 from django_bolt.views import APIView, ViewSet
 
+
+@asynccontextmanager
+async def lifespan(app):
+    """Run startup/shutdown logic for the application."""
+    print("Starting up — warming caches, initializing resources...")
+    app._startup_time = time.time()
+    yield
+    uptime = time.time() - app._startup_time
+    print(f"Shutting down — server was up for {uptime:.1f}s")
+
+
 # OpenAPI is enabled by default at /docs with Swagger UI
 # You can customize it by passing openapi_config:
 #
@@ -40,6 +52,7 @@ from django_bolt.views import APIView, ViewSet
 #
 # 1. Default compression (brotli with gzip fallback):
 api = BoltAPI(
+    lifespan=lifespan,
     openapi_config=OpenAPIConfig(
         title="My API",
         version="1.0.0",

--- a/python/tests/test_lifecycle_hooks.py
+++ b/python/tests/test_lifecycle_hooks.py
@@ -1,47 +1,122 @@
-import asyncio
+from contextlib import asynccontextmanager
+
 import pytest
+
 from django_bolt.api import BoltAPI
+from django_bolt.testing import TestClient
 
 
-def test_startup_hook_registered():
+def test_no_lifespan_by_default():
     api = BoltAPI()
-
-    @api.on_startup
-    def my_hook():
-        pass
-
-    assert my_hook in api._startup_hooks
+    assert api._lifespan_context is None
+    assert api._has_lifespan is False
 
 
-def test_shutdown_hook_registered():
-    api = BoltAPI()
+def test_lifespan_stored():
+    @asynccontextmanager
+    async def my_lifespan(app):
+        yield
 
-    @api.on_shutdown
-    def my_hook():
-        pass
-
-    assert my_hook in api._shutdown_hooks
+    api = BoltAPI(lifespan=my_lifespan)
+    assert api._lifespan_context is my_lifespan
+    assert api._has_lifespan is True
 
 
-def test_sync_startup_hook_runs():
-    api = BoltAPI()
+def test_lifespan_runs_on_test_client_enter_exit():
+    """Lifespan startup runs on TestClient enter, shutdown on exit."""
     called = []
 
-    @api.on_startup
-    def my_hook():
-        called.append("started")
+    @asynccontextmanager
+    async def lifespan(app):
+        called.append("startup")
+        yield
+        called.append("shutdown")
 
-    asyncio.run(api._run_lifecycle_hooks(api._startup_hooks))
-    assert called == ["started"]
+    api = BoltAPI(lifespan=lifespan)
+
+    @api.get("/health")
+    async def health():
+        return {"ok": True}
+
+    with TestClient(api) as client:
+        assert called == ["startup"]
+        response = client.get("/health")
+        assert response.status_code == 200
+
+    assert called == ["startup", "shutdown"]
 
 
-def test_async_shutdown_hook_runs():
-    api = BoltAPI()
+def test_lifespan_receives_app_instance():
+    received = []
+
+    @asynccontextmanager
+    async def lifespan(app):
+        received.append(app)
+        yield
+
+    api = BoltAPI(lifespan=lifespan)
+
+    @api.get("/ping")
+    async def ping():
+        return "pong"
+
+    with TestClient(api):
+        pass
+
+    assert received[0] is api
+
+
+def test_lifespan_shutdown_runs_on_exception():
     called = []
 
-    @api.on_shutdown
-    async def my_hook():
-        called.append("stopped")
+    @asynccontextmanager
+    async def lifespan(app):
+        called.append("startup")
+        try:
+            yield
+        finally:
+            called.append("shutdown")
 
-    asyncio.run(api._run_lifecycle_hooks(api._shutdown_hooks))
-    assert called == ["stopped"]
+    api = BoltAPI(lifespan=lifespan)
+
+    @api.get("/fail")
+    async def fail():
+        raise RuntimeError("boom")
+
+    with TestClient(api, raise_server_exceptions=False) as client:
+        client.get("/fail")
+
+    assert called == ["startup", "shutdown"]
+
+
+def test_no_lifespan_still_works():
+    """TestClient works normally when no lifespan is configured."""
+    api = BoltAPI()
+
+    @api.get("/hello")
+    async def hello():
+        return {"message": "world"}
+
+    with TestClient(api) as client:
+        response = client.get("/hello")
+        assert response.status_code == 200
+        assert response.json() == {"message": "world"}
+
+
+def test_lifespan_startup_failure_prevents_tests():
+    """If startup raises, it propagates out of TestClient.__enter__."""
+
+    @asynccontextmanager
+    async def bad_lifespan(app):
+        raise RuntimeError("startup failed")
+        yield  # noqa: RET503
+
+    api = BoltAPI(lifespan=bad_lifespan)
+
+    @api.get("/x")
+    async def x():
+        return "x"
+
+    with pytest.raises(RuntimeError, match="startup failed"):
+        with TestClient(api):
+            pass


### PR DESCRIPTION

**feat: add lifespan context manager for startup/shutdown hooks**

Replace the `on_startup`/`on_shutdown` decorator API from PR #179 with a single lifespan async context manager (Starlette pattern). Startup code runs before yield, shutdown after — cleanup is guaranteed even on crash.

- Add `lifespan` parameter to BoltAPI
- Add `serve_with_lifespan()` for running the server inside lifespan contexts
- Integrate into runbolt (startup before server, shutdown after)
- Merge lifespan contexts from multiple autodiscovered APIs
- Make TestClient and AsyncTestClient lifespan-aware (enter/exit on with block)
- Add docs, example, and 7 tests with red/green TDD verification
