### PR TITLE
feat: rewrite serializer model extraction with async support and type…

### DIFF
--- a/docs/src/getting-started/quickstart.md
+++ b/docs/src/getting-started/quickstart.md
@@ -525,7 +525,7 @@ async def list_missions(filters: Annotated[MissionFilters, Query()]) -> MissionL
 
     missions: list[MissionResponse] = []
     async for mission in queryset[:filters.limit]:
-        missions.append(MissionResponse.from_model(mission))
+        missions.append(await MissionResponse.afrom_model(mission))
 
     return MissionListResponse(missions=missions, count=len(missions))
 
@@ -534,7 +534,7 @@ async def list_missions(filters: Annotated[MissionFilters, Query()]) -> MissionL
 async def get_mission(mission_id: int) -> MissionResponse:
     try:
         mission = await Mission.objects.aget(id=mission_id)
-        return MissionResponse.from_model(mission)
+        return await MissionResponse.afrom_model(mission)
     except Mission.DoesNotExist as exc:
         raise NotFound(detail=f"Mission {mission_id} not found") from exc
 
@@ -559,8 +559,8 @@ async def add_astronaut(
 
 A few things to notice:
 
-- `from_model()` is great when you're mapping already-loaded model data into a response serializer.
-- `afrom_model()` is the async-safe option when your serializer reads related data, like `mission.name` via `field(source="mission.name")`.
+- In async handlers, `await afrom_model()` is the safest default for response serializers. It keeps working if you later add related fields.
+- `from_model()` is still great when you're mapping already-loaded model data in sync code, or when you know your async response stays flat and fully loaded.
 - Plain `list[AstronautResponse]` is enough for nested response fields. You don't need `Nested(..., many=True)` just to express a list of child serializers.
 
 ## Response types
@@ -848,7 +848,7 @@ async def list_missions(filters: Annotated[MissionFilters, Query()]) -> MissionL
 
     missions: list[MissionResponse] = []
     async for mission in queryset[:filters.limit]:
-        missions.append(MissionResponse.from_model(mission))
+        missions.append(await MissionResponse.afrom_model(mission))
     return MissionListResponse(missions=missions, count=len(missions))
 
 
@@ -856,7 +856,7 @@ async def list_missions(filters: Annotated[MissionFilters, Query()]) -> MissionL
 async def get_mission(mission_id: int) -> MissionResponse:
     try:
         mission = await Mission.objects.aget(id=mission_id)
-        return MissionResponse.from_model(mission)
+        return await MissionResponse.afrom_model(mission)
     except Mission.DoesNotExist as exc:
         raise NotFound(detail=f"Mission {mission_id} not found") from exc
 
@@ -892,7 +892,7 @@ async def update_mission(mission_id: int, data: UpdateMission) -> MissionRespons
         mission.description = data.description
 
     await mission.asave()
-    return MissionResponse.from_model(mission)
+    return await MissionResponse.afrom_model(mission)
 
 
 @api.delete("/missions/{mission_id}", status_code=204, tags=["missions"])
@@ -990,7 +990,7 @@ async def list_astronauts(mission_id: int) -> AstronautListResponse:
 
     astronauts: list[AstronautResponse] = []
     async for astronaut in Astronaut.objects.filter(mission=mission):
-        astronauts.append(AstronautResponse.from_model(astronaut))
+        astronauts.append(await AstronautResponse.afrom_model(astronaut))
     return AstronautListResponse(mission=mission.name, astronauts=astronauts)
 
 

--- a/docs/src/getting-started/quickstart.md
+++ b/docs/src/getting-started/quickstart.md
@@ -482,6 +482,8 @@ So far we've been building response dicts by hand. That's a great way to learn t
 Once the same response shapes start showing up in multiple endpoints, move them into `Serializer` classes too. That gives you reusable, typed response contracts and keeps the model-to-JSON mapping in one place.
 
 ```python
+import asyncio
+
 from django_bolt.serializers import Serializer, field
 
 
@@ -523,9 +525,11 @@ async def list_missions(filters: Annotated[MissionFilters, Query()]) -> MissionL
     if filters.status:
         queryset = queryset.filter(status=filters.status)
 
-    missions: list[MissionResponse] = []
-    async for mission in queryset[:filters.limit]:
-        missions.append(await MissionResponse.afrom_model(mission))
+    mission_tasks = [
+        MissionResponse.afrom_model(mission)
+        async for mission in queryset[:filters.limit]
+    ]
+    missions = list(await asyncio.gather(*mission_tasks))
 
     return MissionListResponse(missions=missions, count=len(missions))
 
@@ -732,6 +736,7 @@ Here's the complete `missions/api.py` file:
 ```python
 from __future__ import annotations
 
+import asyncio
 import os
 from datetime import datetime
 from typing import Annotated, Literal
@@ -846,9 +851,11 @@ async def list_missions(filters: Annotated[MissionFilters, Query()]) -> MissionL
     if filters.status:
         queryset = queryset.filter(status=filters.status)
 
-    missions: list[MissionResponse] = []
-    async for mission in queryset[:filters.limit]:
-        missions.append(await MissionResponse.afrom_model(mission))
+    mission_tasks = [
+        MissionResponse.afrom_model(mission)
+        async for mission in queryset[:filters.limit]
+    ]
+    missions = list(await asyncio.gather(*mission_tasks))
     return MissionListResponse(missions=missions, count=len(missions))
 
 
@@ -988,9 +995,11 @@ async def list_astronauts(mission_id: int) -> AstronautListResponse:
     except Mission.DoesNotExist as exc:
         raise NotFound(detail=f"Mission {mission_id} not found") from exc
 
-    astronauts: list[AstronautResponse] = []
-    async for astronaut in Astronaut.objects.filter(mission=mission):
-        astronauts.append(await AstronautResponse.afrom_model(astronaut))
+    astronaut_tasks = [
+        AstronautResponse.afrom_model(astronaut)
+        async for astronaut in Astronaut.objects.filter(mission=mission)
+    ]
+    astronauts = list(await asyncio.gather(*astronaut_tasks))
     return AstronautListResponse(mission=mission.name, astronauts=astronauts)
 
 

--- a/docs/src/getting-started/quickstart.md
+++ b/docs/src/getting-started/quickstart.md
@@ -105,6 +105,8 @@ Visit `http://localhost:8000/` in your browser:
 {"status": "operational", "message": "Mission Control Online"}
 ```
 
+If you're exploring the bundled multi-app example project in this repo instead of starting from a fresh tutorial app, the equivalent route lives at `/mission-control` because `/` is already used by the top-level example API.
+
 ## Path parameters
 
 Let's add an endpoint to get a specific mission by ID. Path parameters are defined using curly braces:
@@ -196,7 +198,7 @@ from typing import Annotated
 
 from msgspec import Meta
 
-from django_bolt.serializers import Serializer, field_validator
+from django_bolt.serializers import Serializer, field, field_validator
 
 
 class CreateMission(Serializer):
@@ -380,7 +382,7 @@ class CreateAstronaut(Serializer):
 
     @field_validator("role")
     def validate_role(cls, value):
-        valid_roles = ["Commander", "Pilot", "Mission Specialist", "Flight Engineer"]
+        valid_roles = ["Commander", "Pilot", "Mission Specialist", "Flight Engineer", "Payload Specialist"]
         if value not in valid_roles:
             raise ValueError(f"Role must be one of: {', '.join(valid_roles)}")
         return value
@@ -472,6 +474,94 @@ Test with a file:
 curl -X POST http://localhost:8000/missions/1/patch \
   -F "patch=@mission_patch.png"
 ```
+
+## Response serializers
+
+So far we've been building response dicts by hand. That's a great way to learn the basics and keeps the early examples easy to follow.
+
+Once the same response shapes start showing up in multiple endpoints, move them into `Serializer` classes too. That gives you reusable, typed response contracts and keeps the model-to-JSON mapping in one place.
+
+```python
+from django_bolt.serializers import Serializer, field
+
+
+class MissionResponse(Serializer):
+    id: int
+    name: str
+    status: str
+    launch_date: datetime | None = None
+    description: str = ""
+
+
+class MissionListResponse(Serializer):
+    missions: list[MissionResponse]
+    count: int
+
+
+class AstronautResponse(Serializer):
+    id: int
+    name: str
+    role: str
+    mission_id: int
+
+
+class AstronautListResponse(Serializer):
+    mission: str
+    astronauts: list[AstronautResponse]
+
+
+class AstronautCreatedResponse(Serializer):
+    id: int
+    name: str
+    role: str
+    mission: str = field(source="mission.name")
+
+
+@api.get("/missions")
+async def list_missions(filters: Annotated[MissionFilters, Query()]) -> MissionListResponse:
+    queryset = Mission.objects.all()
+    if filters.status:
+        queryset = queryset.filter(status=filters.status)
+
+    missions: list[MissionResponse] = []
+    async for mission in queryset[:filters.limit]:
+        missions.append(MissionResponse.from_model(mission))
+
+    return MissionListResponse(missions=missions, count=len(missions))
+
+
+@api.get("/missions/{mission_id}")
+async def get_mission(mission_id: int) -> MissionResponse:
+    try:
+        mission = await Mission.objects.aget(id=mission_id)
+        return MissionResponse.from_model(mission)
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
+
+
+@api.post("/missions/{mission_id}/astronauts")
+async def add_astronaut(
+    mission_id: int,
+    data: Annotated[CreateAstronaut, Form()],
+) -> AstronautCreatedResponse:
+    try:
+        mission = await Mission.objects.aget(id=mission_id)
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
+
+    astronaut = await Astronaut.objects.acreate(
+        name=data.name,
+        role=data.role,
+        mission=mission,
+    )
+    return await AstronautCreatedResponse.afrom_model(astronaut)
+```
+
+A few things to notice:
+
+- `from_model()` is great when you're mapping already-loaded model data into a response serializer.
+- `afrom_model()` is the async-safe option when your serializer reads related data, like `mission.name` via `field(source="mission.name")`.
+- Plain `list[AstronautResponse]` is enough for nested response fields. You don't need `Nested(..., many=True)` just to express a list of child serializers.
 
 ## Response types
 
@@ -653,7 +743,7 @@ from django_bolt.exceptions import HTTPException, NotFound
 from django_bolt.openapi import OpenAPIConfig
 from django_bolt.param_functions import File, Form, Header, Query
 from django_bolt.responses import HTML, PlainText, Redirect
-from django_bolt.serializers import Serializer, field_validator
+from django_bolt.serializers import Serializer, field, field_validator
 from django_bolt.shortcuts import render
 
 from missions.models import Astronaut, Mission
@@ -667,7 +757,7 @@ api = BoltAPI(
 )
 
 
-# Schemas
+# Input and output schemas
 class CreateMission(Serializer):
     name: Annotated[str, Meta(min_length=1, max_length=100)]
     description: Annotated[str, Meta(max_length=500)] = ""
@@ -686,6 +776,26 @@ class UpdateMission(Serializer):
     description: Annotated[str, Meta(max_length=500)] | None = None
 
 
+class MissionResponse(Serializer):
+    id: int
+    name: str
+    status: str
+    launch_date: datetime | None = None
+    description: str = ""
+
+
+class MissionListResponse(Serializer):
+    missions: list[MissionResponse]
+    count: int
+
+
+class MissionCreatedResponse(Serializer):
+    id: int
+    name: str
+    status: str
+    message: str
+
+
 # Query parameter model for filtering missions
 class MissionFilters(Serializer):
     status: Literal["planned", "active", "completed", "aborted"] | None = None
@@ -699,10 +809,29 @@ class CreateAstronaut(Serializer):
 
     @field_validator("role")
     def validate_role(cls, value):
-        valid_roles = ["Commander", "Pilot", "Mission Specialist", "Flight Engineer"]
+        valid_roles = ["Commander", "Pilot", "Mission Specialist", "Flight Engineer", "Payload Specialist"]
         if value not in valid_roles:
             raise ValueError(f"Role must be one of: {', '.join(valid_roles)}")
         return value
+
+
+class AstronautResponse(Serializer):
+    id: int
+    name: str
+    role: str
+    mission_id: int
+
+
+class AstronautCreatedResponse(Serializer):
+    id: int
+    name: str
+    role: str
+    mission: str = field(source="mission.name")
+
+
+class AstronautListResponse(Serializer):
+    mission: str
+    astronauts: list[AstronautResponse]
 
 
 # Endpoints
@@ -712,57 +841,48 @@ async def mission_control_status():
 
 
 @api.get("/missions", tags=["missions"])
-async def list_missions(filters: Annotated[MissionFilters, Query()]):
+async def list_missions(filters: Annotated[MissionFilters, Query()]) -> MissionListResponse:
     queryset = Mission.objects.all()
     if filters.status:
         queryset = queryset.filter(status=filters.status)
 
-    missions = []
+    missions: list[MissionResponse] = []
     async for mission in queryset[:filters.limit]:
-        missions.append({
-            "id": mission.id,
-            "name": mission.name,
-            "status": mission.status,
-        })
-    return {"missions": missions, "count": len(missions)}
+        missions.append(MissionResponse.from_model(mission))
+    return MissionListResponse(missions=missions, count=len(missions))
 
 
 @api.get("/missions/{mission_id}", tags=["missions"])
-async def get_mission(mission_id: int):
+async def get_mission(mission_id: int) -> MissionResponse:
     try:
         mission = await Mission.objects.aget(id=mission_id)
-        return {
-            "id": mission.id,
-            "name": mission.name,
-            "status": mission.status,
-            "launch_date": str(mission.launch_date) if mission.launch_date else None,
-            "description": mission.description,
-        }
-    except Mission.DoesNotExist:
-        raise NotFound(detail=f"Mission {mission_id} not found")
+        return MissionResponse.from_model(mission)
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
 
 
 @api.post("/missions", tags=["missions"])
-async def create_mission(mission: CreateMission):
+async def create_mission(mission: CreateMission) -> MissionCreatedResponse:
     new_mission = await Mission.objects.acreate(
         name=mission.name,
         description=mission.description,
         launch_date=mission.launch_date,
         status="planned",
     )
-    return {
-        "id": new_mission.id,
-        "name": new_mission.name,
-        "status": new_mission.status,
-    }
+    return MissionCreatedResponse(
+        id=new_mission.id,
+        name=new_mission.name,
+        status=new_mission.status,
+        message="Mission created successfully",
+    )
 
 
 @api.put("/missions/{mission_id}", tags=["missions"])
-async def update_mission(mission_id: int, data: UpdateMission):
+async def update_mission(mission_id: int, data: UpdateMission) -> MissionResponse:
     try:
         mission = await Mission.objects.aget(id=mission_id)
-    except Mission.DoesNotExist:
-        raise NotFound(detail=f"Mission {mission_id} not found")
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
 
     if data.name is not None:
         mission.name = data.name
@@ -772,15 +892,15 @@ async def update_mission(mission_id: int, data: UpdateMission):
         mission.description = data.description
 
     await mission.asave()
-    return {"id": mission.id, "name": mission.name, "status": mission.status}
+    return MissionResponse.from_model(mission)
 
 
 @api.delete("/missions/{mission_id}", status_code=204, tags=["missions"])
 async def delete_mission(mission_id: int):
     try:
         mission = await Mission.objects.aget(id=mission_id)
-    except Mission.DoesNotExist:
-        raise NotFound(detail=f"Mission {mission_id} not found")
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
 
     await mission.adelete()
 
@@ -795,8 +915,8 @@ async def get_classified_info(
 
     try:
         mission = await Mission.objects.aget(id=mission_id)
-    except Mission.DoesNotExist:
-        raise NotFound(detail=f"Mission {mission_id} not found")
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
 
     return {
         "mission": mission.name,
@@ -808,8 +928,8 @@ async def get_classified_info(
 async def get_mission_log(mission_id: int):
     try:
         mission = await Mission.objects.aget(id=mission_id)
-    except Mission.DoesNotExist:
-        raise NotFound(detail=f"Mission {mission_id} not found")
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
 
     log = f"=== MISSION LOG: {mission.name} ===\nStatus: {mission.status.upper()}"
     return PlainText(log)
@@ -822,8 +942,8 @@ async def upload_mission_patch(
 ):
     try:
         mission = await Mission.objects.aget(id=mission_id)
-    except Mission.DoesNotExist:
-        raise NotFound(detail=f"Mission {mission_id} not found")
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
 
     if not patch:
         raise HTTPException(status_code=400, detail="No file uploaded")
@@ -847,40 +967,31 @@ async def upload_mission_patch(
 async def add_astronaut(
     mission_id: int,
     data: Annotated[CreateAstronaut, Form()],
-):
+) -> AstronautCreatedResponse:
     try:
         mission = await Mission.objects.aget(id=mission_id)
-    except Mission.DoesNotExist:
-        raise NotFound(detail=f"Mission {mission_id} not found")
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
 
     astronaut = await Astronaut.objects.acreate(
         name=data.name,
         role=data.role,
         mission=mission,
     )
-    return {
-        "id": astronaut.id,
-        "name": astronaut.name,
-        "role": astronaut.role,
-        "mission": mission.name,
-    }
+    return await AstronautCreatedResponse.afrom_model(astronaut)
 
 
 @api.get("/missions/{mission_id}/astronauts", tags=["astronauts"])
-async def list_astronauts(mission_id: int):
+async def list_astronauts(mission_id: int) -> AstronautListResponse:
     try:
         mission = await Mission.objects.aget(id=mission_id)
-    except Mission.DoesNotExist:
-        raise NotFound(detail=f"Mission {mission_id} not found")
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
 
-    astronauts = []
+    astronauts: list[AstronautResponse] = []
     async for astronaut in Astronaut.objects.filter(mission=mission):
-        astronauts.append({
-            "id": astronaut.id,
-            "name": astronaut.name,
-            "role": astronaut.role,
-        })
-    return {"mission": mission.name, "astronauts": astronauts}
+        astronauts.append(AstronautResponse.from_model(astronaut))
+    return AstronautListResponse(mission=mission.name, astronauts=astronauts)
 
 
 @api.get("/status-page", tags=["status"])

--- a/docs/src/topics/class-based-views.md
+++ b/docs/src/topics/class-based-views.md
@@ -192,7 +192,7 @@ Get a single object by primary key:
 ```python
 async def retrieve(self, request, pk: int):
     article = await self.get_object(pk)  # Raises 404 if not found
-    return ArticleSchema.from_model(article)
+    return await ArticleSchema.afrom_model(article)
 ```
 
 ### Custom lookup field

--- a/docs/src/topics/serializers.md
+++ b/docs/src/topics/serializers.md
@@ -611,7 +611,7 @@ class BlogPostSerializer(Serializer):
 
 ### From model to serializer
 
-Use `from_model()` to create serializer instances from Django models:
+Use `from_model()` to create serializer instances from Django models when you already have the data you need loaded:
 
 ```python
 class ArticleSerializer(Serializer):
@@ -619,10 +619,23 @@ class ArticleSerializer(Serializer):
     title: str
     content: str
 
-# From Django model
-article = await Article.objects.aget(id=1)
+# From a Django model without extra relation loading
+article = Article.objects.get(id=1)
 serializer = ArticleSerializer.from_model(article)
 ```
+
+Use `afrom_model()` in async handlers when a serializer may need to read unloaded relations:
+
+```python
+article = await Article.objects.aget(id=1)
+serializer = await ArticleSerializer.afrom_model(article)
+```
+
+Quick rule of thumb:
+
+- `from_model()` is sync and non-querying
+- `afrom_model()` is async-safe and may lazy-load missing relations
+- in async handlers, default to `await afrom_model(...)` unless you intentionally want strict non-querying behavior
 
 ### Relation loading with from_model()
 
@@ -750,13 +763,13 @@ UserDetailSerializer = UserSerializer.fields("detail")
 async def list_users() -> list[UserListSerializer]:
     users = []
     async for user in User.objects.all()[:20]:
-        users.append(UserListSerializer.from_model(user))
+        users.append(await UserListSerializer.afrom_model(user))
     return users
 
 @api.get("/users/{user_id}")
 async def get_user(user_id: int) -> UserDetailSerializer:
     user = await User.objects.aget(id=user_id)
-    return UserDetailSerializer.from_model(user)
+    return await UserDetailSerializer.afrom_model(user)
 ```
 
 ## Serializer vs raw msgspec.Struct

--- a/docs/src/topics/serializers.md
+++ b/docs/src/topics/serializers.md
@@ -578,9 +578,9 @@ tags = [TagSerializer(id=1, name="python"), TagSerializer(id=2, name="django")]
 post = PostSerializer(id=1, title="Hello World", tags=tags)
 ```
 
-### Using Nested marker for Django models
+### Nested serializer fields
 
-The `Nested` marker provides explicit control over nested serialization:
+Nested fields are inferred directly from the type annotation:
 
 ```python
 from typing import Annotated
@@ -594,8 +594,17 @@ class AuthorSerializer(Serializer):
 class BlogPostSerializer(Serializer):
     id: int
     title: str
-    author: Annotated[AuthorSerializer, Nested(AuthorSerializer)]
-    tags: Annotated[list[TagSerializer], Nested(TagSerializer, many=True)]
+    author: AuthorSerializer
+    tags: list[TagSerializer]
+```
+
+You only need `Nested(...)` when you want extra nested-field metadata, such as a custom list limit:
+
+```python
+class BlogPostSerializer(Serializer):
+    id: int
+    title: str
+    tags: Annotated[list[TagSerializer], Nested(max_items=200)]
 ```
 
 ## Django model integration
@@ -615,18 +624,39 @@ article = await Article.objects.aget(id=1)
 serializer = ArticleSerializer.from_model(article)
 ```
 
-### With select_related
+### Relation loading with from_model()
 
-When using `from_model()` with ForeignKey relationships, use `select_related`:
+`from_model()` is non-querying. It only serializes relations that are already loaded on the model instance.
+
+Use `select_related()` for single relations and `prefetch_related()` for reverse or many relations:
 
 ```python
-# Without select_related - may cause N+1 queries
-post = await BlogPost.objects.aget(id=1)
-serializer = BlogPostSerializer.from_model(post)  # author might be just an ID
+# Sync from_model() expects loaded relations
+post = await BlogPost.objects.select_related("author").prefetch_related("tags").aget(id=1)
+serializer = BlogPostSerializer.from_model(post)
+```
 
-# With select_related - nested object included
-post = await BlogPost.objects.select_related("author").aget(id=1)
-serializer = BlogPostSerializer.from_model(post)  # author is full object
+If a nested relation is unloaded:
+
+- fields with defaults like `[]` or `None` keep their default value
+- required nested fields raise `SerializationError` with a preload hint
+
+For async handlers where relations may need to be loaded lazily, use `afrom_model()`:
+
+```python
+post = await BlogPost.objects.aget(id=1)
+serializer = await BlogPostSerializer.afrom_model(post)
+```
+
+This also applies to reverse relations:
+
+```python
+class UserSerializer(Serializer):
+    id: int
+    addresses: list[AddressSerializer] = []
+
+user = await User.objects.prefetch_related("addresses").aget(id=1)
+serializer = UserSerializer.from_model(user)
 ```
 
 ### Bulk serialization

--- a/python/django_bolt/exceptions.py
+++ b/python/django_bolt/exceptions.py
@@ -100,6 +100,10 @@ class ValidationException(BoltException, ValueError):
         return self._errors
 
 
+class SerializationError(BoltException, ValueError):
+    """Server-side serialization misuse or unsupported serializer state."""
+
+
 class RequestValidationError(ValidationException):
     """Request data validation error.
 

--- a/python/django_bolt/pagination.py
+++ b/python/django_bolt/pagination.py
@@ -194,7 +194,7 @@ class PaginationBase(ABC):
         else:
             return len(queryset)
 
-    def _serialize_items(self, items: list[Any]) -> list[dict]:
+    async def _serialize_items(self, items: list[Any]) -> list[dict]:
         """
         Serialize items using efficient batch serialization.
 
@@ -228,7 +228,10 @@ class PaginationBase(ABC):
 
         # Bolt Serializer - use from_model + dump_many for efficiency
         if getattr(self.serializer_class, "__is_bolt_serializer__", False):
-            serializer_instances = [self.serializer_class.from_model(item) for item in items]
+            if hasattr(self.serializer_class, "afrom_model"):
+                serializer_instances = [await self.serializer_class.afrom_model(item) for item in items]
+            else:
+                serializer_instances = [self.serializer_class.from_model(item) for item in items]
             return self.serializer_class.dump_many(serializer_instances)
 
         # Plain msgspec.Struct - extract fields from model instances
@@ -397,7 +400,7 @@ class PageNumberPagination(PaginationBase):
         raw_items = await self._evaluate_queryset_slice(queryset[offset : offset + page_size])
 
         # Serialize items using efficient batch serialization
-        items = self._serialize_items(raw_items)
+        items = await self._serialize_items(raw_items)
 
         # Build response
         return PaginatedResponse(
@@ -485,7 +488,7 @@ class LimitOffsetPagination(PaginationBase):
         raw_items = await self._evaluate_queryset_slice(queryset[offset : offset + limit])
 
         # Serialize items using efficient batch serialization
-        items = self._serialize_items(raw_items)
+        items = await self._serialize_items(raw_items)
 
         # Calculate page info
         has_next = (offset + limit) < total
@@ -627,7 +630,7 @@ class CursorPagination(PaginationBase):
                 next_cursor = self._encode_cursor(last_value)
 
         # Serialize items using efficient batch serialization
-        items = self._serialize_items(raw_items)
+        items = await self._serialize_items(raw_items)
 
         return PaginatedResponse(
             items=items,

--- a/python/django_bolt/pagination.py
+++ b/python/django_bolt/pagination.py
@@ -21,6 +21,7 @@ Example (Class-Based View):
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import inspect
 from abc import ABC, abstractmethod
@@ -228,10 +229,9 @@ class PaginationBase(ABC):
 
         # Bolt Serializer - use from_model + dump_many for efficiency
         if getattr(self.serializer_class, "__is_bolt_serializer__", False):
-            if hasattr(self.serializer_class, "afrom_model"):
-                serializer_instances = [await self.serializer_class.afrom_model(item) for item in items]
-            else:
-                serializer_instances = [self.serializer_class.from_model(item) for item in items]
+            serializer_instances = list(
+                await asyncio.gather(*(self.serializer_class.afrom_model(item) for item in items))
+            )
             return self.serializer_class.dump_many(serializer_instances)
 
         # Plain msgspec.Struct - extract fields from model instances

--- a/python/django_bolt/serializers/base.py
+++ b/python/django_bolt/serializers/base.py
@@ -63,6 +63,25 @@ class _ModelFieldSpec:
 
 
 @dataclass(frozen=True)
+class _DumpFieldSpec:
+    """Cached dump metadata for one struct field."""
+
+    field_name: str
+    output_key: str
+    alias: str | None
+    nested: _ModelOutputNested | None
+    default_value: Any = _MISSING
+
+
+@dataclass(frozen=True)
+class _ComputedDumpSpec:
+    """Cached dump metadata for one computed field."""
+
+    field_name: str
+    method_name: str
+
+
+@dataclass(frozen=True)
 class _DjangoRelationInfo:
     """Lightweight cached description of a Django relation accessor."""
 
@@ -132,6 +151,13 @@ def _build_rename_map(cls: type[msgspec.Struct]) -> dict[str, str]:
         # Forward reference not resolvable yet
         pass
     return rename_map
+
+
+def _resolve_dump_default(default_value: Any) -> Any:
+    """Resolve msgspec/_FieldMarker defaults into their runtime value."""
+    if isinstance(default_value, _FieldMarker) and default_value.config.has_default():
+        return default_value.config.get_default()
+    return default_value
 
 
 def _get_model_output_nested(field_type: Any) -> _ModelOutputNested | None:
@@ -280,6 +306,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
     __model_validators__: ClassVar[list[Any]] = []
     # Pre-computed tuple of (field_name, validators_tuple) for faster iteration
     __field_validators_tuple__: ClassVar[tuple[tuple[str, tuple[Any, ...]], ...]] = ()
+    _computed_dump_specs: ClassVar[tuple[_ComputedDumpSpec, ...]] = ()
 
     # Cached type hints and metadata (populated by __init_subclass__)
     __cached_type_hints__: ClassVar[dict[str, Any]] = {}
@@ -312,6 +339,14 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
     __default_values_map__: ClassVar[dict[str, Any] | None] = None
     # Fast-path flag for dump: True if dump can use simple/fast path
     __dump_fast_path__: ClassVar[bool] = True
+    _dump_field_specs: ClassVar[tuple[_DumpFieldSpec, ...]] = ()
+    _dump_field_spec_cache: ClassVar[
+        dict[tuple[frozenset[str] | None, frozenset[str] | None], tuple[_DumpFieldSpec, ...]]
+    ] = {}
+    _computed_dump_spec_cache: ClassVar[
+        dict[tuple[frozenset[str] | None, frozenset[str] | None], tuple[_ComputedDumpSpec, ...]]
+    ] = {}
+    _serializer_view_cache: ClassVar[dict[tuple[frozenset[str] | None, frozenset[str] | None], Any]] = {}
     # Track if any field is a Serializer type (requires recursive dump)
     __has_serializer_fields__: ClassVar[bool] = False
     # Rename mapping: Python field name -> encoded name (e.g., "user_name" -> "userName")
@@ -327,11 +362,21 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
         cls.__field_validators__ = collect_field_validators(cls)
         cls.__model_validators__ = collect_model_validators(cls)
         cls.__computed_fields__ = collect_computed_fields(cls)
+        cls._computed_dump_specs = tuple(
+            _ComputedDumpSpec(field_name=field_name, method_name=config.method_name)
+            for field_name, config in cls.__computed_fields__.items()
+        )
 
         # Pre-compute validators as tuple for faster iteration (no dict overhead)
         cls.__field_validators_tuple__ = tuple(
             (field_name, tuple(validators)) for field_name, validators in cls.__field_validators__.items()
         )
+
+        cls.__default_values_map__ = None
+        cls._dump_field_specs = ()
+        cls._dump_field_spec_cache = {}
+        cls._computed_dump_spec_cache = {}
+        cls._serializer_view_cache = {}
 
         # Collect configuration from Meta class (read_only, write_only, field_sets)
         # Note: _FieldMarker processing is deferred to _lazy_collect_field_configs
@@ -492,10 +537,12 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
         if cls.__default_values_map__ is not None:
             return
 
+        cls._ensure_dump_ready()
+
         default_values: dict[str, Any] = {}
-        # Use helper to iterate over (field_name, default_value) pairs
-        for field_name, default_val in _iter_field_defaults(cls):
-            default_values[field_name] = default_val
+        for spec in cls._dump_field_specs:
+            if spec.default_value is not _MISSING:
+                default_values[spec.field_name] = spec.default_value
 
         cls.__default_values_map__ = default_values
 
@@ -633,6 +680,11 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
             and not cls.__has_serializer_fields__
             and not any(cfg.exclude for cfg in cls.__field_configs__.values())
         )
+        cls._dump_field_specs = cls._build_dump_field_specs()
+        cls._dump_field_spec_cache.clear()
+        cls._computed_dump_spec_cache.clear()
+        cls._serializer_view_cache.clear()
+        cls.__default_values_map__ = None
 
         # Mark as collected so we don't run again
         cls.__field_configs_collected__ = True
@@ -921,6 +973,108 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
         """Ensure lazy field metadata has been collected before model extraction."""
         if not cls.__field_configs_collected__:
             cls._lazy_collect_field_configs()
+
+    @classmethod
+    def _ensure_dump_ready(cls) -> None:
+        """Ensure lazy field metadata has been collected before dumping/views."""
+        if not cls.__field_configs_collected__:
+            cls._lazy_collect_field_configs()
+
+    @classmethod
+    def _build_dump_field_specs(cls) -> tuple[_DumpFieldSpec, ...]:
+        """Pre-compute dump metadata for struct fields."""
+        default_values = {
+            field_name: _resolve_dump_default(default_value) for field_name, default_value in _iter_field_defaults(cls)
+        }
+        nested_fields = cls.__nested_fields__
+        rename_map = cls.__rename_map__
+        specs: list[_DumpFieldSpec] = []
+
+        for field_name in cls.__struct_fields__:
+            if field_name in cls.__write_only_fields__:
+                continue
+
+            field_config = cls.__field_configs__.get(field_name)
+            if field_config and field_config.exclude:
+                continue
+
+            specs.append(
+                _DumpFieldSpec(
+                    field_name=field_name,
+                    output_key=rename_map.get(field_name, field_name),
+                    alias=field_config.alias if field_config else None,
+                    nested=_get_model_output_nested(cls.__cached_type_hints__.get(field_name, Any))
+                    if field_name in nested_fields
+                    else None,
+                    default_value=default_values.get(field_name, _MISSING),
+                )
+            )
+
+        return tuple(specs)
+
+    @classmethod
+    def _get_dump_field_specs(
+        cls,
+        *,
+        include_fields: frozenset[str] | None = None,
+        exclude_fields: frozenset[str] | None = None,
+    ) -> tuple[_DumpFieldSpec, ...]:
+        """Return cached dump field specs for the requested field filter."""
+        cls._ensure_dump_ready()
+        if include_fields is None and exclude_fields is None:
+            return cls._dump_field_specs
+
+        cache_key = (include_fields, exclude_fields)
+        specs = cls._dump_field_spec_cache.get(cache_key)
+        if specs is None:
+            specs = tuple(
+                spec
+                for spec in cls._dump_field_specs
+                if (include_fields is None or spec.field_name in include_fields)
+                and (exclude_fields is None or spec.field_name not in exclude_fields)
+            )
+            cls._dump_field_spec_cache[cache_key] = specs
+        return specs
+
+    @classmethod
+    def _get_computed_dump_specs(
+        cls,
+        *,
+        include_fields: frozenset[str] | None = None,
+        exclude_fields: frozenset[str] | None = None,
+    ) -> tuple[_ComputedDumpSpec, ...]:
+        """Return cached computed-field specs for the requested field filter."""
+        cls._ensure_dump_ready()
+        if include_fields is None and exclude_fields is None:
+            return cls._computed_dump_specs
+
+        cache_key = (include_fields, exclude_fields)
+        specs = cls._computed_dump_spec_cache.get(cache_key)
+        if specs is None:
+            specs = tuple(
+                spec
+                for spec in cls._computed_dump_specs
+                if (include_fields is None or spec.field_name in include_fields)
+                and (exclude_fields is None or spec.field_name not in exclude_fields)
+            )
+            cls._computed_dump_spec_cache[cache_key] = specs
+        return specs
+
+    @classmethod
+    def _get_cached_view(
+        cls: type[T],
+        *,
+        include_fields: frozenset[str] | None = None,
+        exclude_fields: frozenset[str] | None = None,
+    ) -> SerializerView[T]:
+        """Return a cached SerializerView for a given field-selection pair."""
+        cls._ensure_dump_ready()
+        cache_key = (include_fields, exclude_fields)
+        cached = cls._serializer_view_cache.get(cache_key)
+        if cached is None:
+            cached = SerializerView(cls, include_fields=include_fields, exclude_fields=exclude_fields)
+            cls._serializer_view_cache[cache_key] = cached
+        return cast("SerializerView[T]", cached)
 
     @classmethod
     def _relation_loading_hint(cls, relation: _DjangoRelationInfo) -> str:
@@ -1702,7 +1856,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
             # Chain with dump_many for lists
             UserSerializer.only("id", "email").dump_many(users)
         """
-        return SerializerView(cls, include_fields=frozenset(fields))
+        return cls._get_cached_view(include_fields=frozenset(fields))
 
     @classmethod
     def exclude(cls: type[T], *fields: str) -> SerializerView[T]:
@@ -1725,7 +1879,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
             # Chain with dump_many for lists
             UserSerializer.exclude("internal_notes").dump_many(users)
         """
-        return SerializerView(cls, exclude_fields=frozenset(fields))
+        return cls._get_cached_view(exclude_fields=frozenset(fields))
 
     @classmethod
     def use(cls: type[T], field_set: str) -> SerializerView[T]:
@@ -1768,7 +1922,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
                 f"Field set '{field_set}' not found in {cls.__name__}.Config.field_sets. "
                 f"Available field sets: {available}"
             )
-        return SerializerView(cls, include_fields=frozenset(field_sets[field_set]))
+        return cls._get_cached_view(include_fields=frozenset(field_sets[field_set]))
 
     # -------------------------------------------------------------------------
     # Dump Methods (Serialization)
@@ -1804,8 +1958,9 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
         """
         # FAST PATH: use msgspec native methods (significantly faster than Python iteration)
         cls = self.__class__
-        self._ensure_dumpable_orm_state()
+        cls._ensure_dump_ready()
         if cls.__dump_fast_path__ and not exclude_none and not exclude_defaults and not exclude_unset and not by_alias:
+            self._ensure_dumpable_orm_state()
             if cls.__has_rename__:
                 return msgspec.to_builtins(self)
             return msgspec_structs.asdict(self)
@@ -1829,113 +1984,83 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
         by_alias: bool = False,
         include_fields: frozenset[str] | None = None,
         exclude_fields: frozenset[str] | None = None,
+        field_specs: tuple[_DumpFieldSpec, ...] | None = None,
+        computed_specs: tuple[_ComputedDumpSpec, ...] | None = None,
     ) -> dict[str, Any]:
         """Internal implementation of dump with field filtering."""
-        # Cache class attributes locally for faster access in the loop
         cls = self.__class__
-        struct_fields = cls.__struct_fields__
-        write_only_fields = cls.__write_only_fields__
-        field_configs = cls.__field_configs__
-        has_computed = cls.__has_computed_fields__
-        computed_fields = cls.__computed_fields__
-        rename_map = cls.__rename_map__
-
-        # Use pre-computed default values map (computed once per class, not per call)
-        default_values = None
-        if exclude_defaults:
-            # Lazy cache the default values map on first use (None = not cached)
-            if cls.__default_values_map__ is None:
-                cls._cache_default_values_map()
-            default_values = cls.__default_values_map__
+        cls._ensure_dump_ready()
+        field_specs = (
+            field_specs
+            if field_specs is not None
+            else cls._get_dump_field_specs(include_fields=include_fields, exclude_fields=exclude_fields)
+        )
+        computed_specs = (
+            computed_specs
+            if computed_specs is not None
+            else cls._get_computed_dump_specs(include_fields=include_fields, exclude_fields=exclude_fields)
+        )
 
         result: dict[str, Any] = {}
 
         # Local reference to getattr for micro-optimization
         _getattr = getattr
 
-        for field_name in struct_fields:
-            # Skip write_only fields (they shouldn't appear in output)
-            if field_name in write_only_fields:
-                continue
-
-            # Apply include/exclude filtering
-            if include_fields is not None and field_name not in include_fields:
-                continue
-            if exclude_fields is not None and field_name in exclude_fields:
-                continue
-
-            # Check field config for exclusion
-            field_config = field_configs.get(field_name)
-            if field_config and field_config.exclude:
-                continue
-
-            value = _getattr(self, field_name)
+        for spec in field_specs:
+            value = _getattr(self, spec.field_name)
 
             # Skip None values if exclude_none
             if exclude_none and value is None:
                 continue
 
-            # Skip default values if exclude_defaults (using pre-computed map)
-            if default_values is not None and field_name in default_values and value == default_values[field_name]:
+            if exclude_defaults and spec.default_value is not _MISSING and value == spec.default_value:
                 continue
 
             # Determine output key: by_alias takes precedence, then rename_map
-            if by_alias and field_config and field_config.alias:
-                output_key = field_config.alias
-            else:
-                # rename_map.get() returns field_name if not in map (works for empty dict too)
-                output_key = rename_map.get(field_name, field_name)
+            output_key = spec.alias if by_alias and spec.alias else spec.output_key
 
             if isinstance(value, (BaseManager, QuerySet)):
                 raise SerializationError(
-                    f"{cls.__name__}.{field_name} contains {value.__class__.__name__}. "
+                    f"{cls.__name__}.{spec.field_name} contains {value.__class__.__name__}. "
                     "Serialize Django relations with from_model()/afrom_model() before dump()."
                 )
 
-            # Handle nested serializers
-            if isinstance(value, Serializer):
-                result[output_key] = value.dump(
-                    exclude_none=exclude_none,
-                    exclude_unset=exclude_unset,
-                    exclude_defaults=exclude_defaults,
-                    by_alias=by_alias,
-                )
-            elif isinstance(value, list):
-                # Check if it's a list of serializers
-                if value and isinstance(value[0], Serializer):
-                    result[output_key] = [
-                        item.dump(
-                            exclude_none=exclude_none,
-                            exclude_unset=exclude_unset,
-                            exclude_defaults=exclude_defaults,
-                            by_alias=by_alias,
-                        )
-                        for item in value
-                    ]
+            if spec.nested is not None:
+                if spec.nested.many:
+                    if isinstance(value, list) and value and isinstance(value[0], Serializer):
+                        result[output_key] = [
+                            item.dump(
+                                exclude_none=exclude_none,
+                                exclude_unset=exclude_unset,
+                                exclude_defaults=exclude_defaults,
+                                by_alias=by_alias,
+                            )
+                            for item in value
+                        ]
+                    else:
+                        result[output_key] = value
+                elif isinstance(value, Serializer):
+                    result[output_key] = value.dump(
+                        exclude_none=exclude_none,
+                        exclude_unset=exclude_unset,
+                        exclude_defaults=exclude_defaults,
+                        by_alias=by_alias,
+                    )
                 else:
                     result[output_key] = value
             else:
                 result[output_key] = value
 
         # Add computed fields
-        if has_computed:
-            for field_name, config in computed_fields.items():
-                # Apply include/exclude filtering to computed fields too
-                if include_fields is not None and field_name not in include_fields:
+        for spec in computed_specs:
+            method = _getattr(self, spec.method_name, None)
+            if method is not None:
+                value = method()
+
+                if exclude_none and value is None:
                     continue
-                if exclude_fields is not None and field_name in exclude_fields:
-                    continue
 
-                # Get the method and call it
-                method = _getattr(self, config.method_name, None)
-                if method is not None:
-                    value = method()
-
-                    # Skip None values if exclude_none
-                    if exclude_none and value is None:
-                        continue
-
-                    result[field_name] = value
+                result[spec.field_name] = value
 
         return result
 
@@ -2007,6 +2132,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
             users = [UserSerializer.from_model(u) for u in User.objects.all()]
             UserSerializer.dump_many(users)
         """
+        cls._ensure_dump_ready()
         instances_list = list(instances)
 
         # FAST PATH: use msgspec native methods (significantly faster than Python iteration)
@@ -2117,6 +2243,8 @@ class SerializerView(Iterable[T]):
         view.from_model(user_instance)
     """
 
+    __slots__ = ("_serializer_class", "_include_fields", "_exclude_fields", "_field_specs", "_computed_specs")
+
     def __init__(
         self,
         serializer_class: type[T],
@@ -2127,6 +2255,14 @@ class SerializerView(Iterable[T]):
         self._serializer_class = serializer_class
         self._include_fields = include_fields
         self._exclude_fields = exclude_fields
+        self._field_specs = serializer_class._get_dump_field_specs(
+            include_fields=include_fields,
+            exclude_fields=exclude_fields,
+        )
+        self._computed_specs = serializer_class._get_computed_dump_specs(
+            include_fields=include_fields,
+            exclude_fields=exclude_fields,
+        )
 
     def __iter__(self):
         """Allow iteration (returns empty iterator - use dump_many instead)."""
@@ -2138,8 +2274,7 @@ class SerializerView(Iterable[T]):
         if self._include_fields is not None:
             # Intersection with existing include
             new_include = self._include_fields & new_include
-        return SerializerView(
-            self._serializer_class,
+        return self._serializer_class._get_cached_view(
             include_fields=new_include,
             exclude_fields=self._exclude_fields,
         )
@@ -2149,8 +2284,7 @@ class SerializerView(Iterable[T]):
         new_exclude = frozenset(fields)
         if self._exclude_fields is not None:
             new_exclude = self._exclude_fields | new_exclude
-        return SerializerView(
-            self._serializer_class,
+        return self._serializer_class._get_cached_view(
             include_fields=self._include_fields,
             exclude_fields=new_exclude,
         )
@@ -2192,6 +2326,8 @@ class SerializerView(Iterable[T]):
             by_alias=by_alias,
             include_fields=self._include_fields,
             exclude_fields=self._exclude_fields,
+            field_specs=self._field_specs,
+            computed_specs=self._computed_specs,
         )
 
     def dump_many(

--- a/python/django_bolt/serializers/base.py
+++ b/python/django_bolt/serializers/base.py
@@ -29,6 +29,7 @@ from typing import (
 from weakref import WeakKeyDictionary
 
 import msgspec
+from django.core.exceptions import FieldDoesNotExist
 from django.db.models import Model as DjangoModel
 from django.db.models.manager import BaseManager
 from django.db.models.query import QuerySet
@@ -197,7 +198,22 @@ def _get_model_output_nested(field_type: Any) -> _ModelOutputNested | None:
 
 def _field_type_may_hold_orm_state(field_type: Any) -> bool:
     """Return True when a field type could plausibly hold a manager/queryset at runtime."""
-    if field_type in {Any, object, BaseManager, QuerySet, DjangoModel}:
+    if field_type in {
+        Any,
+        object,
+        BaseManager,
+        QuerySet,
+        DjangoModel,
+        list,
+        tuple,
+        set,
+        frozenset,
+        dict,
+        Collection,
+        Iterable,
+        Mapping,
+        Sequence,
+    }:
         return True
 
     origin = get_origin(field_type)
@@ -207,15 +223,16 @@ def _field_type_may_hold_orm_state(field_type: Any) -> bool:
     if origin is Literal:
         return False
 
-    if origin in {list, tuple, set, frozenset, dict, Collection, Iterable, Mapping, Sequence}:
-        return True
-
     if origin in {Union, UnionType}:
         return any(_field_type_may_hold_orm_state(arg) for arg in get_args(field_type) if arg is not type(None))
 
     if origin is Annotated:
         args = get_args(field_type)
         return bool(args) and _field_type_may_hold_orm_state(args[0])
+
+    if origin in {list, tuple, set, frozenset, dict, Collection, Iterable, Mapping, Sequence}:
+        args = tuple(arg for arg in get_args(field_type) if arg not in {type(None), Ellipsis})
+        return not args or any(_field_type_may_hold_orm_state(arg) for arg in args)
 
     return False
 
@@ -239,7 +256,7 @@ def _get_django_relation_info(model_cls: type, attr_name: str) -> _DjangoRelatio
 
     try:
         field = meta.get_field(attr_name)
-    except Exception:
+    except FieldDoesNotExist:
         model_cache[attr_name] = None
         return None
 

--- a/python/django_bolt/serializers/base.py
+++ b/python/django_bolt/serializers/base.py
@@ -6,15 +6,18 @@ import inspect
 import logging
 import re
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar, get_args, get_origin, get_type_hints
+from dataclasses import dataclass
+from functools import cache
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar, cast, get_args, get_origin, get_type_hints
 
 import msgspec
 from django.db.models import Model as DjangoModel
+from django.db.models.manager import BaseManager
+from django.db.models.query import QuerySet
 from msgspec import ValidationError as MsgspecValidationError
 from msgspec import structs as msgspec_structs
-from msgspec._core import StructMeta
 
-from django_bolt.exceptions import RequestValidationError
+from django_bolt.exceptions import RequestValidationError, SerializationError
 
 from .decorators import (
     ComputedFieldConfig,
@@ -23,7 +26,7 @@ from .decorators import (
     collect_model_validators,
 )
 from .fields import FieldConfig, _FieldMarker
-from .nested import get_nested_config, validate_nested_field
+from .nested import resolve_nested_config, validate_nested_field
 
 # Regex to extract field path from msgspec error messages (e.g., "at `$.field_name`")
 # Borrowed from Litestar's approach
@@ -35,17 +38,49 @@ if TYPE_CHECKING:
     from django.db.models import Model
 
 T = TypeVar("T", bound="Serializer")
+_MISSING = object()
+_USE_DEFAULT = object()
+_STRUCT_META = type(msgspec.Struct)
 
 
-def _is_serializer_type(field_type: Any) -> bool:
-    """Check if a type is a Serializer subclass (for dump fast path detection)."""
-    try:
-        # Check if it's a class and subclass of msgspec.Struct with __is_bolt_serializer__
-        if isinstance(field_type, type):
-            return issubclass(field_type, msgspec.Struct) and getattr(field_type, "__is_bolt_serializer__", False)
-    except TypeError:
-        pass
-    return False
+@dataclass(frozen=True)
+class _ModelOutputNested:
+    """Cached nested output metadata for from_model()/afrom_model()."""
+
+    serializer_class: type[Serializer]
+    many: bool
+    max_items: int | None
+
+
+@dataclass(frozen=True)
+class _ModelFieldSpec:
+    """Cached model extraction metadata for a serializer field."""
+
+    field_name: str
+    source: str | None
+    nested: _ModelOutputNested | None
+    has_default: bool
+
+
+@dataclass(frozen=True)
+class _DjangoRelationInfo:
+    """Lightweight cached description of a Django relation accessor."""
+
+    name: str
+    kind: Literal["forward_one", "reverse_one", "many"]
+    cache_name: str
+    related_model: type[DjangoModel] | None
+    attname: str | None = None
+    reverse_query_attname: str | None = None
+
+
+@dataclass(frozen=True)
+class _UnloadedRelation:
+    """Marker describing a relation path that would require ORM I/O."""
+
+    source: str
+    relation_name: str
+    relation_kind: Literal["forward_one", "reverse_one", "many"]
 
 
 def _iter_field_defaults(cls: type) -> list[tuple[str, Any]]:
@@ -74,7 +109,7 @@ def _iter_field_defaults(cls: type) -> list[tuple[str, Any]]:
     return result
 
 
-def _build_rename_map(cls: type) -> dict[str, str]:
+def _build_rename_map(cls: type[msgspec.Struct]) -> dict[str, str]:
     """
     Build field name -> encoded name mapping for msgspec rename support.
 
@@ -99,7 +134,86 @@ def _build_rename_map(cls: type) -> dict[str, str]:
     return rename_map
 
 
-class _SerializerMeta(StructMeta):
+def _get_model_output_nested(field_type: Any) -> _ModelOutputNested | None:
+    """Infer nested output behavior from the type hint plus optional Nested() metadata."""
+    nested_config = resolve_nested_config(field_type)
+    if nested_config is None:
+        return None
+
+    return _ModelOutputNested(
+        serializer_class=nested_config.serializer_class,
+        many=nested_config.many,
+        max_items=nested_config.max_items,
+    )
+
+
+@cache
+def _get_django_relation_info(model_cls: type, attr_name: str) -> _DjangoRelationInfo | None:
+    """Return cached Django relation metadata for a model accessor."""
+    meta = getattr(model_cls, "_meta", None)
+    if meta is None:
+        return None
+
+    try:
+        field = meta.get_field(attr_name)
+    except Exception:
+        return None
+
+    if not getattr(field, "is_relation", False):
+        return None
+
+    cache_name = attr_name
+    get_cache_name = getattr(field, "get_cache_name", None)
+    if callable(get_cache_name):
+        try:
+            cache_name = get_cache_name()
+        except TypeError:
+            cache_name = attr_name
+
+    related_model = getattr(field, "related_model", None)
+
+    if getattr(field, "auto_created", False) and not getattr(field, "concrete", True):
+        if getattr(field, "one_to_one", False):
+            reverse_field = getattr(field, "field", None)
+            reverse_query_attname = (
+                getattr(reverse_field, "attname", None) or getattr(reverse_field, "name", None)
+            )
+            return _DjangoRelationInfo(
+                name=attr_name,
+                kind="reverse_one",
+                cache_name=cache_name,
+                related_model=related_model,
+                reverse_query_attname=reverse_query_attname,
+            )
+
+        return _DjangoRelationInfo(
+            name=attr_name,
+            kind="many",
+            cache_name=attr_name,
+            related_model=related_model,
+        )
+
+    if getattr(field, "many_to_many", False):
+        return _DjangoRelationInfo(
+            name=attr_name,
+            kind="many",
+            cache_name=attr_name,
+            related_model=related_model,
+        )
+
+    if getattr(field, "one_to_one", False) or getattr(field, "many_to_one", False):
+        return _DjangoRelationInfo(
+            name=attr_name,
+            kind="forward_one",
+            cache_name=cache_name,
+            related_model=related_model,
+            attname=getattr(field, "attname", None),
+        )
+
+    return None
+
+
+class _SerializerMeta(_STRUCT_META):
     """
     Custom metaclass that forces kw_only=True for all Serializer subclasses.
 
@@ -110,12 +224,12 @@ class _SerializerMeta(StructMeta):
     def __new__(mcs, name: str, bases: tuple, namespace: dict, **kwargs):
         # Force kw_only=True for all Serializer subclasses
         kwargs.setdefault("kw_only", True)
-        cls = super().__new__(mcs, name, bases, namespace, **kwargs)
+        cls = cast(Any, super().__new__(mcs, name, bases, namespace, **kwargs))
 
         # Build rename map (e.g., {"user_name": "userName"} for rename="camel").
         # Done here because __struct_fields__ isn't available in __init_subclass__.
         # If forward references can't be resolved, deferred to _lazy_collect_field_configs.
-        rename_map = _build_rename_map(cls) if hasattr(cls, "__struct_fields__") else {}
+        rename_map = _build_rename_map(cast(type[msgspec.Struct], cls)) if hasattr(cls, "__struct_fields__") else {}
         cls.__rename_map__ = rename_map
         # Fast boolean flag avoids dict truthiness check on every dump()
         cls.__has_rename__ = bool(rename_map)
@@ -123,7 +237,7 @@ class _SerializerMeta(StructMeta):
         return cls
 
 
-class Serializer(msgspec.Struct, metaclass=_SerializerMeta):  # type: ignore[misc]
+class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
     """
     Enhanced msgspec.Struct with validation and Django model integration.
 
@@ -171,6 +285,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):  # type: ignore[mis
     __cached_type_hints__: ClassVar[dict[str, Any]] = {}
     __nested_fields__: ClassVar[dict[str, Any]] = {}
     __literal_fields__: ClassVar[dict[str, frozenset[Any]]] = {}  # Frozenset for O(1) lookup
+    __model_field_specs__: ClassVar[tuple[_ModelFieldSpec, ...]] = ()
 
     # Field configuration (populated by __init_subclass__)
     __field_configs__: ClassVar[dict[str, FieldConfig]] = {}
@@ -244,7 +359,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):  # type: ignore[mis
         # - No computed fields
         # - No write_only fields
         # - No field configs with exclude
-        # - No nested serializer fields (with Nested() annotation)
+        # - No nested serializer fields
         # - No serializer-typed fields (they need recursive dump)
         cls.__dump_fast_path__ = (
             not cls.__has_computed_fields__
@@ -347,10 +462,11 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):  # type: ignore[mis
         has_serializer_fields = False  # Track if any field is a Serializer (for dump optimization)
 
         for field_name, field_type in hints.items():
-            # Check if field has NestedConfig metadata
-            nested_config = get_nested_config(field_type)
+            # Infer nested serializer behavior from the field type.
+            nested_config = resolve_nested_config(field_type)
             if nested_config is not None:
                 nested_fields[field_name] = nested_config
+                has_serializer_fields = True
 
             # Check if field is a Literal type (for Django choices validation)
             origin = get_origin(field_type)
@@ -358,18 +474,6 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):  # type: ignore[mis
                 allowed_values = get_args(field_type)
                 # Convert to frozenset for O(1) membership testing (optimization #3)
                 literal_fields[field_name] = frozenset(allowed_values)
-
-            # Check if field type is a Serializer subclass (for dump fast path)
-            # This handles cases like `address: AddressSerializer` without Nested()
-            if not has_serializer_fields:
-                # Check direct type
-                if _is_serializer_type(field_type):
-                    has_serializer_fields = True
-                # Check list[Serializer]
-                elif origin is list:
-                    args = get_args(field_type)
-                    if args and _is_serializer_type(args[0]):
-                        has_serializer_fields = True
 
         cls.__nested_fields__ = nested_fields
         cls.__literal_fields__ = literal_fields
@@ -499,6 +603,17 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):  # type: ignore[mis
         cls.__write_only_fields__ = cls.__write_only_fields__ | frozenset(write_only)
         cls.__source_mapping__.update(source_mapping)
 
+        default_field_names = {field_name for field_name, _ in _iter_field_defaults(cls)}
+        cls.__model_field_specs__ = tuple(
+            _ModelFieldSpec(
+                field_name=field_name,
+                source=cls.__source_mapping__.get(field_name),
+                nested=_get_model_output_nested(cls.__cached_type_hints__.get(field_name, Any)),
+                has_default=field_name in default_field_names,
+            )
+            for field_name in cls.__struct_fields__
+        )
+
         # Update the has_field_markers flag based on actual _FieldMarker defaults found
         cls.__has_field_markers__ = bool(field_configs)
 
@@ -576,7 +691,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):  # type: ignore[mis
         Validate nested serializer fields and Literal (choice) fields using cached metadata.
 
         This method handles two types of validation:
-        1. Nested fields: Fields with Nested() annotation that contain serializer instances
+        1. Nested fields: Fields whose type resolves to a nested serializer
         2. Literal fields: Fields with Literal[] type hints that restrict values to specific choices
 
         Returns:
@@ -802,6 +917,383 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):  # type: ignore[mis
             raise
 
     @classmethod
+    def _ensure_from_model_ready(cls) -> None:
+        """Ensure lazy field metadata has been collected before model extraction."""
+        if not cls.__field_configs_collected__:
+            cls._lazy_collect_field_configs()
+
+    @classmethod
+    def _relation_loading_hint(cls, relation: _DjangoRelationInfo) -> str:
+        """Return the recommended Django ORM hint for preloading a relation."""
+        if relation.kind == "many":
+            return f"prefetch_related('{relation.name}')"
+        return f"select_related('{relation.name}')"
+
+    @classmethod
+    def _raise_unloaded_relation_error(
+        cls,
+        *,
+        field_name: str,
+        relation: _UnloadedRelation,
+        instance: Any,
+    ) -> None:
+        """Raise a descriptive error when sync from_model() would need ORM I/O."""
+        raise SerializationError(
+            f"{cls.__name__}.{field_name} requires loaded relation '{relation.source}' on "
+            f"{instance.__class__.__name__} when using from_model(). Preload it with "
+            f"{cls._relation_loading_hint(_DjangoRelationInfo(relation.relation_name, relation.relation_kind, relation.relation_name, None))} "
+            f"or use await {cls.__name__}.afrom_model(instance)."
+        )
+
+    @staticmethod
+    def _normalize_many_relation_value(value: Any) -> list[Any]:
+        """Normalize prefetched many-relation values into a concrete list."""
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return value
+        if isinstance(value, tuple):
+            return list(value)
+        if isinstance(value, (BaseManager, QuerySet)):
+            return list(value)
+        if isinstance(value, Iterable) and not isinstance(value, (str, bytes, dict)):
+            return list(value)
+        return [value]
+
+    @classmethod
+    def _get_loaded_relation_sync(cls, obj: DjangoModel, relation: _DjangoRelationInfo) -> Any:
+        """Read a relation only if Django already has it cached on the instance."""
+        state = getattr(obj, "_state", None)
+        fields_cache = getattr(state, "fields_cache", {}) if state is not None else {}
+
+        if relation.kind in {"forward_one", "reverse_one"}:
+            for key in (relation.cache_name, relation.name):
+                if key in fields_cache:
+                    return fields_cache[key]
+                if key in getattr(obj, "__dict__", {}):
+                    return obj.__dict__[key]
+            return _MISSING
+
+        prefetch_cache = getattr(obj, "_prefetched_objects_cache", None)
+        if isinstance(prefetch_cache, dict):
+            for key in (relation.cache_name, relation.name):
+                if key in prefetch_cache:
+                    return cls._normalize_many_relation_value(prefetch_cache[key])
+        return _MISSING
+
+    @staticmethod
+    def _cache_loaded_relation(obj: DjangoModel, relation: _DjangoRelationInfo, value: Any) -> None:
+        """Store async-loaded relations back on the Django instance for reuse."""
+        if relation.kind == "many":
+            cache = getattr(obj, "_prefetched_objects_cache", None)
+            if cache is None:
+                cache = {}
+                obj._prefetched_objects_cache = cache
+            cache[relation.cache_name] = list(value) if isinstance(value, list) else value
+            return
+
+        state = getattr(obj, "_state", None)
+        if state is not None:
+            fields_cache = getattr(state, "fields_cache", None)
+            if fields_cache is not None:
+                fields_cache[relation.cache_name] = value
+                return
+        obj.__dict__[relation.cache_name] = value
+
+    @classmethod
+    async def _load_relation_async(cls, obj: DjangoModel, relation: _DjangoRelationInfo) -> Any:
+        """Load a relation through Django's async ORM when afrom_model() is used."""
+        related_model = relation.related_model
+        if related_model is None:
+            return None
+        related_model_cls = cast(Any, related_model)
+
+        if relation.kind == "forward_one":
+            if relation.attname is None:
+                return None
+            related_id = getattr(obj, relation.attname, None)
+            if related_id is None:
+                return None
+            value = await related_model_cls.objects.aget(pk=related_id)
+            cls._cache_loaded_relation(obj, relation, value)
+            return value
+
+        if relation.kind == "reverse_one":
+            if relation.reverse_query_attname is None:
+                return None
+            try:
+                value = await related_model_cls.objects.aget(**{relation.reverse_query_attname: obj.pk})
+            except related_model_cls.DoesNotExist:
+                value = None
+            cls._cache_loaded_relation(obj, relation, value)
+            return value
+
+        manager = getattr(obj, relation.name)
+        value = [item async for item in manager.all()]
+        cls._cache_loaded_relation(obj, relation, value)
+        return value
+
+    @classmethod
+    def _resolve_source_sync(
+        cls,
+        obj: Any,
+        source: str,
+        *,
+        nested_output: _ModelOutputNested | None,
+    ) -> Any:
+        """Resolve a dot-path without triggering ORM I/O."""
+        parts = source.split(".")
+        current = obj
+
+        for idx, part in enumerate(parts):
+            if current is None:
+                return None
+
+            is_last = idx == len(parts) - 1
+            relation = _get_django_relation_info(current.__class__, part) if isinstance(current, DjangoModel) else None
+
+            if relation is not None:
+                if is_last and nested_output is None and relation.kind == "forward_one" and relation.attname is not None:
+                    return getattr(current, relation.attname, None)
+
+                loaded_value = cls._get_loaded_relation_sync(current, relation)
+                if loaded_value is _MISSING:
+                    return _UnloadedRelation(
+                        source=".".join(parts[: idx + 1]),
+                        relation_name=relation.name,
+                        relation_kind=relation.kind,
+                    )
+                current = loaded_value
+                continue
+
+            if isinstance(current, dict):
+                if part not in current:
+                    return _MISSING
+                current = current[part]
+                continue
+
+            if isinstance(current, list):
+                return _MISSING
+
+            if not hasattr(current, part):
+                return _MISSING
+            current = getattr(current, part)
+
+        return current
+
+    @classmethod
+    async def _resolve_source_async(
+        cls,
+        obj: Any,
+        source: str,
+        *,
+        nested_output: _ModelOutputNested | None,
+    ) -> Any:
+        """Resolve a dot-path, loading relations through Django's async ORM as needed."""
+        parts = source.split(".")
+        current = obj
+
+        for idx, part in enumerate(parts):
+            if current is None:
+                return None
+
+            is_last = idx == len(parts) - 1
+            relation = _get_django_relation_info(current.__class__, part) if isinstance(current, DjangoModel) else None
+
+            if relation is not None:
+                if is_last and nested_output is None and relation.kind == "forward_one" and relation.attname is not None:
+                    return getattr(current, relation.attname, None)
+
+                loaded_value = cls._get_loaded_relation_sync(current, relation)
+                if loaded_value is _MISSING:
+                    loaded_value = await cls._load_relation_async(current, relation)
+                current = loaded_value
+                continue
+
+            if isinstance(current, dict):
+                if part not in current:
+                    return _MISSING
+                current = current[part]
+                continue
+
+            if isinstance(current, list):
+                return _MISSING
+
+            if not hasattr(current, part):
+                return _MISSING
+            current = getattr(current, part)
+
+        return current
+
+    @classmethod
+    def _convert_regular_from_model_value(cls, value: Any, *, field_name: str) -> Any:
+        """Convert ORM-ish values into regular serializer output values."""
+        if isinstance(value, DjangoModel):
+            return value.pk
+        if isinstance(value, (BaseManager, QuerySet)):
+            raise SerializationError(
+                f"{cls.__name__}.{field_name} still contains {value.__class__.__name__}; "
+                "from_model() must resolve Django managers/querysets before dump()."
+            )
+        if isinstance(value, list) and value and isinstance(value[0], DjangoModel):
+            return [item.pk for item in value]
+        return value
+
+    @classmethod
+    def _validate_nested_item_limit(
+        cls,
+        *,
+        field_name: str,
+        nested_output: _ModelOutputNested,
+        item_count: int,
+    ) -> None:
+        """Enforce nested list size limits for output serialization too."""
+        if nested_output.max_items is not None and item_count > nested_output.max_items:
+            raise SerializationError(
+                f"{cls.__name__}.{field_name} resolved {item_count} nested items. "
+                f"Maximum allowed: {nested_output.max_items}."
+            )
+
+    @classmethod
+    def _convert_nested_from_model_value(
+        cls,
+        value: Any,
+        *,
+        field_name: str,
+        nested_output: _ModelOutputNested,
+        _depth: int,
+        max_depth: int,
+    ) -> Any:
+        """Convert nested model values for sync from_model()."""
+        serializer_class = nested_output.serializer_class
+
+        if value is None:
+            return None
+
+        if nested_output.many:
+            items = cls._normalize_many_relation_value(value)
+            cls._validate_nested_item_limit(field_name=field_name, nested_output=nested_output, item_count=len(items))
+
+            result = []
+            for item in items:
+                if isinstance(item, serializer_class):
+                    result.append(item)
+                elif isinstance(item, DjangoModel):
+                    result.append(serializer_class.from_model(item, _depth=_depth + 1, max_depth=max_depth))
+                elif isinstance(item, dict):
+                    result.append(serializer_class(**item))
+                else:
+                    result.append(item)
+            return result
+
+        if isinstance(value, serializer_class):
+            return value
+        if isinstance(value, DjangoModel):
+            return serializer_class.from_model(value, _depth=_depth + 1, max_depth=max_depth)
+        if isinstance(value, dict):
+            return serializer_class(**value)
+        return value
+
+    @classmethod
+    async def _convert_nested_from_model_value_async(
+        cls,
+        value: Any,
+        *,
+        field_name: str,
+        nested_output: _ModelOutputNested,
+        _depth: int,
+        max_depth: int,
+    ) -> Any:
+        """Convert nested model values for async afrom_model()."""
+        serializer_class = nested_output.serializer_class
+
+        if value is None:
+            return None
+
+        if nested_output.many:
+            items = cls._normalize_many_relation_value(value)
+            cls._validate_nested_item_limit(field_name=field_name, nested_output=nested_output, item_count=len(items))
+
+            result = []
+            for item in items:
+                if isinstance(item, serializer_class):
+                    result.append(item)
+                elif isinstance(item, DjangoModel):
+                    result.append(await serializer_class.afrom_model(item, _depth=_depth + 1, max_depth=max_depth))
+                elif isinstance(item, dict):
+                    result.append(serializer_class(**item))
+                else:
+                    result.append(item)
+            return result
+
+        if isinstance(value, serializer_class):
+            return value
+        if isinstance(value, DjangoModel):
+            return await serializer_class.afrom_model(value, _depth=_depth + 1, max_depth=max_depth)
+        if isinstance(value, dict):
+            return serializer_class(**value)
+        return value
+
+    @classmethod
+    def _extract_model_field_sync(
+        cls,
+        instance: Any,
+        spec: _ModelFieldSpec,
+        *,
+        _depth: int,
+        max_depth: int,
+    ) -> Any:
+        """Extract one serializer field from a model/object without ORM I/O."""
+        source = spec.source or spec.field_name
+        value = cls._resolve_source_sync(instance, source, nested_output=spec.nested)
+
+        if value is _MISSING:
+            return _USE_DEFAULT if spec.has_default else _MISSING
+
+        if isinstance(value, _UnloadedRelation):
+            if spec.has_default:
+                return _USE_DEFAULT
+            cls._raise_unloaded_relation_error(field_name=spec.field_name, relation=value, instance=instance)
+
+        if spec.nested is not None:
+            return cls._convert_nested_from_model_value(
+                value,
+                field_name=spec.field_name,
+                nested_output=spec.nested,
+                _depth=_depth,
+                max_depth=max_depth,
+            )
+
+        return cls._convert_regular_from_model_value(value, field_name=spec.field_name)
+
+    @classmethod
+    async def _extract_model_field_async(
+        cls,
+        instance: Any,
+        spec: _ModelFieldSpec,
+        *,
+        _depth: int,
+        max_depth: int,
+    ) -> Any:
+        """Extract one serializer field from a model/object with async ORM support."""
+        source = spec.source or spec.field_name
+        value = await cls._resolve_source_async(instance, source, nested_output=spec.nested)
+
+        if value is _MISSING:
+            return _USE_DEFAULT if spec.has_default else _MISSING
+
+        if spec.nested is not None:
+            return await cls._convert_nested_from_model_value_async(
+                value,
+                field_name=spec.field_name,
+                nested_output=spec.nested,
+                _depth=_depth,
+                max_depth=max_depth,
+            )
+
+        return cls._convert_regular_from_model_value(value, field_name=spec.field_name)
+
+    @classmethod
     def from_model(
         cls: type[T],
         instance: Model,
@@ -842,81 +1334,42 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):  # type: ignore[mis
                 f"Consider using separate serializers with ID-only fields for deeply nested relationships."
             )
 
-        # Ensure field configs are collected (populates __source_mapping__)
-        # This is normally done lazily in __post_init__, but we need it before creating the instance
-        if not cls.__field_configs_collected__:
-            cls._lazy_collect_field_configs()
+        cls._ensure_from_model_ready()
 
-        # Use cached nested field metadata (no expensive introspection!)
         data = {}
-        source_mapping = cls.__source_mapping__
+        for spec in cls.__model_field_specs__:
+            value = cls._extract_model_field_sync(instance, spec, _depth=_depth, max_depth=max_depth)
+            if value is _MISSING or value is _USE_DEFAULT:
+                continue
+            data[spec.field_name] = value
 
-        for field_name in cls.__struct_fields__:
-            # Check if this field has a source mapping (field uses a different model attribute)
-            source = source_mapping.get(field_name)
+        return cls(**data)
 
-            if source:
-                # Use the source path to get the value from the model
-                value = cls._get_value_from_source(instance, source)
-                # Skip if source root attribute doesn't exist (vs. exists but is None)
-                if value is None and not hasattr(instance, source.split(".")[0]):
-                    continue
-            else:
-                # No source mapping - use field name directly
-                if not hasattr(instance, field_name):
-                    continue
-                value = getattr(instance, field_name)
+    @classmethod
+    async def afrom_model(
+        cls: type[T],
+        instance: Model,
+        *,
+        _depth: int = 0,
+        max_depth: int = 10,
+    ) -> T:
+        """Async variant of from_model() that may lazy-load relations safely."""
+        if _depth > max_depth:
+            raise ValueError(
+                f"Maximum recursion depth ({max_depth}) exceeded in afrom_model(). "
+                f"This usually indicates overly deep nesting or circular references. "
+                f"Current serializer: {cls.__name__}, instance: {instance.__class__.__name__}(pk={instance.pk}). "
+                f"Consider using separate serializers with ID-only fields for deeply nested relationships."
+            )
 
-            # Check if this field has a nested serializer (from cache!)
-            nested_config = cls.__nested_fields__.get(field_name)
+        cls._ensure_from_model_ready()
 
-            if nested_config:
-                # This field is a nested serializer - extract full object data
-                if nested_config.many:
-                    # Many-to-many or reverse relationship
-                    if hasattr(value, "all") and callable(getattr(value, "all", None)):
-                        # Convert each related object to a dict for the nested serializer
-                        items = []
-                        for item in value.all():
-                            if isinstance(item, DjangoModel):
-                                # Recursively call from_model with depth tracking
-                                items.append(
-                                    nested_config.serializer_class.from_model(
-                                        item,
-                                        _depth=_depth + 1,
-                                        max_depth=max_depth,
-                                    )
-                                )
-                        data[field_name] = items
-                    elif isinstance(value, list):
-                        data[field_name] = value
-                    else:
-                        data[field_name] = []
-                else:
-                    # Single nested object (ForeignKey)
-                    if isinstance(value, DjangoModel):
-                        # Convert to nested serializer with depth tracking
-                        data[field_name] = nested_config.serializer_class.from_model(
-                            value,
-                            _depth=_depth + 1,
-                            max_depth=max_depth,
-                        )
-                    else:
-                        data[field_name] = value
-            else:
-                # Regular field - not nested
-                if isinstance(value, DjangoModel):
-                    # Related object without nested serializer - use ID
-                    data[field_name] = value.pk
-                elif hasattr(value, "all") and callable(getattr(value, "all", None)):
-                    # Manager without nested serializer - extract IDs
-                    try:
-                        data[field_name] = [item.pk for item in value.all()]
-                    except Exception:
-                        data[field_name] = value
-                else:
-                    # Regular field
-                    data[field_name] = value
+        data = {}
+        for spec in cls.__model_field_specs__:
+            value = await cls._extract_model_field_async(instance, spec, _depth=_depth, max_depth=max_depth)
+            if value is _MISSING or value is _USE_DEFAULT:
+                continue
+            data[spec.field_name] = value
 
         return cls(**data)
 
@@ -979,13 +1432,13 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):  # type: ignore[mis
         omit_defaults = self.__struct_config__.omit_defaults
 
         # Get field defaults if omit_defaults is enabled
-        defaults = self.__struct_defaults__ if omit_defaults else None
+        default_values = dict(_iter_field_defaults(type(self))) if omit_defaults else {}
 
-        for idx, field_name in enumerate(self.__struct_fields__):
+        for field_name in self.__struct_fields__:
             value = getattr(self, field_name)
 
             # Skip fields that are at their default value if omit_defaults is True
-            if omit_defaults and defaults is not None and value == defaults[idx]:
+            if omit_defaults and field_name in default_values and value == default_values[field_name]:
                 continue
 
             setattr(instance, field_name, value)
@@ -1158,7 +1611,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):  # type: ignore[mis
 
         # Add from_parent class method
         @classmethod
-        def from_parent(new_cls_ref: type[T], instance: Serializer) -> T:  # type: ignore
+        def from_parent(new_cls_ref: type[T], instance: Serializer) -> T:
             """Create instance from a parent serializer instance."""
             data = {}
             for field_name in new_cls_ref.__struct_fields__:
@@ -1166,7 +1619,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):  # type: ignore[mis
                     data[field_name] = getattr(instance, field_name)
             return new_cls_ref(**data)
 
-        new_cls.from_parent = from_parent  # type: ignore
+        cast(Any, new_cls).from_parent = from_parent
 
         return new_cls
 
@@ -1351,6 +1804,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):  # type: ignore[mis
         """
         # FAST PATH: use msgspec native methods (significantly faster than Python iteration)
         cls = self.__class__
+        self._ensure_dumpable_orm_state()
         if cls.__dump_fast_path__ and not exclude_none and not exclude_defaults and not exclude_unset and not by_alias:
             if cls.__has_rename__:
                 return msgspec.to_builtins(self)
@@ -1432,6 +1886,12 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):  # type: ignore[mis
                 # rename_map.get() returns field_name if not in map (works for empty dict too)
                 output_key = rename_map.get(field_name, field_name)
 
+            if isinstance(value, (BaseManager, QuerySet)):
+                raise SerializationError(
+                    f"{cls.__name__}.{field_name} contains {value.__class__.__name__}. "
+                    "Serialize Django relations with from_model()/afrom_model() before dump()."
+                )
+
             # Handle nested serializers
             if isinstance(value, Serializer):
                 result[output_key] = value.dump(
@@ -1478,6 +1938,17 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):  # type: ignore[mis
                     result[field_name] = value
 
         return result
+
+    def _ensure_dumpable_orm_state(self) -> None:
+        """Fail fast if ORM manager/queryset objects leaked into serializer state."""
+        cls = self.__class__
+        for field_name in cls.__struct_fields__:
+            value = getattr(self, field_name)
+            if isinstance(value, (BaseManager, QuerySet)):
+                raise SerializationError(
+                    f"{cls.__name__}.{field_name} contains {value.__class__.__name__}. "
+                    "Serialize Django relations with from_model()/afrom_model() before dump()."
+                )
 
     def dump_json(
         self,
@@ -1536,13 +2007,17 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):  # type: ignore[mis
             users = [UserSerializer.from_model(u) for u in User.objects.all()]
             UserSerializer.dump_many(users)
         """
+        instances_list = list(instances)
+
         # FAST PATH: use msgspec native methods (significantly faster than Python iteration)
         if cls.__dump_fast_path__ and not exclude_none and not exclude_defaults and not exclude_unset and not by_alias:
+            for instance in instances_list:
+                instance._ensure_dumpable_orm_state()
             if cls.__has_rename__:
                 _to_builtins = msgspec.to_builtins
-                return [_to_builtins(instance) for instance in instances]
+                return [_to_builtins(instance) for instance in instances_list]
             _asdict = msgspec_structs.asdict
-            return [_asdict(instance) for instance in instances]
+            return [_asdict(instance) for instance in instances_list]
 
         # SLOW PATH: Need special handling (computed fields, write_only, exclude_*, etc.)
         return [
@@ -1552,7 +2027,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):  # type: ignore[mis
                 exclude_defaults=exclude_defaults,
                 by_alias=by_alias,
             )
-            for instance in instances
+            for instance in instances_list
         ]
 
     @classmethod
@@ -1683,6 +2158,10 @@ class SerializerView(Iterable[T]):
     def from_model(self, instance: Model, **kwargs) -> T:
         """Create a serializer instance from a Django model."""
         return self._serializer_class.from_model(instance, **kwargs)
+
+    async def afrom_model(self, instance: Model, **kwargs) -> T:
+        """Create a serializer instance from a Django model using async ORM loading."""
+        return await self._serializer_class.afrom_model(instance, **kwargs)
 
     def dump(
         self,

--- a/python/django_bolt/serializers/base.py
+++ b/python/django_bolt/serializers/base.py
@@ -1,14 +1,32 @@
 """Base Serializer class extending msgspec.Struct with validation and Django integration."""
 
+# The feature-heavy dump path still runs in Python. If we push serializer
+# execution further into Rust later, this module is the main place where a
+# dump-plan executor could replace slow-path field iteration.
+
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
 import re
-from collections.abc import Iterable
+from collections.abc import Collection, Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from functools import cache
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar, cast, get_args, get_origin, get_type_hints
+from types import UnionType
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    ClassVar,
+    Literal,
+    TypeVar,
+    Union,
+    cast,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
+from weakref import WeakKeyDictionary
 
 import msgspec
 from django.db.models import Model as DjangoModel
@@ -102,6 +120,10 @@ class _UnloadedRelation:
     relation_kind: Literal["forward_one", "reverse_one", "many"]
 
 
+type _RelationTaskCache = dict[tuple[int, str], asyncio.Task[Any]]
+_DJANGO_RELATION_CACHE: WeakKeyDictionary[type, dict[str, _DjangoRelationInfo | None]] = WeakKeyDictionary()
+
+
 def _iter_field_defaults(cls: type) -> list[tuple[str, Any]]:
     """
     Iterate over (field_name, default_value) pairs for a msgspec.Struct class.
@@ -173,19 +195,56 @@ def _get_model_output_nested(field_type: Any) -> _ModelOutputNested | None:
     )
 
 
-@cache
+def _field_type_may_hold_orm_state(field_type: Any) -> bool:
+    """Return True when a field type could plausibly hold a manager/queryset at runtime."""
+    if field_type in {Any, object, BaseManager, QuerySet, DjangoModel}:
+        return True
+
+    origin = get_origin(field_type)
+    if origin is None:
+        return False
+
+    if origin is Literal:
+        return False
+
+    if origin in {list, tuple, set, frozenset, dict, Collection, Iterable, Mapping, Sequence}:
+        return True
+
+    if origin in {Union, UnionType}:
+        return any(_field_type_may_hold_orm_state(arg) for arg in get_args(field_type) if arg is not type(None))
+
+    if origin is Annotated:
+        args = get_args(field_type)
+        return bool(args) and _field_type_may_hold_orm_state(args[0])
+
+    return False
+
+
 def _get_django_relation_info(model_cls: type, attr_name: str) -> _DjangoRelationInfo | None:
-    """Return cached Django relation metadata for a model accessor."""
+    """Return cached Django relation metadata for a model accessor.
+
+    Uses weak model-class keys so dev reloads don't pin stale model classes in memory.
+    """
+    model_cache = _DJANGO_RELATION_CACHE.get(model_cls)
+    if model_cache is None:
+        model_cache = {}
+        _DJANGO_RELATION_CACHE[model_cls] = model_cache
+    elif attr_name in model_cache:
+        return model_cache[attr_name]
+
     meta = getattr(model_cls, "_meta", None)
     if meta is None:
+        model_cache[attr_name] = None
         return None
 
     try:
         field = meta.get_field(attr_name)
     except Exception:
+        model_cache[attr_name] = None
         return None
 
     if not getattr(field, "is_relation", False):
+        model_cache[attr_name] = None
         return None
 
     cache_name = attr_name
@@ -204,38 +263,47 @@ def _get_django_relation_info(model_cls: type, attr_name: str) -> _DjangoRelatio
             reverse_query_attname = (
                 getattr(reverse_field, "attname", None) or getattr(reverse_field, "name", None)
             )
-            return _DjangoRelationInfo(
+            info = _DjangoRelationInfo(
                 name=attr_name,
                 kind="reverse_one",
                 cache_name=cache_name,
                 related_model=related_model,
                 reverse_query_attname=reverse_query_attname,
             )
+            model_cache[attr_name] = info
+            return info
 
-        return _DjangoRelationInfo(
+        info = _DjangoRelationInfo(
             name=attr_name,
             kind="many",
             cache_name=attr_name,
             related_model=related_model,
         )
+        model_cache[attr_name] = info
+        return info
 
     if getattr(field, "many_to_many", False):
-        return _DjangoRelationInfo(
+        info = _DjangoRelationInfo(
             name=attr_name,
             kind="many",
             cache_name=attr_name,
             related_model=related_model,
         )
+        model_cache[attr_name] = info
+        return info
 
     if getattr(field, "one_to_one", False) or getattr(field, "many_to_one", False):
-        return _DjangoRelationInfo(
+        info = _DjangoRelationInfo(
             name=attr_name,
             kind="forward_one",
             cache_name=cache_name,
             related_model=related_model,
             attname=getattr(field, "attname", None),
         )
+        model_cache[attr_name] = info
+        return info
 
+    model_cache[attr_name] = None
     return None
 
 
@@ -339,6 +407,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
     __default_values_map__: ClassVar[dict[str, Any] | None] = None
     # Fast-path flag for dump: True if dump can use simple/fast path
     __dump_fast_path__: ClassVar[bool] = True
+    __orm_state_check_fields__: ClassVar[tuple[str, ...]] = ()
     _dump_field_specs: ClassVar[tuple[_DumpFieldSpec, ...]] = ()
     _dump_field_spec_cache: ClassVar[
         dict[tuple[frozenset[str] | None, frozenset[str] | None], tuple[_DumpFieldSpec, ...]]
@@ -377,6 +446,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
         cls._dump_field_spec_cache = {}
         cls._computed_dump_spec_cache = {}
         cls._serializer_view_cache = {}
+        cls.__orm_state_check_fields__ = ()
 
         # Collect configuration from Meta class (read_only, write_only, field_sets)
         # Note: _FieldMarker processing is deferred to _lazy_collect_field_configs
@@ -679,6 +749,11 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
             and not cls.__nested_fields__
             and not cls.__has_serializer_fields__
             and not any(cfg.exclude for cfg in cls.__field_configs__.values())
+        )
+        cls.__orm_state_check_fields__ = tuple(
+            field_name
+            for field_name in cls.__struct_fields__
+            if _field_type_may_hold_orm_state(cls.__cached_type_hints__.get(field_name, Any))
         )
         cls._dump_field_specs = cls._build_dump_field_specs()
         cls._dump_field_spec_cache.clear()
@@ -1188,6 +1263,32 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
         return value
 
     @classmethod
+    async def _get_or_load_relation_async(
+        cls,
+        obj: DjangoModel,
+        relation: _DjangoRelationInfo,
+        *,
+        relation_tasks: _RelationTaskCache,
+    ) -> Any:
+        """Reuse in-flight relation loads so gathered field extraction doesn't duplicate queries."""
+        loaded_value = cls._get_loaded_relation_sync(obj, relation)
+        if loaded_value is not _MISSING:
+            return loaded_value
+
+        cache_key = (id(obj), relation.cache_name)
+        task = relation_tasks.get(cache_key)
+        if task is None:
+            task = asyncio.create_task(cls._load_relation_async(obj, relation))
+            relation_tasks[cache_key] = task
+
+        try:
+            return await task
+        except Exception:
+            if relation_tasks.get(cache_key) is task:
+                relation_tasks.pop(cache_key, None)
+            raise
+
+    @classmethod
     def _resolve_source_sync(
         cls,
         obj: Any,
@@ -1242,6 +1343,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
         source: str,
         *,
         nested_output: _ModelOutputNested | None,
+        relation_tasks: _RelationTaskCache,
     ) -> Any:
         """Resolve a dot-path, loading relations through Django's async ORM as needed."""
         parts = source.split(".")
@@ -1260,7 +1362,11 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
 
                 loaded_value = cls._get_loaded_relation_sync(current, relation)
                 if loaded_value is _MISSING:
-                    loaded_value = await cls._load_relation_async(current, relation)
+                    loaded_value = await cls._get_or_load_relation_async(
+                        current,
+                        relation,
+                        relation_tasks=relation_tasks,
+                    )
                 current = loaded_value
                 continue
 
@@ -1368,17 +1474,16 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
             items = cls._normalize_many_relation_value(value)
             cls._validate_nested_item_limit(field_name=field_name, nested_output=nested_output, item_count=len(items))
 
-            result = []
-            for item in items:
+            async def convert_item(item: Any) -> Any:
                 if isinstance(item, serializer_class):
-                    result.append(item)
-                elif isinstance(item, DjangoModel):
-                    result.append(await serializer_class.afrom_model(item, _depth=_depth + 1, max_depth=max_depth))
-                elif isinstance(item, dict):
-                    result.append(serializer_class(**item))
-                else:
-                    result.append(item)
-            return result
+                    return item
+                if isinstance(item, DjangoModel):
+                    return await serializer_class.afrom_model(item, _depth=_depth + 1, max_depth=max_depth)
+                if isinstance(item, dict):
+                    return serializer_class(**item)
+                return item
+
+            return list(await asyncio.gather(*(convert_item(item) for item in items)))
 
         if isinstance(value, serializer_class):
             return value
@@ -1428,10 +1533,16 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
         *,
         _depth: int,
         max_depth: int,
+        relation_tasks: _RelationTaskCache,
     ) -> Any:
         """Extract one serializer field from a model/object with async ORM support."""
         source = spec.source or spec.field_name
-        value = await cls._resolve_source_async(instance, source, nested_output=spec.nested)
+        value = await cls._resolve_source_async(
+            instance,
+            source,
+            nested_output=spec.nested,
+            relation_tasks=relation_tasks,
+        )
 
         if value is _MISSING:
             return _USE_DEFAULT if spec.has_default else _MISSING
@@ -1518,9 +1629,22 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
 
         cls._ensure_from_model_ready()
 
+        relation_tasks: _RelationTaskCache = {}
+        values = await asyncio.gather(
+            *(
+                cls._extract_model_field_async(
+                    instance,
+                    spec,
+                    _depth=_depth,
+                    max_depth=max_depth,
+                    relation_tasks=relation_tasks,
+                )
+                for spec in cls.__model_field_specs__
+            )
+        )
+
         data = {}
-        for spec in cls.__model_field_specs__:
-            value = await cls._extract_model_field_async(instance, spec, _depth=_depth, max_depth=max_depth)
+        for spec, value in zip(cls.__model_field_specs__, values, strict=False):
             if value is _MISSING or value is _USE_DEFAULT:
                 continue
             data[spec.field_name] = value
@@ -1960,12 +2084,13 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
         cls = self.__class__
         cls._ensure_dump_ready()
         if cls.__dump_fast_path__ and not exclude_none and not exclude_defaults and not exclude_unset and not by_alias:
-            self._ensure_dumpable_orm_state()
+            if cls.__orm_state_check_fields__:
+                self._ensure_dumpable_orm_state(cls.__orm_state_check_fields__)
             if cls.__has_rename__:
                 return msgspec.to_builtins(self)
             return msgspec_structs.asdict(self)
 
-        # SLOW PATH: Need special handling
+        # SLOW PATH: Need special handling.
         return self._dump_impl(
             exclude_none=exclude_none,
             exclude_unset=exclude_unset,
@@ -2064,10 +2189,10 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
 
         return result
 
-    def _ensure_dumpable_orm_state(self) -> None:
+    def _ensure_dumpable_orm_state(self, field_names: tuple[str, ...] | None = None) -> None:
         """Fail fast if ORM manager/queryset objects leaked into serializer state."""
         cls = self.__class__
-        for field_name in cls.__struct_fields__:
+        for field_name in field_names or cls.__struct_fields__:
             value = getattr(self, field_name)
             if isinstance(value, (BaseManager, QuerySet)):
                 raise SerializationError(
@@ -2137,8 +2262,9 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
 
         # FAST PATH: use msgspec native methods (significantly faster than Python iteration)
         if cls.__dump_fast_path__ and not exclude_none and not exclude_defaults and not exclude_unset and not by_alias:
-            for instance in instances_list:
-                instance._ensure_dumpable_orm_state()
+            if cls.__orm_state_check_fields__:
+                for instance in instances_list:
+                    instance._ensure_dumpable_orm_state(cls.__orm_state_check_fields__)
             if cls.__has_rename__:
                 _to_builtins = msgspec.to_builtins
                 return [_to_builtins(instance) for instance in instances_list]

--- a/python/django_bolt/serializers/decorators.py
+++ b/python/django_bolt/serializers/decorators.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, get_type_hints
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, cast, get_type_hints, overload
 
 logger = logging.getLogger(__name__)
 
@@ -13,6 +13,33 @@ if TYPE_CHECKING:
     from .base import Serializer
 
 T = TypeVar("T")
+ValidatorMode = Literal["before", "after"]
+
+
+class _ComputedFieldCallable(Protocol):
+    __name__: str
+    __computed_field__: ComputedFieldConfig
+
+    def __call__(self, instance: Any, /) -> Any: ...
+
+
+class _FieldValidatorCallable(Protocol):
+    __validator_field__: str
+    __validator_mode__: ValidatorMode
+
+    def __call__(self, serializer_cls: type[Serializer], value: Any, /) -> Any: ...
+
+
+class _ModelValidatorCallable(Protocol):
+    __model_validator__: bool
+    __validator_mode__: ValidatorMode
+
+    def __call__(self, serializer: Serializer, /) -> Serializer: ...
+
+
+ComputedFieldMethod = Callable[[Any], Any]
+FieldValidatorFunc = Callable[[type["Serializer"], Any], Any]
+ModelValidatorFunc = Callable[["Serializer"], "Serializer"]
 
 # Marker attributes for storing validators on classes
 FIELD_VALIDATORS_ATTR = "__field_validators__"
@@ -44,7 +71,7 @@ class ComputedFieldConfig:
 
 
 def computed_field(
-    func: Callable[[Any], Any] | None = None,
+    func: ComputedFieldMethod | None = None,
     *,
     alias: str | None = None,
     description: str | None = None,
@@ -91,7 +118,7 @@ def computed_field(
         - Method name becomes the field name (unless alias is specified)
     """
 
-    def decorator(method: Callable[[Any], Any]) -> Callable[[Any], Any]:
+    def decorator(method: ComputedFieldMethod) -> ComputedFieldMethod:
         # Try to get return type from method annotations
         return_type = Any
         try:
@@ -105,8 +132,9 @@ def computed_field(
             )
 
         # Store computed field metadata on the method
-        method.__computed_field__ = ComputedFieldConfig(
-            method_name=method.__name__,
+        typed_method = cast(_ComputedFieldCallable, method)
+        typed_method.__computed_field__ = ComputedFieldConfig(
+            method_name=typed_method.__name__,
             return_type=return_type,
             description=description,
             alias=alias,
@@ -125,8 +153,8 @@ def computed_field(
 
 def field_validator(
     field_name: str,
-    mode: Literal["before", "after"] = "after",
-) -> Callable[[Callable[[type[Serializer], Any], Any]], Callable[[type[Serializer], Any], Any]]:
+    mode: ValidatorMode = "after",
+) -> Callable[[FieldValidatorFunc], FieldValidatorFunc]:
     """
     Decorator to validate a specific field in a Serializer.
 
@@ -146,20 +174,32 @@ def field_validator(
     """
 
     def decorator(
-        func: Callable[[type[Serializer], Any], Any],
-    ) -> Callable[[type[Serializer], Any], Any]:
+        func: FieldValidatorFunc,
+    ) -> FieldValidatorFunc:
         # Store validator metadata on the function
-        func.__validator_field__ = field_name
-        func.__validator_mode__ = mode
+        typed_func = cast(_FieldValidatorCallable, func)
+        typed_func.__validator_field__ = field_name
+        typed_func.__validator_mode__ = mode
         return func
 
     return decorator
 
 
+@overload
+def model_validator(func: ModelValidatorFunc, mode: ValidatorMode = "after") -> ModelValidatorFunc: ...
+
+
+@overload
 def model_validator(
-    func: Callable[[Serializer], Serializer] | None = None,
-    mode: Literal["before", "after"] = "after",
-) -> Callable[[Callable[[Serializer], Serializer]], Callable[[Serializer], Serializer]]:
+    func: None = None,
+    mode: ValidatorMode = "after",
+) -> Callable[[ModelValidatorFunc], ModelValidatorFunc]: ...
+
+
+def model_validator(
+    func: ModelValidatorFunc | None = None,
+    mode: ValidatorMode = "after",
+) -> ModelValidatorFunc | Callable[[ModelValidatorFunc], ModelValidatorFunc]:
     """
     Decorator to validate an entire Serializer after all fields are set.
 
@@ -179,11 +219,12 @@ def model_validator(
     """
 
     def decorator(
-        validator_func: Callable[[Serializer], Serializer],
-    ) -> Callable[[Serializer], Serializer]:
+        validator_func: ModelValidatorFunc,
+    ) -> ModelValidatorFunc:
         # Store validator metadata on the function
-        validator_func.__model_validator__ = True
-        validator_func.__validator_mode__ = mode
+        typed_validator = cast(_ModelValidatorCallable, validator_func)
+        typed_validator.__model_validator__ = True
+        typed_validator.__validator_mode__ = mode
         return validator_func
 
     if func is None:
@@ -191,18 +232,19 @@ def model_validator(
         return decorator
     else:
         # Called without parentheses: @model_validator
-        func.__model_validator__ = True
-        func.__validator_mode__ = mode
+        typed_func = cast(_ModelValidatorCallable, func)
+        typed_func.__model_validator__ = True
+        typed_func.__validator_mode__ = mode
         return func
 
 
-def collect_field_validators(cls: type[Serializer]) -> dict[str, list[Callable[[Any], Any]]]:
+def collect_field_validators(cls: type[Serializer]) -> dict[str, list[FieldValidatorFunc]]:
     """
     Collect all field validators from a class and its bases.
 
     Returns a dict mapping field names to lists of validator functions.
     """
-    validators: dict[str, list[Callable[[Any], Any]]] = {}
+    validators: dict[str, list[FieldValidatorFunc]] = {}
 
     # Walk through MRO to collect validators
     for base in cls.__mro__:
@@ -211,21 +253,22 @@ def collect_field_validators(cls: type[Serializer]) -> dict[str, list[Callable[[
 
         for _name, value in base.__dict__.items():
             if callable(value) and hasattr(value, "__validator_field__"):
-                field_name = value.__validator_field__
+                validator = cast(_FieldValidatorCallable, value)
+                field_name = validator.__validator_field__
                 if field_name not in validators:
                     validators[field_name] = []
-                validators[field_name].append(value)
+                validators[field_name].append(cast(FieldValidatorFunc, value))
 
     return validators
 
 
-def collect_model_validators(cls: type[Serializer]) -> list[Callable[[Serializer], Serializer]]:
+def collect_model_validators(cls: type[Serializer]) -> list[ModelValidatorFunc]:
     """
     Collect all model validators from a class and its bases.
 
     Returns a list of validator functions in MRO order.
     """
-    validators: list[Callable[[Serializer], Serializer]] = []
+    validators: list[ModelValidatorFunc] = []
 
     # Walk through MRO to collect validators
     for base in cls.__mro__:
@@ -234,7 +277,7 @@ def collect_model_validators(cls: type[Serializer]) -> list[Callable[[Serializer
 
         for _name, value in base.__dict__.items():
             if callable(value) and hasattr(value, "__model_validator__"):
-                validators.append(value)
+                validators.append(cast(ModelValidatorFunc, value))
 
     return validators
 
@@ -254,7 +297,7 @@ def collect_computed_fields(cls: type[Serializer]) -> dict[str, ComputedFieldCon
 
         for _name, value in base.__dict__.items():
             if callable(value) and hasattr(value, "__computed_field__"):
-                config: ComputedFieldConfig = value.__computed_field__
+                config = cast(_ComputedFieldCallable, value).__computed_field__
                 # Use alias if provided, otherwise use method name
                 field_name = config.alias or config.method_name
                 computed[field_name] = config

--- a/python/django_bolt/serializers/fields.py
+++ b/python/django_bolt/serializers/fields.py
@@ -186,7 +186,12 @@ def field(
     return _FieldMarker(config=config)
 
 
-def get_msgspec_type_for_django_field(field: models.Field) -> type:
+def _build_literal_type(choice_values: list[Any]) -> Any:
+    """Build a runtime Literal annotation from dynamic Django choices."""
+    return Literal.__getitem__(tuple(choice_values))
+
+
+def get_msgspec_type_for_django_field(field: models.Field) -> Any:
     """
     Convert a Django model field to a msgspec-compatible type annotation.
 
@@ -209,8 +214,7 @@ def get_msgspec_type_for_django_field(field: models.Field) -> type:
         if field.choices:
             # Extract choice values (first element of each tuple)
             choice_values = [choice[0] for choice in field.choices]
-            # Create Literal type with all valid choices
-            base_type = Literal[tuple(choice_values)]
+            base_type = _build_literal_type(choice_values)
         else:
             constraints["max_length"] = field.max_length
             base_type = str
@@ -228,8 +232,7 @@ def get_msgspec_type_for_django_field(field: models.Field) -> type:
         if field.choices:
             # Extract choice values (first element of each tuple)
             choice_values = [choice[0] for choice in field.choices]
-            # Create Literal type with all valid choices
-            base_type = Literal[tuple(choice_values)]
+            base_type = _build_literal_type(choice_values)
         else:
             base_type = int
             # Handle validators for ranges
@@ -302,7 +305,7 @@ def create_msgspec_field_definition(
     field: models.Field,
     write_only: bool = False,
     read_only: bool = False,
-) -> tuple[str, type, dict[str, Any]]:
+) -> tuple[str, Any, dict[str, Any]]:
     """
     Create a msgspec field definition from a Django field.
 
@@ -314,6 +317,10 @@ def create_msgspec_field_definition(
     Returns:
         Tuple of (field_name, field_type, field_metadata)
     """
+    field_name = field.name
+    if not field_name:
+        raise ValueError("Django field must have a name to create a serializer definition")
+
     field_type = get_msgspec_type_for_django_field(field)
 
     # Build metadata dict
@@ -324,4 +331,4 @@ def create_msgspec_field_definition(
         "verbose_name": field.verbose_name,
     }
 
-    return field.name, field_type, metadata
+    return field_name, field_type, metadata

--- a/python/django_bolt/serializers/helpers.py
+++ b/python/django_bolt/serializers/helpers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from django.db import models
 
@@ -49,7 +49,12 @@ def create_serializer(
     read_only = read_only or set()
 
     # Get all model fields
-    model_fields = {f.name: f for f in model._meta.get_fields()}
+    model_meta = cast(Any, model)._meta
+    model_fields = {
+        field.name: field
+        for field in model_meta.get_fields()
+        if isinstance(field, models.Field) and field.name is not None
+    }
 
     # Determine which fields to include
     fields_to_include = set(fields) if fields is not None else set(model_fields.keys())
@@ -78,19 +83,19 @@ def create_serializer(
     class_name = serializer_name or f"{model.__name__}Serializer"
 
     # Create the class
-    attrs = {
+    attrs: dict[str, Any] = {
         "__annotations__": annotations,
         "__doc__": f"Auto-generated serializer for {model.__name__}",
         "__module__": model.__module__,
     }
 
-    # Add Meta class with model reference
-    meta_attrs = {
+    # Add Config class with model reference
+    config_attrs = {
         "model": model,
         "write_only": write_only,
         "read_only": read_only,
     }
-    attrs["Meta"] = type("Meta", (), meta_attrs)
+    attrs["Config"] = type("Config", (), config_attrs)
 
     # Create and return the Serializer class
     serializer_class = type(class_name, (Serializer,), attrs)

--- a/python/django_bolt/serializers/nested.py
+++ b/python/django_bolt/serializers/nested.py
@@ -1,152 +1,121 @@
-"""Support for nested serializers with flexible handling of foreign keys and relationships."""
+"""Support for nested serializers with type-driven inference."""
 
 from __future__ import annotations
 
-import logging
-from typing import TYPE_CHECKING, Any, TypeVar
+from dataclasses import dataclass
+from types import UnionType
+from typing import TYPE_CHECKING, Annotated, Any, TypeVar, Union, cast, get_args, get_origin
 
 if TYPE_CHECKING:
     from .base import Serializer
 
 T = TypeVar("T", bound="Serializer")
-logger = logging.getLogger(__name__)
 
 # Security: Maximum number of items allowed in nested many relationships
 # This prevents DoS attacks via extremely large nested object lists
 DEFAULT_MAX_NESTED_ITEMS = 1000
 
 
+@dataclass(frozen=True, slots=True)
 class NestedConfig:
-    """Configuration for a nested serializer field."""
+    """Optional metadata overrides for inferred nested serializer fields."""
 
-    def __init__(
-        self,
-        serializer_class: type[Serializer],
-        many: bool = False,
-        max_items: int | None = DEFAULT_MAX_NESTED_ITEMS,
-    ):
-        """
-        Initialize nested serializer configuration.
+    max_items: int | None = DEFAULT_MAX_NESTED_ITEMS
 
-        Args:
-            serializer_class: The Serializer class to use for validation
-            many: If True, expects a list of objects (for M2M relationships)
-            max_items: Maximum number of items allowed in many relationships (default: 1000)
-                      Set to None to disable limit (not recommended for production)
 
-        Note:
-            Deep nesting protection is handled by Python's recursion limit (~1000 levels).
-            No custom max_depth needed - Python protects against deeply nested JSON automatically.
-        """
-        self.serializer_class = serializer_class
-        self.many = many
-        self.max_items = max_items
+@dataclass(frozen=True, slots=True)
+class ResolvedNestedConfig:
+    """Fully resolved nested field configuration derived from the type hint."""
 
-    def __repr__(self) -> str:
-        return (
-            f"NestedConfig(serializer={self.serializer_class.__name__}, many={self.many}, max_items={self.max_items})"
+    serializer_class: type[Serializer]
+    many: bool
+    max_items: int | None
+
+
+def Nested(*args: Any, max_items: int | None = DEFAULT_MAX_NESTED_ITEMS, **kwargs: Any) -> NestedConfig:
+    """
+    Add optional nested-field metadata to an Annotated serializer type.
+
+    Nested fields are inferred from the type annotation itself:
+
+        author: AuthorSerializer
+        tags: list[TagSerializer]
+
+    Use Nested() only for extra nested options such as max_items:
+
+        tags: Annotated[list[TagSerializer], Nested(max_items=500)]
+    """
+    if args or kwargs:
+        raise TypeError(
+            "Nested() no longer accepts serializer classes or many=. "
+            "Nested fields are inferred from the type annotation. "
+            "Use ChildSerializer or list[ChildSerializer], and optionally "
+            "Annotated[..., Nested(max_items=...)] for extra limits."
         )
 
+    return NestedConfig(max_items=max_items)
 
-def Nested(
-    serializer_class: type[Serializer],
-    *,
-    many: bool = False,
-    max_items: int | None = DEFAULT_MAX_NESTED_ITEMS,
-) -> NestedConfig:
-    """
-    Mark a field as a nested serializer that validates related objects.
 
-    Use this to define relationships that contain full nested objects.
-    For simple ID references, use plain `int` or `list[int]` types instead.
-
-    Args:
-        serializer_class: The Serializer class for the related object(s)
-        many: If True, field contains a list (for M2M or reverse FK relationships)
-        max_items: Maximum number of items allowed in many relationships (default: 1000)
-                  Set to None to disable limit (not recommended for production)
-
-    Returns:
-        NestedConfig that can be used in field annotations
-
-    Raises:
-        TypeError: If serializer_class is not a Serializer subclass
-
-    Examples:
-        Single nested object (ForeignKey with select_related):
-            class BookSerializer(Serializer):
-                title: str
-                author: Annotated[AuthorSerializer, Nested(AuthorSerializer)]
-
-        Multiple nested objects (ManyToMany with prefetch_related):
-            class BookSerializer(Serializer):
-                title: str
-                tags: Annotated[list[TagSerializer], Nested(TagSerializer, many=True)]
-
-        With custom max_items limit:
-            class BookSerializer(Serializer):
-                title: str
-                tags: Annotated[list[TagSerializer], Nested(TagSerializer, many=True, max_items=500)]
-
-        Simple ID reference (no Nested wrapper needed):
-            class BookListSerializer(Serializer):
-                title: str
-                author_id: int  # Just the ID, no nested object
-    """
-    # Import locally to avoid circular dependency with base.py
+def _is_serializer_type(field_type: Any) -> bool:
+    """Return True if the type is a django-bolt Serializer subclass."""
+    # Import locally to avoid a circular import with base.py
     # ruff: noqa: PLC0415
     from .base import Serializer as BaseSerializer
 
-    # Type safety: Validate that serializer_class is actually a Serializer subclass
-    # This catches errors at definition time rather than at validation time
+    try:
+        return isinstance(field_type, type) and issubclass(field_type, BaseSerializer)
+    except TypeError:
+        return False
 
-    if not isinstance(serializer_class, type):
-        raise TypeError(
-            f"serializer_class must be a class, got {type(serializer_class).__name__}. "
-            f"Usage: Nested(MySerializer) not Nested(MySerializer())"
+
+def _unwrap_nested_type(field_type: Any) -> Any:
+    """Strip Annotated and Optional wrappers when inferring nested serializer types."""
+    while True:
+        origin = get_origin(field_type)
+        if origin is Annotated:
+            field_type = get_args(field_type)[0]
+            continue
+        if origin in (Union, UnionType):
+            non_none = [arg for arg in get_args(field_type) if arg is not type(None)]
+            if len(non_none) == 1:
+                field_type = non_none[0]
+                continue
+        return field_type
+
+
+def resolve_nested_config(field_type: Any) -> ResolvedNestedConfig | None:
+    """Infer nested serializer behavior from a field type plus optional Nested() metadata."""
+    metadata = get_nested_config(field_type)
+    resolved_type = _unwrap_nested_type(field_type)
+
+    if _is_serializer_type(resolved_type):
+        return ResolvedNestedConfig(
+            serializer_class=resolved_type,
+            many=False,
+            max_items=None,
         )
 
-    if not issubclass(serializer_class, BaseSerializer):
-        raise TypeError(
-            f"serializer_class must be a Serializer subclass, "
-            f"got {serializer_class.__name__}. "
-            f"Make sure your serializer inherits from django_bolt.serializers.Serializer"
-        )
+    origin = get_origin(resolved_type)
+    if origin is list:
+        args = get_args(resolved_type)
+        if args:
+            item_type = _unwrap_nested_type(args[0])
+            if _is_serializer_type(item_type):
+                return ResolvedNestedConfig(
+                    serializer_class=item_type,
+                    many=True,
+                    max_items=metadata.max_items if metadata is not None else DEFAULT_MAX_NESTED_ITEMS,
+                )
 
-    return NestedConfig(
-        serializer_class=serializer_class,
-        many=many,
-        max_items=max_items,
-    )
+    return None
 
 
 def validate_nested_field(
     value: Any,
-    nested_config: NestedConfig,
+    nested_config: ResolvedNestedConfig,
     field_name: str,
 ) -> Any:
-    """
-    Validate and convert a nested field value.
-
-    Handles both ID values (when not prefetched) and nested objects/dicts
-    (when prefetched or provided explicitly).
-
-    Args:
-        value: The field value to validate
-        nested_config: NestedConfig instance describing the field
-        field_name: Field name (for error messages)
-
-    Returns:
-        The validated value (either the original ID, nested Serializer instance,
-        or list thereof)
-
-    Raises:
-        ValueError: If validation fails
-
-    Note:
-        Deep nesting protection is handled by Python's recursion limit (~1000 levels).
-        If extremely deep nesting is attempted, Python will raise RecursionError automatically.
-    """
+    """Validate and convert an inferred nested field value."""
     if value is None:
         return None
 
@@ -154,29 +123,24 @@ def validate_nested_field(
 
     if nested_config.many:
         return _validate_many_nested(value, serializer_class, nested_config, field_name)
-    else:
-        return _validate_single_nested(value, serializer_class, nested_config, field_name)
+    return _validate_single_nested(value, serializer_class, field_name)
 
 
 def _validate_single_nested(
     value: Any,
     serializer_class: type[Serializer],
-    config: NestedConfig,
     field_name: str,
 ) -> Any:
-    """Validate a single nested object (no ID fallback)."""
-    # If it's a dict, convert to Serializer instance
+    """Validate a single nested object inferred from the field type."""
     if isinstance(value, dict):
         try:
             return serializer_class(**value)
         except Exception as e:
             raise ValueError(f"{field_name}: Failed to validate nested {serializer_class.__name__}: {e}") from e
 
-    # If it's already a Serializer instance, validate it
     if isinstance(value, serializer_class):
         return value
 
-    # No longer accept plain IDs - use separate serializers for that
     raise ValueError(
         f"{field_name}: Expected {serializer_class.__name__} object or dict, "
         f"got {type(value).__name__}. "
@@ -187,37 +151,33 @@ def _validate_single_nested(
 def _validate_many_nested(
     value: Any,
     serializer_class: type[Serializer],
-    config: NestedConfig,
+    config: ResolvedNestedConfig,
     field_name: str,
 ) -> Any:
-    """Validate a list of nested objects (no ID fallback)."""
+    """Validate a list of nested objects inferred from the field type."""
     if not isinstance(value, list):
-        raise ValueError(f"{field_name}: Expected list for many=True relationship, got {type(value).__name__}")
+        raise ValueError(f"{field_name}: Expected list for nested relationship, got {type(value).__name__}")
 
-    # Security: Check list size to prevent DoS attacks
     if config.max_items is not None and len(value) > config.max_items:
         raise ValueError(
             f"{field_name}: Too many items ({len(value)}). "
             f"Maximum allowed: {config.max_items}. "
             f"This limit prevents resource exhaustion attacks. "
-            f"If you need more items, increase max_items in Nested() configuration."
+            f"If you need more items, increase max_items in Nested(max_items=...) metadata."
         )
 
     result = []
     for idx, item in enumerate(value):
-        # Handle dict values (convert to Serializer)
         if isinstance(item, dict):
             try:
-                result.append(serializer_class(**item))
+                result.append(serializer_class(**cast(dict[str, Any], item)))
             except Exception as e:
                 raise ValueError(
                     f"{field_name}[{idx}]: Failed to validate nested {serializer_class.__name__}: {e}"
                 ) from e
-        # Handle Serializer instances
         elif isinstance(item, serializer_class):
             result.append(item)
         else:
-            # No longer accept plain IDs - use separate serializers for that
             raise ValueError(
                 f"{field_name}[{idx}]: Expected {serializer_class.__name__} object or dict, "
                 f"got {type(item).__name__}. "
@@ -228,23 +188,18 @@ def _validate_many_nested(
 
 
 def is_nested_field(metadata: Any) -> bool:
-    """Check if a field metadata contains NestedConfig."""
-    if isinstance(metadata, NestedConfig):
-        return True
-    # Check if it's in an Annotated type
-    if hasattr(metadata, "__metadata__"):
-        return any(isinstance(m, NestedConfig) for m in metadata.__metadata__)
-    return False
+    """Check if a field type resolves to a nested serializer field."""
+    return resolve_nested_config(metadata) is not None
 
 
 def get_nested_config(metadata: Any) -> NestedConfig | None:
-    """Extract NestedConfig from field metadata."""
+    """Extract Nested() metadata from an Annotated type."""
     if isinstance(metadata, NestedConfig):
         return metadata
 
     if hasattr(metadata, "__metadata__"):
-        for m in metadata.__metadata__:
-            if isinstance(m, NestedConfig):
-                return m
+        for item in metadata.__metadata__:
+            if isinstance(item, NestedConfig):
+                return item
 
     return None

--- a/python/django_bolt/views.py
+++ b/python/django_bolt/views.py
@@ -15,6 +15,7 @@ Example:
             return {"user": current_user.id}
 """
 
+import asyncio
 import inspect
 from collections.abc import Callable
 from typing import Any
@@ -210,6 +211,15 @@ class APIView:
             if hasattr(cls, method) and callable(getattr(cls, method)):
                 allowed.add(method.upper())
         return allowed
+
+
+async def _serialize_many_results(serializer_class: type[Any], items: list[Any]) -> list[Any]:
+    """Serialize already-loaded instances, parallelizing async serializer work when available."""
+    if hasattr(serializer_class, "afrom_model"):
+        return list(await asyncio.gather(*(serializer_class.afrom_model(item) for item in items)))
+
+    fields = getattr(serializer_class, "__annotations__", {})
+    return [msgspec.convert({name: getattr(item, name, None) for name in fields}, serializer_class) for item in items]
 
 
 class ViewSet(APIView):
@@ -560,28 +570,19 @@ class ListMixin:
         if hasattr(self, "filter_queryset"):
             queryset = await self.filter_queryset(queryset)
 
-        # Convert queryset to list (evaluates database query here)
-        results = []
-        async for obj in queryset:
-            # If serializer_class is defined, use it
-            if hasattr(self, "serializer_class") and self.serializer_class:
-                # Get serializer class (use method if available, otherwise direct attribute)
-                if hasattr(self, "get_serializer_class"):
-                    serializer_class = self.get_serializer_class()
-                else:
-                    serializer_class = self.serializer_class
-
-                if hasattr(serializer_class, "afrom_model"):
-                    results.append(await serializer_class.afrom_model(obj))
-                else:
-                    # Assume it's a msgspec.Struct, use convert
-                    fields = getattr(serializer_class, "__annotations__", {})
-                    mapped = {name: getattr(obj, name, None) for name in fields}
-                    results.append(msgspec.convert(mapped, serializer_class))
+        if hasattr(self, "serializer_class") and self.serializer_class:
+            if hasattr(self, "get_serializer_class"):
+                serializer_class = self.get_serializer_class()
             else:
-                results.append(obj)
+                serializer_class = self.serializer_class
+        else:
+            serializer_class = None
 
-        return results
+        items = [obj async for obj in queryset]
+        if serializer_class is None:
+            return items
+
+        return await _serialize_many_results(serializer_class, items)
 
 
 class RetrieveMixin:
@@ -932,18 +933,8 @@ class ModelViewSet(ViewSet):
         qs = await self.filter_queryset(qs)  # Apply filtering (still lazy)
         serializer_class = self.get_serializer_class(action="list")
 
-        # Queryset is evaluated here during iteration
-        results = []
-        async for obj in qs:
-            if hasattr(serializer_class, "afrom_model"):
-                results.append(await serializer_class.afrom_model(obj))
-            else:
-                # Fallback: manual conversion
-                fields = getattr(serializer_class, "__annotations__", {})
-                mapped = {name: getattr(obj, name, None) for name in fields}
-                results.append(msgspec.convert(mapped, serializer_class))
-
-        return results
+        items = [obj async for obj in qs]
+        return await _serialize_many_results(serializer_class, items)
 
     async def retrieve(self, request, **kwargs):
         """

--- a/python/django_bolt/views.py
+++ b/python/django_bolt/views.py
@@ -571,8 +571,8 @@ class ListMixin:
                 else:
                     serializer_class = self.serializer_class
 
-                if hasattr(serializer_class, "from_model"):
-                    results.append(serializer_class.from_model(obj))
+                if hasattr(serializer_class, "afrom_model"):
+                    results.append(await serializer_class.afrom_model(obj))
                 else:
                     # Assume it's a msgspec.Struct, use convert
                     fields = getattr(serializer_class, "__annotations__", {})
@@ -609,8 +609,8 @@ class RetrieveMixin:
             else:
                 serializer_class = self.serializer_class
 
-            if hasattr(serializer_class, "from_model"):
-                return serializer_class.from_model(obj)
+            if hasattr(serializer_class, "afrom_model"):
+                return await serializer_class.afrom_model(obj)
             else:
                 # Assume it's a msgspec.Struct, use convert
                 fields = getattr(serializer_class, "__annotations__", {})
@@ -661,8 +661,8 @@ class CreateMixin:
             else:
                 serializer_class = self.serializer_class
 
-            if hasattr(serializer_class, "from_model"):
-                return serializer_class.from_model(obj)
+            if hasattr(serializer_class, "afrom_model"):
+                return await serializer_class.afrom_model(obj)
             else:
                 fields = getattr(serializer_class, "__annotations__", {})
                 mapped = {name: getattr(obj, name, None) for name in fields}
@@ -712,8 +712,8 @@ class UpdateMixin:
             else:
                 serializer_class = self.serializer_class
 
-            if hasattr(serializer_class, "from_model"):
-                return serializer_class.from_model(obj)
+            if hasattr(serializer_class, "afrom_model"):
+                return await serializer_class.afrom_model(obj)
             else:
                 fields = getattr(serializer_class, "__annotations__", {})
                 mapped = {name: getattr(obj, name, None) for name in fields}
@@ -764,8 +764,8 @@ class PartialUpdateMixin:
             else:
                 serializer_class = self.serializer_class
 
-            if hasattr(serializer_class, "from_model"):
-                return serializer_class.from_model(obj)
+            if hasattr(serializer_class, "afrom_model"):
+                return await serializer_class.afrom_model(obj)
             else:
                 fields = getattr(serializer_class, "__annotations__", {})
                 mapped = {name: getattr(obj, name, None) for name in fields}
@@ -935,8 +935,8 @@ class ModelViewSet(ViewSet):
         # Queryset is evaluated here during iteration
         results = []
         async for obj in qs:
-            if hasattr(serializer_class, "from_model"):
-                results.append(serializer_class.from_model(obj))
+            if hasattr(serializer_class, "afrom_model"):
+                results.append(await serializer_class.afrom_model(obj))
             else:
                 # Fallback: manual conversion
                 fields = getattr(serializer_class, "__annotations__", {})
@@ -959,8 +959,8 @@ class ModelViewSet(ViewSet):
         obj = await self.get_object(**{self.lookup_field: lookup_value})
         serializer_class = self.get_serializer_class(action="retrieve")
 
-        if hasattr(serializer_class, "from_model"):
-            return serializer_class.from_model(obj)
+        if hasattr(serializer_class, "afrom_model"):
+            return await serializer_class.afrom_model(obj)
         else:
             fields = getattr(serializer_class, "__annotations__", {})
             mapped = {name: getattr(obj, name, None) for name in fields}
@@ -993,8 +993,8 @@ class ModelViewSet(ViewSet):
 
         # Serialize response
         serializer_class = self.get_serializer_class(action="create")
-        if hasattr(serializer_class, "from_model"):
-            return serializer_class.from_model(obj)
+        if hasattr(serializer_class, "afrom_model"):
+            return await serializer_class.afrom_model(obj)
         else:
             fields = getattr(serializer_class, "__annotations__", {})
             mapped = {name: getattr(obj, name, None) for name in fields}
@@ -1030,8 +1030,8 @@ class ModelViewSet(ViewSet):
 
         # Serialize response
         serializer_class = self.get_serializer_class(action="update")
-        if hasattr(serializer_class, "from_model"):
-            return serializer_class.from_model(obj)
+        if hasattr(serializer_class, "afrom_model"):
+            return await serializer_class.afrom_model(obj)
         else:
             fields = getattr(serializer_class, "__annotations__", {})
             mapped = {name: getattr(obj, name, None) for name in fields}
@@ -1067,8 +1067,8 @@ class ModelViewSet(ViewSet):
 
         # Serialize response
         serializer_class = self.get_serializer_class(action="partial_update")
-        if hasattr(serializer_class, "from_model"):
-            return serializer_class.from_model(obj)
+        if hasattr(serializer_class, "afrom_model"):
+            return await serializer_class.afrom_model(obj)
         else:
             fields = getattr(serializer_class, "__annotations__", {})
             mapped = {name: getattr(obj, name, None) for name in fields}

--- a/python/example/media/patches/18_patch.txt
+++ b/python/example/media/patches/18_patch.txt
@@ -1,0 +1,1 @@
+patch-bytes

--- a/python/example/missions/api.py
+++ b/python/example/missions/api.py
@@ -140,7 +140,7 @@ async def list_missions(filters: Annotated[MissionFilters, Query()]) -> MissionL
         queryset = queryset.filter(status=filters.status)
     missions: list[MissionResponse] = []
     async for mission in queryset[: filters.limit]:
-        missions.append(MissionResponse.from_model(mission))
+        missions.append(await MissionResponse.afrom_model(mission))
     return MissionListResponse(missions=missions, count=len(missions))
 
 
@@ -149,7 +149,7 @@ async def get_mission(mission_id: int) -> MissionResponse:
     """Get a specific mission by ID."""
     try:
         mission = await Mission.objects.aget(id=mission_id)
-        return MissionResponse.from_model(mission)
+        return await MissionResponse.afrom_model(mission)
     except Mission.DoesNotExist as exc:
         raise NotFound(detail=f"Mission {mission_id} not found") from exc
 
@@ -187,7 +187,7 @@ async def update_mission(mission_id: int, data: UpdateMission) -> MissionRespons
         mission.description = data.description
 
     await mission.asave()
-    return MissionResponse.from_model(mission)
+    return await MissionResponse.afrom_model(mission)
 
 
 @api.delete("/missions/{mission_id}", status_code=204)
@@ -306,7 +306,7 @@ async def list_astronauts(mission_id: int) -> AstronautListResponse:
 
     astronauts: list[AstronautResponse] = []
     async for astronaut in Astronaut.objects.filter(mission=mission):
-        astronauts.append(AstronautResponse.from_model(astronaut))
+        astronauts.append(await AstronautResponse.afrom_model(astronaut))
     return AstronautListResponse(mission=mission.name, astronauts=astronauts)
 
 

--- a/python/example/missions/api.py
+++ b/python/example/missions/api.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
+import os
 from datetime import datetime
 from typing import Annotated, Literal
 
 from msgspec import Meta
 
-from django_bolt import BoltAPI
-from django_bolt.exceptions import NotFound
+from django_bolt import BoltAPI, Request
+from django_bolt.exceptions import HTTPException, NotFound
 from django_bolt.param_functions import Cookie, File, Form, Header, Query
-from django_bolt.serializers import Serializer, field_validator
+from django_bolt.responses import HTML, PlainText, Redirect
+from django_bolt.serializers import Serializer, field, field_validator
+from django_bolt.shortcuts import render
 from missions.models import Astronaut, Mission
 
 api = BoltAPI()
@@ -41,11 +44,66 @@ class MissionResponse(Serializer):
     description: str = ""
 
 
+class MissionListResponse(Serializer):
+    missions: list[MissionResponse]
+    count: int
+
+
+class MissionCreatedResponse(Serializer):
+    id: int
+    name: str
+    status: str
+    message: str
+
+
 class AstronautResponse(Serializer):
     id: int
     name: str
     role: str
     mission_id: int
+
+
+class AstronautCreatedResponse(Serializer):
+    id: int
+    name: str
+    role: str
+    mission: str = field(source="mission.name")
+
+
+class AstronautListResponse(Serializer):
+    mission: str
+    astronauts: list[AstronautResponse]
+
+
+class UploadedDocumentResponse(Serializer):
+    filename: str | None = None
+    content_type: str | None = None
+    size: int | None = None
+
+
+class MissionDocumentsResponse(Serializer):
+    mission: str
+    title: str
+    documents: list[UploadedDocumentResponse]
+    count: int
+
+
+class SecureMissionResponse(Serializer):
+    api_key: str
+    request_id: str | None = None
+    message: str
+
+
+class PreferencesResponse(Serializer):
+    theme: str
+    language: str
+
+
+class MissionReportResponse(Serializer):
+    mission: str
+    title: str
+    summary: str
+    attachments: int
 
 
 # Query parameter model for filtering missions
@@ -67,43 +125,37 @@ class CreateAstronaut(Serializer):
         return value
 
 
+@api.get("/mission-control")
+async def mission_control_status():
+    """Simple status endpoint for the missions example app."""
+    return {"status": "operational", "message": "Mission Control Online"}
+
+
 # Endpoints
 @api.get("/missions")
-async def list_missions(filters: Annotated[MissionFilters, Query()]):
+async def list_missions(filters: Annotated[MissionFilters, Query()]) -> MissionListResponse:
     """List all missions with optional filtering."""
     queryset = Mission.objects.all()
     if filters.status:
         queryset = queryset.filter(status=filters.status)
-    missions = []
+    missions: list[MissionResponse] = []
     async for mission in queryset[: filters.limit]:
-        missions.append(
-            {
-                "id": mission.id,
-                "name": mission.name,
-                "status": mission.status,
-            }
-        )
-    return {"missions": missions, "count": len(missions)}
+        missions.append(MissionResponse.from_model(mission))
+    return MissionListResponse(missions=missions, count=len(missions))
 
 
 @api.get("/missions/{mission_id}")
-async def get_mission(mission_id: int):
+async def get_mission(mission_id: int) -> MissionResponse:
     """Get a specific mission by ID."""
     try:
         mission = await Mission.objects.aget(id=mission_id)
-        return {
-            "id": mission.id,
-            "name": mission.name,
-            "status": mission.status,
-            "launch_date": str(mission.launch_date) if mission.launch_date else None,
-            "description": mission.description,
-        }
-    except Mission.DoesNotExist:
-        raise NotFound(detail=f"Mission {mission_id} not found")
+        return MissionResponse.from_model(mission)
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
 
 
 @api.post("/missions")
-async def create_mission(mission: CreateMission):
+async def create_mission(mission: CreateMission) -> MissionCreatedResponse:
     """Create a new mission."""
     new_mission = await Mission.objects.acreate(
         name=mission.name,
@@ -111,21 +163,21 @@ async def create_mission(mission: CreateMission):
         launch_date=mission.launch_date,
         status="planned",
     )
-    return {
-        "id": new_mission.id,
-        "name": new_mission.name,
-        "status": new_mission.status,
-        "message": "Mission created successfully",
-    }
+    return MissionCreatedResponse(
+        id=new_mission.id,
+        name=new_mission.name,
+        status=new_mission.status,
+        message="Mission created successfully",
+    )
 
 
 @api.put("/missions/{mission_id}")
-async def update_mission(mission_id: int, data: UpdateMission):
+async def update_mission(mission_id: int, data: UpdateMission) -> MissionResponse:
     """Update a mission."""
     try:
         mission = await Mission.objects.aget(id=mission_id)
-    except Mission.DoesNotExist:
-        raise NotFound(detail=f"Mission {mission_id} not found")
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
 
     if data.name is not None:
         mission.name = data.name
@@ -135,7 +187,7 @@ async def update_mission(mission_id: int, data: UpdateMission):
         mission.description = data.description
 
     await mission.asave()
-    return {"id": mission.id, "name": mission.name, "status": mission.status}
+    return MissionResponse.from_model(mission)
 
 
 @api.delete("/missions/{mission_id}", status_code=204)
@@ -143,10 +195,85 @@ async def delete_mission(mission_id: int):
     """Delete a mission."""
     try:
         mission = await Mission.objects.aget(id=mission_id)
-    except Mission.DoesNotExist:
-        raise NotFound(detail=f"Mission {mission_id} not found")
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
 
     await mission.adelete()
+
+
+@api.get("/missions/{mission_id}/classified")
+async def get_classified_info(
+    mission_id: int,
+    clearance: Annotated[str, Header(alias="X-Clearance-Level")],
+):
+    """Return protected mission metadata when the caller has clearance."""
+    if clearance not in ["top-secret", "confidential"]:
+        raise HTTPException(status_code=403, detail="Insufficient clearance level")
+
+    try:
+        mission = await Mission.objects.aget(id=mission_id)
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
+
+    return {
+        "mission": mission.name,
+        "classified_data": "Launch codes: APOLLO-7749-OMEGA",
+        "clearance_verified": clearance,
+    }
+
+
+@api.get("/missions/{mission_id}/log")
+async def get_mission_log(mission_id: int):
+    """Return a plain-text mission log."""
+    try:
+        mission = await Mission.objects.aget(id=mission_id)
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
+
+    log = f"""
+=== MISSION LOG: {mission.name} ===
+Status: {mission.status.upper()}
+Launch Date: {mission.launch_date or 'TBD'}
+Description: {mission.description or 'No description'}
+================================
+    """.strip()
+
+    return PlainText(log)
+
+
+@api.post("/missions/{mission_id}/patch")
+async def upload_mission_patch(
+    mission_id: int,
+    patch: Annotated[list[dict], File(alias="patch")],
+):
+    """Upload and persist a mission patch image."""
+    try:
+        mission = await Mission.objects.aget(id=mission_id)
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
+
+    if not patch:
+        raise HTTPException(status_code=400, detail="No file uploaded")
+
+    file_info = patch[0]
+    filename = file_info.get("filename", "patch.png")
+    content = file_info.get("content", b"")
+    size = file_info.get("size", 0)
+
+    save_path = f"media/patches/{mission_id}_{filename}"
+    os.makedirs("media/patches", exist_ok=True)
+    with open(save_path, "wb") as patch_file:
+        patch_file.write(content)
+
+    mission.patch_image = save_path
+    await mission.asave()
+
+    return {
+        "message": "Mission patch uploaded successfully",
+        "filename": filename,
+        "size": size,
+        "mission": mission.name,
+    }
 
 
 # Astronaut endpoints
@@ -154,44 +281,33 @@ async def delete_mission(mission_id: int):
 async def add_astronaut(
     mission_id: int,
     data: Annotated[CreateAstronaut, Form()],
-):
+) -> AstronautCreatedResponse:
     """Add an astronaut to a mission."""
     try:
         mission = await Mission.objects.aget(id=mission_id)
-    except Mission.DoesNotExist:
-        raise NotFound(detail=f"Mission {mission_id} not found")
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
 
     astronaut = await Astronaut.objects.acreate(
         name=data.name,
         role=data.role,
         mission=mission,
     )
-    return {
-        "id": astronaut.id,
-        "name": astronaut.name,
-        "role": astronaut.role,
-        "mission": mission.name,
-    }
+    return await AstronautCreatedResponse.afrom_model(astronaut)
 
 
 @api.get("/missions/{mission_id}/astronauts")
-async def list_astronauts(mission_id: int):
+async def list_astronauts(mission_id: int) -> AstronautListResponse:
     """List all astronauts for a mission."""
     try:
         mission = await Mission.objects.aget(id=mission_id)
-    except Mission.DoesNotExist:
-        raise NotFound(detail=f"Mission {mission_id} not found")
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
 
-    astronauts = []
+    astronauts: list[AstronautResponse] = []
     async for astronaut in Astronaut.objects.filter(mission=mission):
-        astronauts.append(
-            {
-                "id": astronaut.id,
-                "name": astronaut.name,
-                "role": astronaut.role,
-            }
-        )
-    return {"mission": mission.name, "astronauts": astronauts}
+        astronauts.append(AstronautResponse.from_model(astronaut))
+    return AstronautListResponse(mission=mission.name, astronauts=astronauts)
 
 
 # Header model for API metadata
@@ -212,50 +328,47 @@ async def upload_document(
     mission_id: int,
     title: Annotated[str, Form()],
     files: Annotated[list[dict], File(alias="file")],
-):
+) -> MissionDocumentsResponse:
     """Upload documents for a mission."""
     try:
         mission = await Mission.objects.aget(id=mission_id)
-    except Mission.DoesNotExist:
-        raise NotFound(detail=f"Mission {mission_id} not found")
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
 
-    uploaded = []
+    uploaded: list[UploadedDocumentResponse] = []
     for f in files:
         uploaded.append(
-            {
-                "filename": f.get("filename"),
-                "content_type": f.get("content_type"),
-                "size": f.get("size"),
-            }
+            UploadedDocumentResponse(
+                filename=f.get("filename"),
+                content_type=f.get("content_type"),
+                size=f.get("size"),
+            )
         )
 
-    return {
-        "mission": mission.name,
-        "title": title,
-        "documents": uploaded,
-        "count": len(uploaded),
-    }
+    return MissionDocumentsResponse(
+        mission=mission.name,
+        title=title,
+        documents=uploaded,
+        count=len(uploaded),
+    )
 
 
 # Header struct endpoint
 @api.get("/missions/secure")
-async def secure_endpoint(headers: Annotated[APIHeaders, Header()]):
+async def secure_endpoint(headers: Annotated[APIHeaders, Header()]) -> SecureMissionResponse:
     """Endpoint requiring API key header."""
-    return {
-        "api_key": headers.x_api_key,
-        "request_id": headers.x_request_id,
-        "message": "Access granted",
-    }
+    return SecureMissionResponse(
+        api_key=headers.x_api_key,
+        request_id=headers.x_request_id,
+        message="Access granted",
+    )
 
 
 # Cookie struct endpoint
 @api.get("/missions/preferences")
-async def get_preferences(cookies: Annotated[UserPreferences, Cookie()]):
+async def get_preferences(cookies: Annotated[UserPreferences, Cookie()]) -> PreferencesResponse:
     """Get user preferences from cookies."""
-    return {
-        "theme": cookies.theme,
-        "language": cookies.language,
-    }
+    return PreferencesResponse(theme=cookies.theme, language=cookies.language)
 
 
 # Mixed form and file upload
@@ -265,18 +378,46 @@ async def submit_report(
     title: Annotated[str, Form()],
     summary: Annotated[str, Form()] = "",
     attachments: Annotated[list[dict], File(alias="file")] = None,
-):
+) -> MissionReportResponse:
     """Submit a mission report with optional attachments."""
     if attachments is None:
         attachments = []
     try:
         mission = await Mission.objects.aget(id=mission_id)
-    except Mission.DoesNotExist:
-        raise NotFound(detail=f"Mission {mission_id} not found")
+    except Mission.DoesNotExist as exc:
+        raise NotFound(detail=f"Mission {mission_id} not found") from exc
 
-    return {
-        "mission": mission.name,
-        "title": title,
-        "summary": summary,
-        "attachments": len(attachments),
-    }
+    return MissionReportResponse(
+        mission=mission.name,
+        title=title,
+        summary=summary,
+        attachments=len(attachments),
+    )
+
+
+@api.get("/status-page")
+async def status_page():
+    """Return a simple HTML status page."""
+    return HTML("<h1>Mission Control: All Systems Operational</h1>")
+
+
+@api.get("/go")
+async def go_to_dashboard():
+    """Redirect to the missions dashboard."""
+    return Redirect("/dashboard")
+
+
+@api.get("/dashboard")
+async def mission_dashboard(request: Request):
+    """Render a small dashboard using a Django template."""
+    missions = []
+    async for mission in Mission.objects.all()[:20]:
+        missions.append(
+            {
+                "name": mission.name,
+                "status": mission.status,
+                "description": mission.description,
+            }
+        )
+
+    return render(request, "missions/dashboard.html", {"missions": missions})

--- a/python/example/missions/templates/missions/dashboard.html
+++ b/python/example/missions/templates/missions/dashboard.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mission Dashboard</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; background: #1a1a2e; color: #eee; }
+        h1 { color: #00d4ff; }
+        .mission { background: #16213e; padding: 15px; margin: 10px 0; border-radius: 8px; }
+        .status { display: inline-block; padding: 4px 8px; border-radius: 4px; font-size: 12px; }
+        .planned { background: #ffc107; color: #000; }
+        .active { background: #28a745; }
+        .completed { background: #6c757d; }
+        .aborted { background: #dc3545; }
+    </style>
+</head>
+<body>
+    <h1>Mission Dashboard</h1>
+    <p>Total missions: {{ missions|length }}</p>
+    {% for mission in missions %}
+    <div class="mission">
+        <strong>{{ mission.name }}</strong>
+        <span class="status {{ mission.status }}">{{ mission.status|upper }}</span>
+        <p>{{ mission.description|default:"No description" }}</p>
+    </div>
+    {% empty %}
+    <p>No missions found.</p>
+    {% endfor %}
+</body>
+</html>

--- a/python/example/missions/tests.py
+++ b/python/example/missions/tests.py
@@ -326,3 +326,71 @@ class TestCookieStructEndpoints:
         data = response.json()
         assert data["theme"] == "dark"
         assert data["language"] == "en"
+
+
+@pytest.mark.django_db(transaction=True)
+class TestAdditionalMissionRoutes:
+    """Test tutorial-style routes that are also exposed in the example app."""
+
+    def test_mission_control_status(self, client):
+        """GET /mission-control returns the mission status payload."""
+        response = client.get("/mission-control")
+        assert response.status_code == 200
+        assert response.json() == {"status": "operational", "message": "Mission Control Online"}
+
+    def test_classified_endpoint_requires_clearance(self, client):
+        """GET /missions/{id}/classified enforces the header guard."""
+        mission = Mission.objects.create(name="Secret Mission", status="planned")
+
+        denied = client.get(f"/missions/{mission.id}/classified", headers={"X-Clearance-Level": "public"})
+        assert denied.status_code == 403
+
+        allowed = client.get(
+            f"/missions/{mission.id}/classified",
+            headers={"X-Clearance-Level": "top-secret"},
+        )
+        assert allowed.status_code == 200
+        assert allowed.json()["mission"] == "Secret Mission"
+
+    def test_mission_log_returns_plain_text(self, client):
+        """GET /missions/{id}/log returns a text log."""
+        mission = Mission.objects.create(name="Apollo 11", status="active")
+
+        response = client.get(f"/missions/{mission.id}/log")
+        assert response.status_code == 200
+        assert "MISSION LOG: Apollo 11" in response.text
+        assert response.headers["content-type"].startswith("text/plain")
+
+    def test_upload_patch_persists_filename(self, client):
+        """POST /missions/{id}/patch stores the patch path and returns metadata."""
+        mission = Mission.objects.create(name="Patch Test", status="planned")
+
+        response = client.post(
+            f"/missions/{mission.id}/patch",
+            files={"patch": ("patch.txt", b"patch-bytes", "text/plain")},
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["filename"] == "patch.txt"
+        assert payload["mission"] == "Patch Test"
+
+        mission.refresh_from_db()
+        assert mission.patch_image.endswith("patch.txt")
+
+    def test_status_page_and_dashboard_render_html(self, client):
+        """HTML routes should render successfully."""
+        Mission.objects.create(name="Dashboard Mission", status="active", description="Visible in template")
+
+        status_page = client.get("/status-page")
+        assert status_page.status_code == 200
+        assert "Mission Control" in status_page.text
+
+        dashboard = client.get("/dashboard")
+        assert dashboard.status_code == 200
+        assert "Dashboard Mission" in dashboard.text
+
+    def test_go_redirects_to_dashboard(self, client):
+        """GET /go redirects to /dashboard."""
+        response = client.get("/go", follow_redirects=False)
+        assert response.status_code == 307
+        assert response.headers["location"] == "/dashboard"

--- a/python/example/users/api.py
+++ b/python/example/users/api.py
@@ -418,7 +418,7 @@ class UserPaginatedViewSet(ViewSet):
     async def retrieve(self, request, id: int) -> UserDetailSerializer:
         """Retrieve a single user by ID (not paginated)."""
         user = await self.get_object(id=id)
-        return UserDetailSerializer.from_model(user)
+        return await UserDetailSerializer.afrom_model(user)
 
 
 # ----------------------------------------------------------------------------

--- a/python/tests/serializers/t.py
+++ b/python/tests/serializers/t.py
@@ -66,8 +66,8 @@ class ProductSerializer(Serializer):
     tags: list[str] = field(default_factory=list)
 
     # Nested serializers
-    author: Annotated[AuthorSerializer | None, Nested(AuthorSerializer)] = None
-    related: Annotated[list[TagSerializer], Nested(TagSerializer, many=True)] = field(default_factory=list)
+    author: AuthorSerializer | None = None
+    related: list[TagSerializer] = field(default_factory=list)
 
     class Config:
         read_only = {"id"}

--- a/python/tests/serializers/test_api_integration.py
+++ b/python/tests/serializers/test_api_integration.py
@@ -27,7 +27,6 @@ from django_bolt.api import BoltAPI
 from django_bolt.exceptions import BadRequest
 from django_bolt.serializers import (
     Email,
-    Nested,
     NonEmptyStr,
     Serializer,
     computed_field,
@@ -77,7 +76,7 @@ class CommentSerializer(Serializer):
     id: int
     text: str
     # Author as full object
-    author: Annotated[AuthorSerializer, Nested(AuthorSerializer)]
+    author: AuthorSerializer
 
 
 class BlogPostSerializer(Serializer):
@@ -87,9 +86,9 @@ class BlogPostSerializer(Serializer):
     title: str
     content: str
     # Author relationship - full object required
-    author: Annotated[AuthorSerializer, Nested(AuthorSerializer)]
+    author: AuthorSerializer
     # Tags relationship - full objects required
-    tags: Annotated[list[TagSerializer], Nested(TagSerializer, many=True)]
+    tags: list[TagSerializer]
     published: bool = False
 
 
@@ -99,8 +98,8 @@ class BlogPostInputSerializer(Serializer):
     title: str
     content: str
     # For input, we accept full nested objects (msgspec can decode these)
-    author: Annotated[AuthorSerializer, Nested(AuthorSerializer)]
-    tags: Annotated[list[TagSerializer], Nested(TagSerializer, many=True)]
+    author: AuthorSerializer
+    tags: list[TagSerializer]
     published: bool = False
 
 
@@ -110,10 +109,10 @@ class BlogPostDetailedSerializer(Serializer):
     id: int
     title: str
     content: str
-    author: Annotated[AuthorSerializer, Nested(AuthorSerializer)]
-    tags: Annotated[list[TagSerializer], Nested(TagSerializer, many=True)]
+    author: AuthorSerializer
+    tags: list[TagSerializer]
     # Comments nested with their own nested authors
-    comments: Annotated[list[CommentSerializer], Nested(CommentSerializer, many=True)]
+    comments: list[CommentSerializer]
     published: bool = False
 
 
@@ -122,10 +121,10 @@ class BlogPostDetailedInputSerializer(Serializer):
 
     title: str
     content: str
-    author: Annotated[AuthorSerializer, Nested(AuthorSerializer)]
-    tags: Annotated[list[TagSerializer], Nested(TagSerializer, many=True)]
+    author: AuthorSerializer
+    tags: list[TagSerializer]
     # Comments nested with their own nested authors
-    comments: Annotated[list[CommentSerializer], Nested(CommentSerializer, many=True)]
+    comments: list[CommentSerializer]
     published: bool = False
 
 
@@ -211,6 +210,7 @@ def create_post_with_tags(data: BlogPostInputSerializer):
     if tag_ids:
         post.tags.set(tag_ids)
 
+    post = BlogPost.objects.select_related("author").prefetch_related("tags").get(id=post.id)
     return BlogPostSerializer.from_model(post)
 
 
@@ -269,6 +269,7 @@ def create_post_full(data: BlogPostDetailedInputSerializer):
             text=comment_data.text,
         )
 
+    post = BlogPost.objects.select_related("author").prefetch_related("tags", "comments__author").get(id=post.id)
     return BlogPostDetailedSerializer.from_model(post)
 
 
@@ -284,9 +285,9 @@ class BlogPostCreateSerializer(Serializer):
     title: Annotated[str, Meta(min_length=3)]
     content: Annotated[str, Meta(min_length=10)]
     # Author must be a full object, not just ID
-    author: Annotated[AuthorSerializer, Nested(AuthorSerializer)]
+    author: AuthorSerializer
     # Tags must be full objects for input
-    tags: Annotated[list[TagSerializer], Nested(TagSerializer, many=True)]
+    tags: list[TagSerializer]
     published: bool = False
 
     @field_validator("title")
@@ -330,6 +331,7 @@ def create_post_strict(data: BlogPostCreateSerializer):
     if tag_ids:
         post.tags.set(tag_ids)
 
+    post = BlogPost.objects.select_related("author").prefetch_related("tags").get(id=post.id)
     return BlogPostSerializer.from_model(post)
 
 
@@ -803,7 +805,7 @@ class UserProfileSerializer(Serializer):
     """Serializer for user profile with nested user data - OUTPUT."""
 
     id: int
-    user: Annotated[UserSerializer, Nested(UserSerializer)]
+    user: UserSerializer
     bio: Annotated[str, Meta(max_length=500)] = ""
     avatar_url: str = ""
     phone: Annotated[str, Meta(max_length=20)] = ""
@@ -1062,7 +1064,7 @@ class AdvancedCommentSerializer(Serializer):
 
     id: int
     text: str
-    author: Annotated[AdvancedAuthorSerializer, Nested(AdvancedAuthorSerializer)]
+    author: AdvancedAuthorSerializer
     created_at: datetime | None = None
 
     @computed_field
@@ -1080,9 +1082,9 @@ class AdvancedBlogPostSerializer(Serializer):
     id: int
     title: NonEmptyStr
     content: str
-    author: Annotated[AdvancedAuthorSerializer, Nested(AdvancedAuthorSerializer)]
-    tags: Annotated[list[AdvancedTagSerializer], Nested(AdvancedTagSerializer, many=True)]
-    comments: Annotated[list[AdvancedCommentSerializer], Nested(AdvancedCommentSerializer, many=True)] = []
+    author: AdvancedAuthorSerializer
+    tags: list[AdvancedTagSerializer]
+    comments: list[AdvancedCommentSerializer] = []
     published: bool = False
     created_at: datetime | None = None
     updated_at: datetime | None = None
@@ -1144,8 +1146,8 @@ class AdvancedBlogPostInputSerializer(Serializer):
 
     title: Annotated[str, Meta(min_length=3, max_length=300)]
     content: Annotated[str, Meta(min_length=10)]
-    author: Annotated[AdvancedAuthorSerializer, Nested(AdvancedAuthorSerializer)]
-    tags: Annotated[list[AdvancedTagSerializer], Nested(AdvancedTagSerializer, many=True)] = []
+    author: AdvancedAuthorSerializer
+    tags: list[AdvancedTagSerializer] = []
     published: bool = False
 
     @field_validator("title")

--- a/python/tests/serializers/test_django_integration.py
+++ b/python/tests/serializers/test_django_integration.py
@@ -32,7 +32,6 @@ from django_bolt.serializers import (
     URL,
     Email,
     Meta,
-    Nested,
     NonEmptyStr,
     PositiveInt,
     Serializer,
@@ -84,7 +83,7 @@ class CommentSerializer(Serializer):
 
     id: int
     text: str
-    author: Annotated[AuthorSerializer, Nested(AuthorSerializer)]
+    author: AuthorSerializer
     created_at: datetime
 
 
@@ -94,9 +93,9 @@ class BlogPostSerializer(Serializer):
     id: int
     title: NonEmptyStr
     content: str
-    author: Annotated[AuthorSerializer, Nested(AuthorSerializer)]
-    tags: Annotated[list[TagSerializer], Nested(TagSerializer, many=True)]
-    comments: Annotated[list[CommentSerializer], Nested(CommentSerializer, many=True)] = []
+    author: AuthorSerializer
+    tags: list[TagSerializer]
+    comments: list[CommentSerializer] = []
     published: bool = False
     created_at: datetime | None = None
     updated_at: datetime | None = None
@@ -155,7 +154,7 @@ class UserProfileSerializer(Serializer):
     """User profile serializer with nested user."""
 
     id: int
-    user: Annotated[UserSerializer, Nested(UserSerializer)]
+    user: UserSerializer
     bio: str = ""
     avatar_url: URL | None = None
     phone: str = ""
@@ -1320,7 +1319,7 @@ class ComprehensiveProductSerializer(Serializer):
     5. @field_validator decorator for field-level validation/transformation
     6. @model_validator decorator for cross-field validation
     7. @computed_field decorator for calculated output fields
-    8. Nested serializers with Nested() annotation (single and many=True)
+    8. Nested serializers inferred from serializer type hints
     9. Meta class configuration (write_only, read_only, field_sets)
     10. Dynamic field selection (only, exclude, use)
     11. Type-safe subsets (subset, fields)
@@ -1398,12 +1397,12 @@ class ComprehensiveProductSerializer(Serializer):
     # -------------------------------------------------------------------------
     # 12. Nested serializer (single object - ForeignKey equivalent)
     # -------------------------------------------------------------------------
-    supplier: Annotated[AuthorSerializer | None, Nested(AuthorSerializer)] = None
+    supplier: AuthorSerializer | None = None
 
     # -------------------------------------------------------------------------
-    # 13. Nested serializer with many=True (ManyToMany equivalent)
+    # 13. Nested serializer list (ManyToMany equivalent)
     # -------------------------------------------------------------------------
-    related_tags: Annotated[list[TagSerializer], Nested(TagSerializer, many=True)] = field(default_factory=list)
+    related_tags: list[TagSerializer] = field(default_factory=list)
 
     # -------------------------------------------------------------------------
     # Config class configuration

--- a/python/tests/serializers/test_django_integration.py
+++ b/python/tests/serializers/test_django_integration.py
@@ -1092,6 +1092,35 @@ class TestCreateSerializerHelpersWithDjango:
         assert "is_active" in UserSerializer.__annotations__
 
     @pytest.mark.django_db
+    def test_create_serializer_config_applies_end_to_end(self):
+        """Test create_serializer uses Config metadata for model mapping and dump behavior."""
+        UserGeneratedSerializer = create_serializer(
+            User,
+            fields=["id", "username", "email", "password_hash", "created_at"],
+            write_only={"password_hash"},
+            read_only={"id", "created_at"},
+            serializer_name="UserGeneratedSerializer",
+        )
+
+        user = User.objects.create(
+            username="helperuser",
+            email="helper@example.com",
+            password_hash="super-secret",
+        )
+
+        serializer = UserGeneratedSerializer.from_model(user)
+        dumped = serializer.dump()
+
+        assert UserGeneratedSerializer.Config.model is User
+        assert UserGeneratedSerializer.__write_only_fields__ == frozenset({"password_hash"})
+        assert UserGeneratedSerializer.__read_only_fields__ == frozenset({"id", "created_at"})
+        assert dumped["id"] == user.id
+        assert dumped["username"] == "helperuser"
+        assert dumped["email"] == "helper@example.com"
+        assert "created_at" in dumped
+        assert "password_hash" not in dumped
+
+    @pytest.mark.django_db
     def test_create_serializer_set_with_django(self):
         """Test create_serializer_set with Django model."""
         from django.contrib.auth.models import User as DjangoUser  # noqa: PLC0415

--- a/python/tests/serializers/test_from_model_relations.py
+++ b/python/tests/serializers/test_from_model_relations.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import pytest
+from msgspec import structs as msgspec_structs
+
+from django_bolt.exceptions import SerializationError
+from django_bolt.serializers import Serializer, field
+from tests.test_models import Author, BlogPost, Comment, User, UserProfile
+
+
+class BlogPostMiniSerializer(Serializer):
+    id: int
+    title: str
+
+
+class CommentMiniSerializer(Serializer):
+    id: int
+    text: str
+
+
+class UserMiniSerializer(Serializer):
+    id: int
+    username: str
+
+
+class AuthorWithPlainPostsSerializer(Serializer):
+    id: int
+    name: str
+    posts: list[BlogPostMiniSerializer] = field(default_factory=list)
+
+
+class AuthorWithRequiredPostsSerializer(Serializer):
+    id: int
+    name: str
+    posts: list[BlogPostMiniSerializer]
+
+
+class BlogPostWithCommentsSerializer(Serializer):
+    id: int
+    title: str
+    comments: list[CommentMiniSerializer] = field(
+        default_factory=list
+    )
+
+
+class UserProfileOutputSerializer(Serializer):
+    id: int
+    bio: str
+    user: UserMiniSerializer
+
+
+class UserWithProfileBioSerializer(Serializer):
+    id: int
+    username: str
+    profile_bio: str | None = field(source="profile.bio", default=None)
+
+
+@pytest.mark.django_db
+def test_from_model_plain_reverse_relation_prefetched_returns_nested_list():
+    author = Author.objects.create(name="Alice", email="alice@example.com")
+    BlogPost.objects.create(title="Post 1", content="One", author=author)
+    BlogPost.objects.create(title="Post 2", content="Two", author=author)
+
+    author = Author.objects.prefetch_related("posts").get(id=author.id)
+    serializer = AuthorWithPlainPostsSerializer.from_model(author)
+
+    assert len(serializer.posts) == 2
+    assert all(isinstance(post, BlogPostMiniSerializer) for post in serializer.posts)
+    assert {post.title for post in serializer.posts} == {"Post 1", "Post 2"}
+
+
+@pytest.mark.django_db
+def test_from_model_plain_reverse_relation_unprefetched_uses_default():
+    author = Author.objects.create(name="Alice", email="alice@example.com")
+    BlogPost.objects.create(title="Post 1", content="One", author=author)
+
+    author = Author.objects.get(id=author.id)
+    serializer = AuthorWithPlainPostsSerializer.from_model(author)
+
+    assert serializer.posts == []
+
+
+@pytest.mark.django_db
+def test_from_model_required_unloaded_reverse_relation_raises_serialization_error():
+    author = Author.objects.create(name="Alice", email="alice@example.com")
+    BlogPost.objects.create(title="Post 1", content="One", author=author)
+
+    author = Author.objects.get(id=author.id)
+
+    with pytest.raises(SerializationError) as exc_info:
+        AuthorWithRequiredPostsSerializer.from_model(author)
+
+    error_message = str(exc_info.value)
+    assert "posts" in error_message
+    assert "prefetch_related('posts')" in error_message
+    assert "afrom_model" in error_message
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_afrom_model_plain_reverse_relation_lazy_loads():
+    author = await Author.objects.acreate(name="Alice", email="alice@example.com")
+    await BlogPost.objects.acreate(title="Post 1", content="One", author=author)
+    await BlogPost.objects.acreate(title="Post 2", content="Two", author=author)
+
+    author = await Author.objects.aget(id=author.id)
+    serializer = await AuthorWithPlainPostsSerializer.afrom_model(author)
+
+    assert len(serializer.posts) == 2
+    assert all(isinstance(post, BlogPostMiniSerializer) for post in serializer.posts)
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_afrom_model_nested_many_lazy_loads_for_reverse_fk():
+    author = await Author.objects.acreate(name="Alice", email="alice@example.com")
+    post = await BlogPost.objects.acreate(title="Post 1", content="One", author=author)
+    commenter = await Author.objects.acreate(name="Bob", email="bob@example.com")
+    await Comment.objects.acreate(post=post, author=commenter, text="Nice post")
+
+    post = await BlogPost.objects.aget(id=post.id)
+    comments_serializer = await BlogPostWithCommentsSerializer.afrom_model(post)
+
+    assert len(comments_serializer.comments) == 1
+    assert isinstance(comments_serializer.comments[0], CommentMiniSerializer)
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_afrom_model_lazy_loads_forward_fk_and_source_paths():
+    user = await User.objects.acreate(
+        username="alice",
+        email="alice@example.com",
+        password_hash="hash",
+    )
+    profile = await UserProfile.objects.acreate(user=user, bio="Hello", location="Earth")
+
+    profile = await UserProfile.objects.aget(id=profile.id)
+    profile_serializer = await UserProfileOutputSerializer.afrom_model(profile)
+    user = await User.objects.aget(id=user.id)
+    user_serializer = await UserWithProfileBioSerializer.afrom_model(user)
+
+    assert isinstance(profile_serializer.user, UserMiniSerializer)
+    assert profile_serializer.user.username == "alice"
+    assert user_serializer.profile_bio == "Hello"
+
+
+@pytest.mark.django_db
+def test_from_model_unloaded_source_path_uses_default_without_querying():
+    user = User.objects.create(
+        username="alice",
+        email="alice@example.com",
+        password_hash="hash",
+    )
+    UserProfile.objects.create(user=user, bio="Hello", location="Earth")
+
+    user = User.objects.get(id=user.id)
+    serializer = UserWithProfileBioSerializer.from_model(user)
+
+    assert serializer.profile_bio is None
+
+
+@pytest.mark.django_db
+def test_dump_fails_fast_when_manager_leaks_into_serializer_state():
+    author = Author.objects.create(name="Alice", email="alice@example.com")
+    serializer = AuthorWithPlainPostsSerializer(id=1, name="Alice")
+
+    # Simulate a broken serializer state caused by bypassing from_model().
+    msgspec_structs.force_setattr(serializer, "posts", author.posts)
+
+    with pytest.raises(SerializationError) as exc_info:
+        serializer.dump()
+
+    assert "Serialize Django relations with from_model()/afrom_model()" in str(exc_info.value)

--- a/python/tests/serializers/test_from_model_relations.py
+++ b/python/tests/serializers/test_from_model_relations.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from msgspec import structs as msgspec_structs
 
@@ -21,6 +23,11 @@ class CommentMiniSerializer(Serializer):
 class UserMiniSerializer(Serializer):
     id: int
     username: str
+
+
+class AuthorMiniSerializer(Serializer):
+    id: int
+    name: str
 
 
 class AuthorWithPlainPostsSerializer(Serializer):
@@ -49,10 +56,34 @@ class UserProfileOutputSerializer(Serializer):
     user: UserMiniSerializer
 
 
+class UserProfileMiniSerializer(Serializer):
+    id: int
+    bio: str
+
+
 class UserWithProfileBioSerializer(Serializer):
     id: int
     username: str
     profile_bio: str | None = field(source="profile.bio", default=None)
+
+
+class UserWithProfileSerializer(Serializer):
+    id: int
+    username: str
+    profile: UserProfileMiniSerializer
+    profile_bio: str | None = field(source="profile.bio", default=None)
+
+
+class BlogPostWithAuthorAndCommentsSerializer(Serializer):
+    id: int
+    title: str
+    author: AuthorMiniSerializer
+    comments: list[CommentMiniSerializer] = field(default_factory=list)
+
+
+class AuthorPostIdsSerializer(Serializer):
+    id: int
+    post_ids: list[int] = field(default_factory=list)
 
 
 @pytest.mark.django_db
@@ -145,6 +176,75 @@ async def test_afrom_model_lazy_loads_forward_fk_and_source_paths():
     assert user_serializer.profile_bio == "Hello"
 
 
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_afrom_model_reuses_inflight_relation_load_for_shared_source_path(monkeypatch):
+    user = await User.objects.acreate(
+        username="alice",
+        email="alice@example.com",
+        password_hash="hash",
+    )
+    await UserProfile.objects.acreate(user=user, bio="Hello", location="Earth")
+
+    user = await User.objects.aget(id=user.id)
+    original_loader = Serializer._load_relation_async.__func__
+    load_calls: list[str] = []
+
+    async def tracked_loader(cls, obj, relation):
+        if obj.__class__ is User and obj.pk == user.pk:
+            load_calls.append(relation.name)
+        return await original_loader(cls, obj, relation)
+
+    monkeypatch.setattr(
+        UserWithProfileSerializer,
+        "_load_relation_async",
+        classmethod(tracked_loader),
+    )
+
+    serializer = await UserWithProfileSerializer.afrom_model(user)
+
+    assert serializer.profile.bio == "Hello"
+    assert serializer.profile_bio == "Hello"
+    assert load_calls == ["profile"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_afrom_model_loads_multiple_unloaded_relations_concurrently(monkeypatch):
+    author = await Author.objects.acreate(name="Alice", email="alice@example.com")
+    post = await BlogPost.objects.acreate(title="Post 1", content="One", author=author)
+    commenter = await Author.objects.acreate(name="Bob", email="bob@example.com")
+    await Comment.objects.acreate(post=post, author=commenter, text="Nice post")
+
+    post = await BlogPost.objects.aget(id=post.id)
+    original_loader = Serializer._load_relation_async.__func__
+    first_started = asyncio.Event()
+    second_started = asyncio.Event()
+    seen_relations: list[str] = []
+
+    async def tracked_loader(cls, obj, relation):
+        if obj.__class__ is BlogPost and obj.pk == post.pk and relation.name in {"author", "comments"}:
+            seen_relations.append(relation.name)
+            if not first_started.is_set():
+                first_started.set()
+                await asyncio.wait_for(second_started.wait(), timeout=0.5)
+            else:
+                second_started.set()
+        return await original_loader(cls, obj, relation)
+
+    monkeypatch.setattr(
+        BlogPostWithAuthorAndCommentsSerializer,
+        "_load_relation_async",
+        classmethod(tracked_loader),
+    )
+
+    serializer = await BlogPostWithAuthorAndCommentsSerializer.afrom_model(post)
+
+    assert serializer.author.name == "Alice"
+    assert len(serializer.comments) == 1
+    assert set(seen_relations) == {"author", "comments"}
+
+
 @pytest.mark.django_db
 def test_from_model_unloaded_source_path_uses_default_without_querying():
     user = User.objects.create(
@@ -172,3 +272,29 @@ def test_dump_fails_fast_when_manager_leaks_into_serializer_state():
         serializer.dump()
 
     assert "Serialize Django relations with from_model()/afrom_model()" in str(exc_info.value)
+
+
+@pytest.mark.django_db
+def test_dump_fast_path_still_guards_collection_fields_for_manager_leaks():
+    author = Author.objects.create(name="Alice", email="alice@example.com")
+    serializer = AuthorPostIdsSerializer(id=author.id)
+
+    msgspec_structs.force_setattr(serializer, "post_ids", author.posts)
+
+    with pytest.raises(SerializationError) as exc_info:
+        serializer.dump()
+
+    assert "post_ids" in str(exc_info.value)
+
+
+@pytest.mark.django_db
+def test_dump_many_fast_path_still_guards_collection_fields_for_manager_leaks():
+    author = Author.objects.create(name="Alice", email="alice@example.com")
+    serializer = AuthorPostIdsSerializer(id=author.id)
+
+    msgspec_structs.force_setattr(serializer, "post_ids", author.posts)
+
+    with pytest.raises(SerializationError) as exc_info:
+        AuthorPostIdsSerializer.dump_many([serializer])
+
+    assert "post_ids" in str(exc_info.value)

--- a/python/tests/serializers/test_from_model_relations.py
+++ b/python/tests/serializers/test_from_model_relations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 import pytest
 from msgspec import structs as msgspec_structs
@@ -84,6 +85,11 @@ class BlogPostWithAuthorAndCommentsSerializer(Serializer):
 class AuthorPostIdsSerializer(Serializer):
     id: int
     post_ids: list[int] = field(default_factory=list)
+
+
+class AuthorPayloadSerializer(Serializer):
+    id: int
+    payload: Any = None
 
 
 @pytest.mark.django_db
@@ -275,26 +281,36 @@ def test_dump_fails_fast_when_manager_leaks_into_serializer_state():
 
 
 @pytest.mark.django_db
-def test_dump_fast_path_still_guards_collection_fields_for_manager_leaks():
-    author = Author.objects.create(name="Alice", email="alice@example.com")
-    serializer = AuthorPostIdsSerializer(id=author.id)
+def test_scalar_list_fields_are_not_marked_for_orm_state_checks():
+    class AuthorTagNamesSerializer(Serializer):
+        id: int
+        tag_names: list[str] = field(default_factory=list)
 
-    msgspec_structs.force_setattr(serializer, "post_ids", author.posts)
+    assert AuthorPostIdsSerializer.__orm_state_check_fields__ == ()
+    assert AuthorTagNamesSerializer.__orm_state_check_fields__ == ()
+
+
+@pytest.mark.django_db
+def test_dump_fast_path_still_guards_any_fields_for_manager_leaks():
+    author = Author.objects.create(name="Alice", email="alice@example.com")
+    serializer = AuthorPayloadSerializer(id=author.id)
+
+    msgspec_structs.force_setattr(serializer, "payload", author.posts)
 
     with pytest.raises(SerializationError) as exc_info:
         serializer.dump()
 
-    assert "post_ids" in str(exc_info.value)
+    assert "payload" in str(exc_info.value)
 
 
 @pytest.mark.django_db
-def test_dump_many_fast_path_still_guards_collection_fields_for_manager_leaks():
+def test_dump_many_fast_path_still_guards_any_fields_for_manager_leaks():
     author = Author.objects.create(name="Alice", email="alice@example.com")
-    serializer = AuthorPostIdsSerializer(id=author.id)
+    serializer = AuthorPayloadSerializer(id=author.id)
 
-    msgspec_structs.force_setattr(serializer, "post_ids", author.posts)
+    msgspec_structs.force_setattr(serializer, "payload", author.posts)
 
     with pytest.raises(SerializationError) as exc_info:
-        AuthorPostIdsSerializer.dump_many([serializer])
+        AuthorPayloadSerializer.dump_many([serializer])
 
-    assert "post_ids" in str(exc_info.value)
+    assert "payload" in str(exc_info.value)

--- a/python/tests/serializers/test_nested_django.py
+++ b/python/tests/serializers/test_nested_django.py
@@ -17,8 +17,8 @@ import msgspec
 import pytest
 from msgspec import Meta
 
-from django_bolt.exceptions import RequestValidationError
-from django_bolt.serializers import Nested, Serializer, field_validator
+from django_bolt.exceptions import RequestValidationError, SerializationError
+from django_bolt.serializers import Serializer, field_validator
 from tests.test_models import Author, BlogPost, Comment, Tag
 
 
@@ -57,7 +57,7 @@ class CommentSerializer(Serializer):
     id: int
     text: str
     # Author as full object
-    author: Annotated[AuthorSerializer, Nested(AuthorSerializer)]
+    author: AuthorSerializer
 
 
 class BlogPostSerializer(Serializer):
@@ -67,9 +67,9 @@ class BlogPostSerializer(Serializer):
     title: str
     content: str
     # Author relationship - full object required
-    author: Annotated[AuthorSerializer, Nested(AuthorSerializer)]
+    author: AuthorSerializer
     # Tags relationship - full objects required
-    tags: Annotated[list[TagSerializer], Nested(TagSerializer, many=True)]
+    tags: list[TagSerializer]
     published: bool = False
 
 
@@ -79,10 +79,10 @@ class BlogPostDetailedSerializer(Serializer):
     id: int
     title: str
     content: str
-    author: Annotated[AuthorSerializer, Nested(AuthorSerializer)]
-    tags: Annotated[list[TagSerializer], Nested(TagSerializer, many=True)]
+    author: AuthorSerializer
+    tags: list[TagSerializer]
     # Comments nested with their own nested authors
-    comments: Annotated[list[CommentSerializer], Nested(CommentSerializer, many=True)]
+    comments: list[CommentSerializer]
     published: bool = False
 
 
@@ -91,18 +91,19 @@ class TestSingleNestedForeignKey:
 
     @pytest.mark.django_db
     def test_from_model_without_select_related(self):
-        """Test that unselected FK returns ID only."""
+        """Test that unloaded nested FK raises a clear serialization error."""
         author = Author.objects.create(name="Alice Smith", email="alice@example.com", bio="Author bio")
         post = BlogPost.objects.create(title="Test Post", content="Content", author=author)
 
         # Fetch without select_related
         post = BlogPost.objects.get(id=post.id)
 
-        # Convert to serializer
-        serializer = BlogPostSerializer.from_model(post)
+        with pytest.raises(SerializationError) as exc_info:
+            BlogPostSerializer.from_model(post)
 
-        # Author should be the ID (not an AuthorSerializer)
-        assert serializer.author == author.id or isinstance(serializer.author, AuthorSerializer)
+        error_message = str(exc_info.value)
+        assert "author" in error_message
+        assert "select_related('author')" in error_message
 
     @pytest.mark.django_db
     def test_from_model_with_select_related(self):
@@ -110,19 +111,15 @@ class TestSingleNestedForeignKey:
         author = Author.objects.create(name="Bob Jones", email="bob@example.com", bio="Bio")
         post = BlogPost.objects.create(title="Test Post", content="Content", author=author)
 
-        # Fetch WITH select_related
-        post = BlogPost.objects.select_related("author").get(id=post.id)
+        # Fetch with all required relations loaded for BlogPostSerializer
+        post = BlogPost.objects.select_related("author").prefetch_related("tags").get(id=post.id)
 
         # Convert to serializer
         serializer = BlogPostSerializer.from_model(post)
 
-        # Check if author was included
-        if isinstance(serializer.author, AuthorSerializer):
-            assert serializer.author.name == "Bob Jones"
-            assert serializer.author.email == "bob@example.com"
-        else:
-            # If it's an ID, that's also valid
-            assert serializer.author == author.id
+        assert isinstance(serializer.author, AuthorSerializer)
+        assert serializer.author.name == "Bob Jones"
+        assert serializer.author.email == "bob@example.com"
 
     @pytest.mark.django_db
     def test_create_with_nested_author_dict(self):
@@ -185,7 +182,7 @@ class TestNestedManyToMany:
 
     @pytest.mark.django_db
     def test_from_model_without_prefetch_related(self):
-        """Test that unprefetched M2M returns IDs only."""
+        """Test that unloaded nested M2M raises a clear serialization error."""
         author = Author.objects.create(name="Eve", email="eve@example.com")
         tag1 = Tag.objects.create(name="python", description="Python tag")
         tag2 = Tag.objects.create(name="django", description="Django tag")
@@ -196,11 +193,12 @@ class TestNestedManyToMany:
         # Fetch without prefetch_related
         post = BlogPost.objects.select_related("author").get(id=post.id)
 
-        serializer = BlogPostSerializer.from_model(post)
+        with pytest.raises(SerializationError) as exc_info:
+            BlogPostSerializer.from_model(post)
 
-        # Tags should be a list (either IDs or TagSerializers)
-        assert isinstance(serializer.tags, list)
-        assert len(serializer.tags) == 2
+        error_message = str(exc_info.value)
+        assert "tags" in error_message
+        assert "prefetch_related('tags')" in error_message
 
     @pytest.mark.django_db
     def test_from_model_with_prefetch_related(self):
@@ -221,9 +219,8 @@ class TestNestedManyToMany:
         assert isinstance(serializer.tags, list)
         assert len(serializer.tags) == 2
 
-        # All tags should be either TagSerializer or int
         for tag in serializer.tags:
-            assert isinstance(tag, (TagSerializer, int))
+            assert isinstance(tag, TagSerializer)
 
     @pytest.mark.django_db
     def test_create_with_tag_dicts(self):
@@ -344,7 +341,7 @@ class TestQueryOptimization:
 
     @pytest.mark.django_db
     def test_list_without_prefetch(self):
-        """Test listing posts without any prefetch (IDs only)."""
+        """Test listing posts without required preloads raises serialization error."""
         author = Author.objects.create(name="Iris", email="iris@example.com")
         tag = Tag.objects.create(name="test")
 
@@ -356,18 +353,12 @@ class TestQueryOptimization:
 
         # Fetch only the posts we created
         all_posts = BlogPost.objects.filter(id__in=post_ids)
-        serializers = [BlogPostSerializer.from_model(p) for p in all_posts]
-
-        assert len(serializers) == 3
-        for serializer in serializers:
-            # Author should be ID (FK not selected)
-            assert isinstance(serializer.author, (int, AuthorSerializer))
-            # Tags should be IDs (M2M not prefetched)
-            assert isinstance(serializer.tags, list)
+        with pytest.raises(SerializationError):
+            [BlogPostSerializer.from_model(p) for p in all_posts]
 
     @pytest.mark.django_db
     def test_list_with_select_related(self):
-        """Test listing posts with select_related."""
+        """Test that select_related alone is insufficient for required nested many relations."""
         author = Author.objects.create(name="Jack", email="jack@example.com")
 
         post_ids = []
@@ -377,13 +368,8 @@ class TestQueryOptimization:
 
         # Fetch only the posts we created with select_related
         all_posts = BlogPost.objects.filter(id__in=post_ids).select_related("author")
-        serializers = [BlogPostSerializer.from_model(p) for p in all_posts]
-
-        assert len(serializers) == 2
-        # Author should be nested object (select_related worked)
-        for serializer in serializers:
-            if isinstance(serializer.author, AuthorSerializer):
-                assert serializer.author.name == "Jack"
+        with pytest.raises(SerializationError):
+            [BlogPostSerializer.from_model(p) for p in all_posts]
 
     @pytest.mark.django_db
     def test_list_with_prefetch_related(self):
@@ -404,11 +390,10 @@ class TestQueryOptimization:
 
         assert len(serializers) == 2
         for serializer in serializers:
-            # Both author and tags should be optimized
-            if isinstance(serializer.author, AuthorSerializer):
-                assert serializer.author.name == "Kate"
-            # Tags list should exist
+            assert isinstance(serializer.author, AuthorSerializer)
+            assert serializer.author.name == "Kate"
             assert len(serializer.tags) == 2
+            assert all(isinstance(tag, TagSerializer) for tag in serializer.tags)
 
     @pytest.mark.django_db
     def test_list_with_full_prefetch(self):
@@ -431,9 +416,8 @@ class TestQueryOptimization:
         assert len(serializers) == 1
         serializer = serializers[0]
 
-        # All relationships should be optimized
-        if isinstance(serializer.author, AuthorSerializer):
-            assert serializer.author.name == "Liam"
+        assert isinstance(serializer.author, AuthorSerializer)
+        assert serializer.author.name == "Liam"
         assert len(serializer.tags) == 1
         assert len(serializer.comments) == 1
 
@@ -625,11 +609,11 @@ class TestNestedFieldValidation:
         post = BlogPost.objects.create(title="Post", content="Content", author=author)
 
         # Fetch and convert
-        post = BlogPost.objects.select_related("author").get(id=post.id)
+        post = BlogPost.objects.select_related("author").prefetch_related("tags").get(id=post.id)
         serializer = BlogPostSerializer.from_model(post)
 
-        # Author should be extracted as ID or object
-        assert serializer.author == author.id or isinstance(serializer.author, AuthorSerializer)
+        assert isinstance(serializer.author, AuthorSerializer)
+        assert serializer.author.name == "Karen"
 
     def test_valid_author_in_nested_comment(self):
         """Test validation of valid author in nested comment."""
@@ -664,19 +648,15 @@ class TestEdgeCases:
 
         serializer = BlogPostDetailedSerializer.from_model(post)
 
-        # Empty lists should be valid
-        assert serializer.tags == [] or all(isinstance(t, (TagSerializer, int)) for t in serializer.tags)
-        assert serializer.comments == [] or all(isinstance(c, (CommentSerializer, int)) for c in serializer.comments)
+        assert serializer.tags == []
+        assert serializer.comments == []
 
     def test_optional_nested_field(self):
         """Test optional nested field with None."""
 
         class OptionalAuthorSerializer(Serializer):
             title: str
-            author: Annotated[
-                AuthorSerializer | None,
-                Nested(AuthorSerializer),
-            ] = None
+            author: AuthorSerializer | None = None
 
         # Should accept None
         serializer = OptionalAuthorSerializer(title="Post", author=None)

--- a/python/tests/serializers/test_security.py
+++ b/python/tests/serializers/test_security.py
@@ -3,7 +3,7 @@ Security tests for Django-Bolt serializers.
 
 Tests cover:
 - DoS prevention: Input size limits for nested lists
-- Type safety: Nested() validation
+- Type safety: Nested() metadata API
 - Circular reference detection in from_model()
 - Performance optimizations
 """
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 from typing import Annotated
 
-import msgspec
 import pytest
 
 from django_bolt.exceptions import RequestValidationError
@@ -31,7 +30,7 @@ class TestNestedListSizeLimits:
 
         class BookSerializer(Serializer):
             title: str
-            tags: Annotated[list[TagSerializer], Nested(TagSerializer, many=True)]
+            tags: list[TagSerializer]
 
         # Create 1001 tags (exceeds default limit of 1000)
         many_tags = [{"id": i, "name": f"tag_{i}"} for i in range(1001)]
@@ -53,7 +52,7 @@ class TestNestedListSizeLimits:
 
         class BookSerializer(Serializer):
             title: str
-            tags: Annotated[list[TagSerializer], Nested(TagSerializer, many=True)]
+            tags: list[TagSerializer]
 
         # Create 999 tags (under default limit)
         tags = [{"id": i, "name": f"tag_{i}"} for i in range(999)]
@@ -70,7 +69,7 @@ class TestNestedListSizeLimits:
 
         class BookSerializer(Serializer):
             title: str
-            tags: Annotated[list[TagSerializer], Nested(TagSerializer, many=True, max_items=10)]
+            tags: Annotated[list[TagSerializer], Nested(max_items=10)]
 
         # 11 items exceeds custom limit of 10
         many_tags = [{"id": i, "name": f"tag_{i}"} for i in range(11)]
@@ -93,7 +92,7 @@ class TestNestedListSizeLimits:
         class BookSerializer(Serializer):
             title: str
             # Note: Setting max_items to None disables limit - NOT recommended for production
-            tags: Annotated[list[TagSerializer], Nested(TagSerializer, many=True, max_items=None)]
+            tags: Annotated[list[TagSerializer], Nested(max_items=None)]
 
         # Create 2000 tags (would exceed default limit, but we disabled it)
         many_tags = [{"id": i, "name": f"tag_{i}"} for i in range(2000)]
@@ -103,7 +102,7 @@ class TestNestedListSizeLimits:
         assert len(book.tags) == 2000
 
     def test_nested_single_not_affected_by_limit(self):
-        """Test that single nested fields (many=False) are not affected by size limits."""
+        """Test that single nested fields are not affected by size limits."""
 
         class AuthorSerializer(Serializer):
             id: int
@@ -111,7 +110,7 @@ class TestNestedListSizeLimits:
 
         class BookSerializer(Serializer):
             title: str
-            author: Annotated[AuthorSerializer, Nested(AuthorSerializer)]
+            author: AuthorSerializer
 
         # Single nested object should work fine
         book = BookSerializer(title="Test", author={"id": 1, "name": "Alice"})
@@ -119,67 +118,33 @@ class TestNestedListSizeLimits:
 
 
 class TestNestedTypeSafety:
-    """Test that Nested() validates serializer_class at definition time."""
+    """Test that Nested() only accepts keyword metadata overrides."""
 
-    def test_nested_rejects_non_class(self):
-        """Test that Nested() rejects non-class values."""
+    def test_nested_rejects_positional_arguments(self):
+        """Test that Nested() rejects the removed positional API."""
 
         class AuthorSerializer(Serializer):
             id: int
             name: str
 
-        # Try to pass an instance instead of a class
         author_instance = AuthorSerializer(id=1, name="Alice")
 
         with pytest.raises(TypeError) as exc_info:
             Nested(author_instance)  # type: ignore
 
         error_msg = str(exc_info.value)
-        assert "must be a class" in error_msg
-        assert "Nested(MySerializer) not Nested(MySerializer())" in error_msg
+        assert "no longer accepts serializer classes" in error_msg
+        assert "type annotation" in error_msg
 
-    def test_nested_rejects_non_serializer_class(self):
-        """Test that Nested() rejects classes that don't inherit from Serializer."""
+    def test_nested_rejects_many_keyword(self):
+        """Test that many= is no longer accepted."""
+        with pytest.raises(TypeError, match="no longer accepts serializer classes or many="):
+            Nested(many=True)  # type: ignore
 
-        class NotASerializer:
-            """This is not a Serializer subclass."""
-
-            id: int
-            name: str
-
-        with pytest.raises(TypeError) as exc_info:
-            Nested(NotASerializer)  # type: ignore
-
-        error_msg = str(exc_info.value)
-        assert "must be a Serializer subclass" in error_msg
-        assert "NotASerializer" in error_msg
-
-    def test_nested_accepts_valid_serializer_class(self):
-        """Test that Nested() accepts valid Serializer subclasses."""
-
-        class AuthorSerializer(Serializer):
-            id: int
-            name: str
-
-        # This should work fine
-        config = Nested(AuthorSerializer)
-        assert config.serializer_class == AuthorSerializer
-        assert config.many is False
-
-    def test_nested_with_msgspec_struct_not_serializer(self):
-        """Test that Nested() rejects msgspec.Struct classes that don't inherit from Serializer."""
-
-        class PlainStruct(msgspec.Struct):
-            """This is a msgspec.Struct but not a Serializer."""
-
-            id: int
-            name: str
-
-        with pytest.raises(TypeError) as exc_info:
-            Nested(PlainStruct)  # type: ignore
-
-        error_msg = str(exc_info.value)
-        assert "must be a Serializer subclass" in error_msg
+    def test_nested_accepts_keyword_metadata_only(self):
+        """Test that Nested() accepts keyword-only max_items metadata."""
+        config = Nested(max_items=25)
+        assert config.max_items == 25
 
 
 class TestRecursionPrevention:
@@ -200,7 +165,7 @@ class TestRecursionPrevention:
         class BookSerializer(Serializer):
             title: str
             # Default max_items=1000
-            tags: Annotated[list[TagSerializer], Nested(TagSerializer, many=True)]
+            tags: list[TagSerializer]
 
         # Attempt to create 10,000 tags (would consume significant memory)
         many_tags = [{"id": i, "name": f"tag_{i}"} for i in range(10000)]
@@ -251,16 +216,8 @@ class TestNestedConfigRepr:
 
     def test_nested_config_repr_includes_max_items(self):
         """Test that NestedConfig __repr__ includes max_items."""
-
-        class TagSerializer(Serializer):
-            id: int
-            name: str
-
-        config = Nested(TagSerializer, many=True, max_items=500)
+        config = Nested(max_items=500)
         repr_str = repr(config)
-
-        assert "TagSerializer" in repr_str
-        assert "many=True" in repr_str
         assert "max_items=500" in repr_str
 
 

--- a/python/tests/test_nested_simple.py
+++ b/python/tests/test_nested_simple.py
@@ -42,6 +42,23 @@ def test_nested_rejects_removed_positional_api():
         Nested(many=True)  # type: ignore
 
 
+def test_nested_rejects_old_serializer_class_api_with_helpful_message():
+    """Test that the removed Nested(ChildSerializer) API gives migration guidance."""
+
+    class AuthorSerializer(Serializer):
+        id: int
+        username: str
+
+    with pytest.raises(TypeError) as exc_info:
+        Nested(AuthorSerializer)  # type: ignore[arg-type]
+
+    message = str(exc_info.value)
+    assert "no longer accepts serializer classes or many=" in message
+    assert "Nested fields are inferred from the type annotation." in message
+    assert "Use ChildSerializer or list[ChildSerializer]" in message
+    assert "Annotated[..., Nested(max_items=...)]" in message
+
+
 def test_nested_annotation():
     """Test nested serializers inferred from plain serializer types."""
 

--- a/python/tests/test_nested_simple.py
+++ b/python/tests/test_nested_simple.py
@@ -1,9 +1,12 @@
-"""Simple tests for nested serializer support."""
+"""Simple tests for type-driven nested serializer support."""
 
 from __future__ import annotations
 
 from typing import Annotated
 
+import pytest
+
+from django_bolt.exceptions import RequestValidationError
 from django_bolt.serializers import Nested, Serializer
 
 
@@ -13,42 +16,43 @@ def test_nested_import():
 
 
 def test_nested_config_creation():
-    """Test creating a Nested config."""
-
-    class TestSerializer(Serializer):
-        id: int
-        name: str
-
-    config = Nested(TestSerializer)
+    """Test creating Nested metadata for optional overrides."""
+    config = Nested()
     assert config is not None
-    assert config.serializer_class == TestSerializer
-    assert config.many is False
+    assert config.max_items == 1000
 
 
-def test_nested_with_many():
-    """Test Nested config with many=True."""
+def test_nested_with_max_items():
+    """Test Nested metadata with custom max_items."""
+    config = Nested(max_items=10)
+    assert config.max_items == 10
+
+
+def test_nested_rejects_removed_positional_api():
+    """Test that redundant positional Nested arguments are rejected."""
 
     class TagSerializer(Serializer):
         id: int
         name: str
 
-    config = Nested(TagSerializer, many=True)
-    assert config.many is True
+    with pytest.raises(TypeError, match="type annotation"):
+        Nested(TagSerializer)  # type: ignore
+
+    with pytest.raises(TypeError, match="type annotation"):
+        Nested(many=True)  # type: ignore
 
 
 def test_nested_annotation():
-    """Test using Nested in a serializer annotation."""
+    """Test nested serializers inferred from plain serializer types."""
 
     class AuthorSerializer(Serializer):
         id: int
         username: str
 
-    # Nested serializers now require full objects
     class BookDetailSerializer(Serializer):
         title: str
-        author: Annotated[AuthorSerializer, Nested(AuthorSerializer)]
+        author: AuthorSerializer
 
-    # Create with full author object
     author = AuthorSerializer(id=1, username="alice")
     book = BookDetailSerializer(title="Test Book", author=author)
 
@@ -66,9 +70,8 @@ def test_nested_with_dict():
 
     class BookSerializer(Serializer):
         title: str
-        author: Annotated[AuthorSerializer, Nested(AuthorSerializer)]
+        author: AuthorSerializer
 
-    # Should accept dict and convert to serializer
     book = BookSerializer(title="Test", author={"id": 123, "username": "bob"})
 
     assert isinstance(book.author, AuthorSerializer)
@@ -77,9 +80,8 @@ def test_nested_with_dict():
 
 
 def test_simple_id_reference():
-    """Test using plain int for ID-only fields (no Nested)."""
+    """Test using plain int for ID-only fields."""
 
-    # For ID-only fields, just use int directly
     class BookListSerializer(Serializer):
         title: str
         author_id: int
@@ -98,7 +100,7 @@ def test_nested_with_serializer_instance():
 
     class BookSerializer(Serializer):
         title: str
-        author: Annotated[AuthorSerializer, Nested(AuthorSerializer)]
+        author: AuthorSerializer
 
     author = AuthorSerializer(id=1, username="alice")
     book = BookSerializer(title="Test", author=author)
@@ -108,7 +110,7 @@ def test_nested_with_serializer_instance():
 
 
 def test_nested_many_with_objects():
-    """Test that nested many field accepts list of objects."""
+    """Test that list[Serializer] fields accept nested objects."""
 
     class TagSerializer(Serializer):
         id: int
@@ -116,9 +118,8 @@ def test_nested_many_with_objects():
 
     class BookSerializer(Serializer):
         title: str
-        tags: Annotated[list[TagSerializer], Nested(TagSerializer, many=True)]
+        tags: list[TagSerializer]
 
-    # Accept list of dicts
     book = BookSerializer(
         title="Test",
         tags=[
@@ -128,12 +129,12 @@ def test_nested_many_with_objects():
     )
 
     assert len(book.tags) == 2
-    assert all(isinstance(t, TagSerializer) for t in book.tags)
+    assert all(isinstance(tag, TagSerializer) for tag in book.tags)
     assert book.tags[0].name == "python"
 
 
 def test_nested_many_accepts_empty_list():
-    """Test that nested many field accepts empty list."""
+    """Test that nested list fields accept empty lists."""
 
     class TagSerializer(Serializer):
         id: int
@@ -141,17 +142,37 @@ def test_nested_many_accepts_empty_list():
 
     class BookSerializer(Serializer):
         title: str
-        tags: Annotated[list[TagSerializer], Nested(TagSerializer, many=True)]
+        tags: list[TagSerializer]
 
     book = BookSerializer(title="Test", tags=[])
 
     assert book.tags == []
 
 
-def test_list_of_ids_without_nested():
-    """Test using plain list[int] for ID-only fields (no Nested)."""
+def test_nested_many_custom_limit_metadata():
+    """Test that Annotated Nested metadata still provides max_items overrides."""
 
-    # For ID-only many-to-many fields, just use list[int] directly
+    class TagSerializer(Serializer):
+        id: int
+        name: str
+
+    class BookSerializer(Serializer):
+        title: str
+        tags: Annotated[list[TagSerializer], Nested(max_items=1)]
+
+    with pytest.raises(RequestValidationError, match="Maximum allowed: 1"):
+        BookSerializer(
+            title="Test",
+            tags=[
+                {"id": 1, "name": "python"},
+                {"id": 2, "name": "django"},
+            ],
+        )
+
+
+def test_list_of_ids_without_nested():
+    """Test using plain list[int] for ID-only fields."""
+
     class BookListSerializer(Serializer):
         title: str
         tag_ids: list[int]

--- a/python/tests/test_pagination_serializers.py
+++ b/python/tests/test_pagination_serializers.py
@@ -7,6 +7,8 @@ or return type annotation for efficient batch serialization.
 
 from __future__ import annotations
 
+import asyncio
+
 import msgspec
 import pytest
 
@@ -61,6 +63,10 @@ class BlogPostListSerializer(Serializer):
     id: int
     title: str
     author: AuthorNestedSerializer
+
+
+class ConcurrentBlogPostListSerializer(BlogPostListSerializer):
+    """Serializer used to verify page item serialization runs concurrently."""
 
 
 # ============================================================================
@@ -251,6 +257,47 @@ def test_paginate_with_nested_serializer_uses_afrom_model(sample_blog_posts):
         assert len(data["items"]) == 5
         first_item = data["items"][0]
         assert first_item["author"]["name"].startswith("Author ")
+
+
+@pytest.mark.django_db(transaction=True)
+def test_paginate_serializes_page_items_concurrently(sample_blog_posts, monkeypatch):
+    """Test paginated async serialization gathers item-level afrom_model() calls."""
+    api = BoltAPI()
+    original_afrom_model = Serializer.afrom_model.__func__
+    first_started = asyncio.Event()
+    second_started = asyncio.Event()
+    seen_ids: list[int] = []
+
+    async def tracked_afrom_model(cls, instance, *, _depth=0, max_depth=10):
+        seen_ids.append(instance.pk)
+        if not first_started.is_set():
+            first_started.set()
+            await asyncio.wait_for(second_started.wait(), timeout=0.5)
+        else:
+            second_started.set()
+        return await original_afrom_model(cls, instance, _depth=_depth, max_depth=max_depth)
+
+    monkeypatch.setattr(
+        ConcurrentBlogPostListSerializer,
+        "afrom_model",
+        classmethod(tracked_afrom_model),
+    )
+
+    class SmallPagePagination(PageNumberPagination):
+        page_size = 2
+
+    @api.get("/posts", response_model=list[ConcurrentBlogPostListSerializer])
+    @paginate(SmallPagePagination)
+    async def list_posts(request):
+        return BlogPost.objects.all()
+
+    with TestClient(api) as client:
+        response = client.get("/posts?page=1")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert len(data["items"]) == 2
+        assert len(seen_ids) == 2
 
 
 # ============================================================================

--- a/python/tests/test_pagination_serializers.py
+++ b/python/tests/test_pagination_serializers.py
@@ -15,7 +15,7 @@ from django_bolt.serializers import Serializer
 from django_bolt.testing import TestClient
 from django_bolt.views import ViewSet
 
-from .test_models import Article
+from .test_models import Article, Author, BlogPost
 
 # ============================================================================
 # Serializers for Testing
@@ -48,6 +48,21 @@ class ArticleMsgspecSchema(msgspec.Struct):
     author: str
 
 
+class AuthorNestedSerializer(Serializer):
+    """Nested author serializer for pagination relation tests."""
+
+    id: int
+    name: str
+
+
+class BlogPostListSerializer(Serializer):
+    """Blog post serializer with nested author."""
+
+    id: int
+    title: str
+    author: AuthorNestedSerializer
+
+
 # ============================================================================
 # Test Fixtures
 # ============================================================================
@@ -66,6 +81,22 @@ def sample_articles(db):
         )
         articles.append(article)
     return articles
+
+
+@pytest.fixture
+def sample_blog_posts(db):
+    """Create blog posts with authors for nested pagination tests."""
+    posts = []
+    for i in range(1, 6):
+        author = Author.objects.create(name=f"Author {i}", email=f"author{i}@example.com")
+        post = BlogPost.objects.create(
+            title=f"Post {i}",
+            content=f"Post content {i}",
+            author=author,
+            published=i % 2 == 0,
+        )
+        posts.append(post)
+    return posts
 
 
 # ============================================================================
@@ -197,6 +228,29 @@ def test_paginate_with_return_type_annotation(sample_articles):
         assert "author" in first_item
         assert "content" not in first_item
         assert "is_published" not in first_item
+
+
+@pytest.mark.django_db(transaction=True)
+def test_paginate_with_nested_serializer_uses_afrom_model(sample_blog_posts):
+    """Test async pagination uses afrom_model for nested relations."""
+    api = BoltAPI()
+
+    class SmallPagePagination(PageNumberPagination):
+        page_size = 5
+
+    @api.get("/posts", response_model=list[BlogPostListSerializer])
+    @paginate(SmallPagePagination)
+    async def list_posts(request):
+        return BlogPost.objects.all()
+
+    with TestClient(api) as client:
+        response = client.get("/posts?page=1")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert len(data["items"]) == 5
+        first_item = data["items"][0]
+        assert first_item["author"]["name"].startswith("Author ")
 
 
 # ============================================================================


### PR DESCRIPTION
…-driven nested inference

Rewrite from_model() with cached field specs and add afrom_model() for async lazy-loading of Django relations. Nested serializer fields are now inferred from type annotations (e.g. `author: AuthorSerializer`, `tags: list[TagSerializer]`) instead of requiring explicit Nested() wrappers. Nested() is retained only for optional metadata like max_items.

Key changes:
- Add afrom_model() async variant that lazy-loads unloaded relations via Django's async ORM, with sync from_model() raising SerializationError for unloaded required relations
- Pre-compute _ModelFieldSpec tuples at registration for zero-introspection field extraction at runtime
- Cache Django relation metadata via _get_django_relation_info() with @cache decorator
- Add SerializationError for clearer server-side misuse diagnostics
- Make pagination _serialize_items async to support afrom_model()
- Update ViewSet/ModelViewSet mixins to use afrom_model()
- Refactor example app endpoints to use response serializers with from_model()/afrom_model() instead of hand-built dicts
- Improve type safety in decorators.py with Protocol classes
- Update docs and tests to reflect new nested inference API

Fixes #181 