### PR TITLE
feat: replace Django autoreload with native Rust dev reloader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "actix-macros",
  "actix-rt",
  "actix_derive",
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "crossbeam-channel",
  "futures-core",
@@ -33,7 +33,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -69,7 +69,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web",
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "derive_more 2.1.1",
  "futures-core",
@@ -93,7 +93,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "base64",
- "bitflags",
+ "bitflags 2.10.0",
  "brotli",
  "bytes",
  "bytestring",
@@ -205,7 +205,7 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "futures-util",
- "mio",
+ "mio 1.1.1",
  "socket2 0.5.10",
  "tokio",
  "tracing",
@@ -422,6 +422,12 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
@@ -445,6 +451,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -676,6 +691,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +846,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,13 +883,16 @@ dependencies = [
  "bytes",
  "chrono",
  "cookie 0.18.1",
+ "ctrlc",
  "dashmap",
  "futures-util",
  "governor",
  "jsonwebtoken",
+ "libc",
  "log",
  "matchit",
  "mimalloc",
+ "notify",
  "once_cell",
  "parking_lot",
  "pyo3",
@@ -976,6 +1017,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1068,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1430,6 +1491,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,6 +1560,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1519,6 +1620,18 @@ checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1614,6 +1727,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
@@ -1625,10 +1750,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "num-bigint"
@@ -1693,6 +1849,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,7 +1911,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1814,6 +1985,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -2075,7 +2252,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2084,7 +2261,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2221,7 +2407,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2239,6 +2425,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2645,7 +2840,7 @@ checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.1.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -2819,6 +3014,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2915,7 +3120,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2956,6 +3161,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -3024,6 +3238,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3047,6 +3270,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3084,6 +3322,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3096,6 +3340,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3105,6 +3355,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3132,6 +3388,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3141,6 +3403,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3156,6 +3424,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3165,6 +3439,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3245,7 +3525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.10.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,9 @@ actix-multipart = "0.7"
 serde_urlencoded = "0.7"
 tempfile = "3"
 log = "0.4"
+notify = "6"
+ctrlc = "3"
+libc = "0.2"
 
 [profile.release]
 codegen-units = 1        # Better optimization (single codegen unit allows more inlining)

--- a/bench/BENCHMARK_BASELINE.md
+++ b/bench/BENCHMARK_BASELINE.md
@@ -1,390 +1,391 @@
 # Django-Bolt Benchmark
-Generated: Mon 16 Mar 2026 01:52:53 PM PKT
+Generated: Sun 22 Mar 2026 12:16:56 PM PKT
 Config: 8 processes × 1 workers | C=100 N=10000
 
 ## Root Endpoint Performance
-  Reqs/sec    173209.02   15350.21  185024.21
-  Latency      557.65us   327.83us     4.90ms
+  Reqs/sec    158129.77   17279.60  168333.63
+  Latency      622.45us   321.55us     3.90ms
   Latency Distribution
-     50%   491.00us
-     75%   614.00us
-     90%   835.00us
-     99%     2.09ms
+     50%   532.00us
+     75%   741.00us
+     90%     1.07ms
+     99%     2.24ms
 
 ## 10kb JSON Response Performance
 ### 10kb JSON (Async) (/10k-json)
-  Reqs/sec    113963.50   12048.13  121575.28
-  Latency        0.86ms   415.63us     7.00ms
+  Reqs/sec    113056.30    9835.12  120502.46
+  Latency        0.86ms   374.54us     5.76ms
   Latency Distribution
-     50%   784.00us
-     75%     1.01ms
-     90%     1.35ms
+     50%   767.00us
+     75%     1.04ms
+     90%     1.42ms
      99%     2.56ms
 ### 10kb JSON (Sync) (/sync-10k-json)
-  Reqs/sec    126633.53    7358.64  130704.62
-  Latency      768.27us   320.51us     8.25ms
+  Reqs/sec    119055.42   13011.29  127769.93
+  Latency      828.91us   449.76us     6.72ms
   Latency Distribution
-     50%   724.00us
-     75%     0.92ms
-     90%     1.16ms
-     99%     2.03ms
+     50%   718.00us
+     75%     0.98ms
+     90%     1.35ms
+     99%     2.96ms
 
 ## Response Type Endpoints
 ### Header Endpoint (/header)
-  Reqs/sec    107420.36    9773.28  113609.81
-  Latency        0.91ms   277.72us     5.22ms
+  Reqs/sec     93308.31   11607.31  104205.25
+  Latency        1.02ms   342.94us     4.63ms
   Latency Distribution
-     50%   843.00us
-     75%     1.11ms
-     90%     1.40ms
-     99%     2.12ms
+     50%     0.95ms
+     75%     1.27ms
+     90%     1.58ms
+     99%     2.50ms
 ### Cookie Endpoint (/cookie)
-  Reqs/sec    108999.39    6967.58  113960.10
-  Latency        0.90ms   333.57us     6.00ms
+  Reqs/sec     95092.16    6171.98  100091.65
+  Latency        1.03ms   335.03us     5.43ms
   Latency Distribution
-     50%   839.00us
-     75%     1.08ms
-     90%     1.35ms
-     99%     2.16ms
+     50%     0.97ms
+     75%     1.29ms
+     90%     1.61ms
+     99%     2.48ms
 ### Exception Endpoint (/exc)
-  Reqs/sec    140356.59   14617.22  148524.28
-  Latency      690.39us   314.25us     5.85ms
+  Reqs/sec    128305.33   10750.16  136087.62
+  Latency      762.16us   341.13us     5.82ms
   Latency Distribution
-     50%   625.00us
-     75%   813.00us
-     90%     1.12ms
-     99%     2.17ms
+     50%   703.00us
+     75%     0.97ms
+     90%     1.25ms
+     99%     2.16ms
 ### HTML Response (/html)
-  Reqs/sec    167573.72   13960.77  175647.42
-  Latency      573.93us   343.12us     7.14ms
+  Reqs/sec    143985.48   14281.02  157485.92
+  Latency      677.69us   415.35us     6.91ms
   Latency Distribution
-     50%   500.00us
-     75%   664.00us
-     90%     0.89ms
-     99%     2.15ms
+     50%   580.00us
+     75%   824.00us
+     90%     1.17ms
+     99%     2.58ms
 ### Redirect Response (/redirect)
 ### File Static via FileResponse (/file-static)
-  Reqs/sec     37099.77    8654.04   42301.57
-  Latency        2.70ms     1.51ms    22.33ms
+  Reqs/sec     30340.38    8644.26   39759.38
+  Latency        3.20ms     2.02ms    25.02ms
   Latency Distribution
-     50%     2.42ms
-     75%     3.21ms
-     90%     4.17ms
-     99%     8.91ms
+     50%     2.71ms
+     75%     3.69ms
+     90%     5.14ms
+     99%    13.24ms
 
 ## Authentication & Authorization Performance
 ### Auth NO User Access (/auth/no-user-access) - lazy loading, no DB query
-  Reqs/sec     77813.37    4919.91   81787.79
-  Latency        1.27ms   393.72us     7.93ms
+  Reqs/sec     72306.44    5215.55   75672.27
+  Latency        1.36ms   371.14us     5.99ms
   Latency Distribution
-     50%     1.19ms
-     75%     1.53ms
-     90%     1.91ms
-     99%     2.91ms
+     50%     1.31ms
+     75%     1.67ms
+     90%     2.05ms
+     99%     2.87ms
 ### Get Authenticated User (/auth/me) - accesses request.user, triggers DB query
-  Reqs/sec     17601.22    1608.83   20987.31
-  Latency        5.67ms     1.64ms    14.87ms
+  Reqs/sec     16964.14    1655.24   18078.70
+  Latency        5.86ms     1.44ms    15.97ms
   Latency Distribution
-     50%     5.45ms
-     75%     7.05ms
-     90%     8.13ms
-     99%    10.70ms
+     50%     5.61ms
+     75%     6.84ms
+     90%     7.92ms
+     99%    10.97ms
 ### Get User via Dependency (/auth/me-dependency)
-  Reqs/sec     15835.97     993.90   17672.89
-  Latency        6.29ms     1.60ms    14.59ms
+  Reqs/sec     15340.84    1075.23   16824.33
+  Latency        6.49ms     1.96ms    23.72ms
   Latency Distribution
-     50%     6.10ms
-     75%     7.45ms
-     90%     8.80ms
-     99%    11.34ms
+     50%     6.23ms
+     75%     7.72ms
+     90%     9.45ms
+     99%    13.20ms
 ### Get Auth Context (/auth/context) validated jwt no db
-  Reqs/sec     84965.01    7413.46   91095.50
-  Latency        1.16ms   402.15us     6.84ms
+  Reqs/sec     73863.95    5707.98   81607.34
+  Latency        1.33ms   530.21us     5.56ms
   Latency Distribution
-     50%     1.08ms
-     75%     1.44ms
-     90%     1.83ms
-     99%     2.81ms
+     50%     1.20ms
+     75%     1.64ms
+     90%     2.31ms
+     99%     3.63ms
 
 ## Items GET Performance (/items/1?q=hello)
-  Reqs/sec    145784.38   20980.98  163903.98
-  Latency      631.08us   302.74us     6.02ms
+  Reqs/sec     88079.96   23131.68  115900.88
+  Latency        1.11ms     0.99ms     9.44ms
   Latency Distribution
-     50%   613.00us
-     75%   733.00us
-     90%     0.87ms
-     99%     1.79ms
+     50%   680.00us
+     75%     1.26ms
+     90%     2.63ms
+     99%     5.88ms
 
 ## Items PUT JSON Performance (/items/1)
-  Reqs/sec    146751.20   15048.61  157735.96
-  Latency      670.25us   364.69us     7.39ms
+  Reqs/sec    127937.68   11403.27  136961.64
+  Latency      758.02us   444.27us     9.17ms
   Latency Distribution
-     50%   645.00us
-     75%   775.00us
-     90%     0.92ms
-     99%     2.09ms
+     50%   633.00us
+     75%     0.87ms
+     90%     1.30ms
+     99%     3.08ms
 
 ## ORM Performance
 Seeding 1000 users for benchmark...
 Successfully seeded users
 Validated: 10 users exist in database
 ### Users Full10 (Async) (/users/full10)
-  Reqs/sec     14730.29    2011.73   16992.58
-  Latency        6.76ms     2.51ms    24.88ms
+  Reqs/sec     14800.17    2082.19   17546.51
+  Latency        6.75ms     2.27ms    23.68ms
   Latency Distribution
-     50%     6.30ms
-     75%     8.08ms
-     90%    10.10ms
-     99%    16.25ms
+     50%     6.38ms
+     75%     8.03ms
+     90%     9.92ms
+     99%    14.83ms
 ### Users Full10 (Sync) (/users/sync-full10)
-  Reqs/sec     11323.96    1463.31   14263.19
-  Latency        8.82ms     3.59ms    28.98ms
+  Reqs/sec     11185.88    1604.34   14239.52
+  Latency        8.81ms     4.49ms    38.62ms
   Latency Distribution
-     50%     8.08ms
-     75%    10.94ms
-     90%    14.11ms
-     99%    20.74ms
+     50%     7.72ms
+     75%    11.27ms
+     90%    15.53ms
+     99%    23.68ms
 ### Users Mini10 (Async) (/users/mini10)
-  Reqs/sec     18610.84    1427.71   21194.24
-  Latency        5.36ms     1.75ms    14.74ms
+ 3590 / 10000 [======>------------]  35.90% 17907/s
+  Reqs/sec     18444.37    1084.43   20003.11
+  Latency        5.39ms     1.47ms    13.30ms
   Latency Distribution
-     50%     5.19ms
-     75%     6.76ms
-     90%     8.16ms
-     99%    10.70ms
+     50%     5.21ms
+     75%     6.50ms
+     90%     7.83ms
+     99%    10.10ms
 ### Users Mini10 (Sync) (/users/sync-mini10)
-  Reqs/sec     12399.44    1093.32   16032.98
-  Latency        8.02ms     2.83ms    23.57ms
+  Reqs/sec     12554.83    1771.59   21395.18
+  Latency        8.04ms     2.88ms    24.56ms
   Latency Distribution
-     50%     7.54ms
-     75%     9.73ms
-     90%    12.25ms
-     99%    17.50ms
+     50%     7.68ms
+     75%    10.07ms
+     90%    12.38ms
+     99%    16.92ms
 Cleaning up test users...
 
 ## Class-Based Views (CBV) Performance
 ### Simple APIView GET (/cbv-simple)
-  Reqs/sec    100104.07   28116.78  119384.22
-  Latency        1.02ms     1.03ms    13.98ms
+  Reqs/sec     97561.90    8227.45  103811.06
+  Latency        1.02ms   434.52us     5.52ms
   Latency Distribution
-     50%     0.85ms
-     75%     1.15ms
-     90%     1.51ms
-     99%     3.29ms
+     50%     0.92ms
+     75%     1.27ms
+     90%     1.64ms
+     99%     2.86ms
 ### Simple APIView POST (/cbv-simple)
-  Reqs/sec    104226.81    9238.13  113182.76
-  Latency        0.94ms   416.11us     5.57ms
+  Reqs/sec     93309.13   11065.44  102735.06
+  Latency        1.01ms   334.18us     4.77ms
   Latency Distribution
-     50%     0.85ms
-     75%     1.13ms
-     90%     1.46ms
-     99%     2.97ms
+     50%     0.93ms
+     75%     1.25ms
+     90%     1.60ms
+     99%     2.44ms
 ### Items100 ViewSet GET (/cbv-items100)
-  Reqs/sec     66466.78    5988.92   71618.76
-  Latency        1.48ms   486.11us     6.65ms
+  Reqs/sec     66811.53   17628.55  110276.38
+  Latency        1.61ms   664.47us     8.85ms
   Latency Distribution
-     50%     1.38ms
-     75%     1.75ms
-     90%     2.20ms
-     99%     3.80ms
+     50%     1.42ms
+     75%     1.89ms
+     90%     2.54ms
+     99%     4.63ms
 
 ## CBV Items - Basic Operations
 ### CBV Items GET (Retrieve) (/cbv-items/1)
-  Reqs/sec     88544.77   22803.51  107039.87
-  Latency        1.00ms   334.11us     4.94ms
+  Reqs/sec     77896.52   26095.76   97382.97
+  Latency        1.30ms     1.01ms    14.27ms
   Latency Distribution
-     50%     0.94ms
-     75%     1.27ms
-     90%     1.60ms
-     99%     2.42ms
+     50%     1.05ms
+     75%     1.53ms
+     90%     2.09ms
+     99%     4.92ms
 ### CBV Items PUT (Update) (/cbv-items/1)
-  Reqs/sec     99707.61    8714.18  105890.17
-  Latency        0.98ms   302.41us     5.51ms
+  Reqs/sec     91218.29    6535.64   99314.82
+  Latency        1.08ms   354.80us     5.92ms
   Latency Distribution
-     50%     0.92ms
-     75%     1.22ms
-     90%     1.53ms
-     99%     2.22ms
+     50%     0.99ms
+     75%     1.36ms
+     90%     1.75ms
+     99%     2.59ms
 
 ## CBV Additional Benchmarks
 ### CBV Bench Parse (POST /cbv-bench-parse)
-  Reqs/sec     99395.70   10111.20  107675.08
-  Latency        0.99ms   372.50us     4.84ms
+  Reqs/sec     97274.56    9984.34  111185.15
+  Latency        1.03ms   326.81us     5.95ms
   Latency Distribution
-     50%     0.91ms
-     75%     1.25ms
+     50%     0.96ms
+     75%     1.29ms
      90%     1.61ms
-     99%     2.79ms
+     99%     2.40ms
 ### CBV Response Types (/cbv-response)
-  Reqs/sec    106509.18    9567.02  113927.26
-  Latency        0.92ms   306.09us     4.57ms
+  Reqs/sec     98949.07    6428.45  104605.61
+  Latency        0.99ms   318.57us     4.08ms
   Latency Distribution
-     50%     0.85ms
-     75%     1.17ms
-     90%     1.47ms
-     99%     2.17ms
+     50%     0.92ms
+     75%     1.22ms
+     90%     1.56ms
+     99%     2.39ms
 
 ## ORM Performance with CBV
 Seeding 1000 users for CBV benchmark...
 Successfully seeded users
 Validated: 10 users exist in database
 ### Users CBV Mini10 (List) (/users/cbv-mini10)
-  Reqs/sec     16705.53    1579.51   18276.42
-  Latency        5.95ms     1.80ms    19.18ms
+  Reqs/sec     16784.52    1379.20   18209.15
+  Latency        5.93ms     1.64ms    19.43ms
   Latency Distribution
-     50%     5.66ms
-     75%     7.11ms
-     90%     8.60ms
-     99%    11.89ms
+     50%     5.77ms
+     75%     7.04ms
+     90%     8.41ms
+     99%    11.28ms
 Cleaning up test users...
 
 
 ## Form and File Upload Performance
 ### Form Data (POST /form)
-  Reqs/sec    118506.27    9414.06  125018.15
-  Latency      822.81us   407.87us     6.48ms
+  Reqs/sec    122223.85   10782.09  131908.57
+  Latency      803.29us   388.55us     5.84ms
   Latency Distribution
-     50%   745.00us
-     75%     1.02ms
-     90%     1.33ms
-     99%     2.80ms
+     50%   709.00us
+     75%     0.99ms
+     90%     1.31ms
+     99%     2.31ms
 ### File Upload (POST /upload)
-  Reqs/sec    107082.08    7417.15  114999.61
-  Latency        0.91ms   376.83us     6.66ms
+  Reqs/sec    114037.28    8365.96  120718.73
+  Latency        0.86ms   455.10us    10.08ms
   Latency Distribution
-     50%   827.00us
-     75%     1.12ms
-     90%     1.47ms
-     99%     2.35ms
+     50%   779.00us
+     75%     0.97ms
+     90%     1.28ms
+     99%     2.85ms
 ### Mixed Form with Files (POST /mixed-form)
-  Reqs/sec    110827.10    9002.91  116730.06
-  Latency        0.88ms   338.73us     6.43ms
+  Reqs/sec    104768.63    8390.18  109189.91
+  Latency        0.93ms   359.91us     6.51ms
   Latency Distribution
-     50%   797.00us
-     75%     1.07ms
-     90%     1.39ms
-     99%     2.17ms
+     50%     0.89ms
+     75%     1.15ms
+     90%     1.40ms
+     99%     2.25ms
 
 ## Django Middleware Performance
 ### Django Middleware + Messages Framework (/middleware/demo)
 Tests: SessionMiddleware, AuthenticationMiddleware, MessageMiddleware, custom middleware, template rendering
-  Reqs/sec      9962.13    1148.71   13959.92
-  Latency       10.06ms     2.53ms    22.14ms
+  Reqs/sec      9595.82    1051.34   12604.53
+  Latency       10.43ms     3.64ms    26.24ms
   Latency Distribution
-     50%     9.86ms
-     75%    11.96ms
-     90%    13.73ms
-     99%    17.60ms
+     50%    10.15ms
+     75%    13.29ms
+     90%    15.78ms
+     99%    20.32ms
 
 ## Django Ninja-style Benchmarks
 ### JSON Parse/Validate (POST /bench/parse)
-  Reqs/sec    142798.24   10822.93  152393.99
-  Latency      682.30us   325.88us     6.64ms
+  Reqs/sec    135611.62   16060.92  145447.95
+  Latency      725.39us   330.50us     4.94ms
   Latency Distribution
-     50%   580.00us
-     75%     0.86ms
-     90%     1.11ms
-     99%     1.92ms
+     50%   643.00us
+     75%     0.88ms
+     90%     1.19ms
+     99%     2.41ms
 
 ## Serializer Performance Benchmarks
 ### Raw msgspec Serializer (POST /bench/serializer-raw)
-  Reqs/sec    106706.19   22889.01  151162.79
-  Latency        1.00ms   353.43us     4.76ms
+  Reqs/sec     93591.40    8121.99  101178.64
+  Latency        1.06ms   355.41us     5.67ms
   Latency Distribution
-     50%     0.93ms
-     75%     1.20ms
-     90%     1.56ms
-     99%     2.44ms
+     50%     0.98ms
+     75%     1.30ms
+     90%     1.66ms
+     99%     2.56ms
 ### Django-Bolt Serializer with Validators (POST /bench/serializer-validated)
-  Reqs/sec     89087.04    6727.46   95024.71
-  Latency        1.10ms   383.55us     5.39ms
+  Reqs/sec     85856.58    8929.03   92739.52
+  Latency        1.15ms   475.54us     7.14ms
   Latency Distribution
-     50%     1.02ms
-     75%     1.33ms
-     90%     1.70ms
-     99%     2.69ms
+     50%     1.06ms
+     75%     1.42ms
+     90%     1.81ms
+     99%     3.19ms
 ### Users msgspec Serializer (POST /users/bench/msgspec)
-  Reqs/sec     98471.39    8037.75  104493.79
-  Latency        0.99ms   310.32us     4.32ms
+  Reqs/sec     90583.72    5668.46   96788.85
+  Latency        1.07ms   368.77us     4.97ms
   Latency Distribution
-     50%     0.93ms
-     75%     1.24ms
-     90%     1.57ms
-     99%     2.34ms
+     50%     0.98ms
+     75%     1.33ms
+     90%     1.73ms
+     99%     2.73ms
 
 ## Multi-Response Performance
 
 ### Multi-response tuple return (/bench/multi/tuple)
-  Reqs/sec    103695.99    9207.58  111725.35
-  Latency        0.95ms   326.11us     4.31ms
+  Reqs/sec     94476.28    7201.18  102073.74
+  Latency        1.01ms   303.56us     5.64ms
   Latency Distribution
-     50%     0.87ms
-     75%     1.17ms
-     90%     1.53ms
-     99%     2.48ms
+     50%     0.94ms
+     75%     1.24ms
+     90%     1.57ms
+     99%     2.23ms
 
 ### Multi-response bare dict (/bench/multi/dict)
-  Reqs/sec     84385.36   18323.44  111351.16
-  Latency        1.16ms   557.93us     7.39ms
+  Reqs/sec     98377.55    6033.80  103755.15
+  Latency        1.00ms   331.00us     4.68ms
   Latency Distribution
-     50%     0.99ms
-     75%     1.38ms
-     90%     1.96ms
-     99%     3.79ms
+     50%     0.91ms
+     75%     1.25ms
+     90%     1.60ms
+     99%     2.46ms
 
 ## Latency Percentile Benchmarks
 Measures p50/p75/p90/p99 latency for type coercion overhead analysis
 
 ### Baseline - No Parameters (/)
-  Reqs/sec    177897.69   15327.33  189514.90
-  Latency      544.92us   300.47us     5.69ms
+  Reqs/sec    149897.11   25787.33  173319.29
+  Latency      602.54us   349.43us     5.38ms
   Latency Distribution
-     50%   481.00us
-     75%   636.00us
-     90%     0.87ms
-     99%     1.94ms
+     50%   507.00us
+     75%   699.00us
+     90%     1.02ms
+     99%     2.22ms
 
 ### Path Parameter - int (/items/12345)
-  Reqs/sec    156941.34   14272.58  170951.00
-  Latency      618.05us   276.17us     4.97ms
+  Reqs/sec    135000.11   12799.10  147741.28
+  Latency      723.56us   405.00us     6.66ms
   Latency Distribution
-     50%   569.00us
-     75%   712.00us
-     90%     0.90ms
-     99%     2.05ms
+     50%   641.00us
+     75%     0.88ms
+     90%     1.24ms
+     99%     2.15ms
 
 ### Path + Query Parameters (/items/12345?q=hello)
-  Reqs/sec    153128.44   13955.24  167465.19
-  Latency      644.50us   315.02us     5.67ms
+  Reqs/sec    137351.30   11017.72  147907.13
+  Latency      704.78us   352.07us     4.73ms
   Latency Distribution
-     50%   588.00us
-     75%   758.00us
-     90%     0.98ms
-     99%     1.76ms
+     50%   629.00us
+     75%   847.00us
+     90%     1.15ms
+     99%     2.63ms
 
 ### Header Parameter (/header)
-  Reqs/sec    104893.06    7912.09  110943.74
-  Latency        0.94ms   348.71us     5.78ms
+  Reqs/sec     95916.77    9923.16  104004.49
+  Latency        1.02ms   379.57us     5.46ms
   Latency Distribution
-     50%     0.86ms
-     75%     1.16ms
-     90%     1.48ms
-     99%     2.42ms
+     50%     0.94ms
+     75%     1.25ms
+     90%     1.61ms
+     99%     2.66ms
 
 ### Cookie Parameter (/cookie)
-  Reqs/sec    104280.46    8614.43  112417.50
-  Latency        0.94ms   316.57us     5.58ms
+  Reqs/sec     94649.11    6706.55   99428.38
+  Latency        1.03ms   372.42us     5.11ms
   Latency Distribution
-     50%     0.87ms
-     75%     1.15ms
-     90%     1.48ms
-     99%     2.25ms
+     50%     0.95ms
+     75%     1.32ms
+     90%     1.68ms
+     99%     2.49ms
 
 ### Auth Context - JWT validated, no DB (/auth/context)
-  Reqs/sec     84795.93    5950.36   89882.96
-  Latency        1.15ms   406.66us     5.23ms
+  Reqs/sec     76032.54    4368.58   82901.42
+  Latency        1.27ms   451.79us     5.39ms
   Latency Distribution
-     50%     1.05ms
-     75%     1.41ms
-     90%     1.88ms
-     99%     2.92ms
+     50%     1.17ms
+     75%     1.61ms
+     90%     2.09ms
+     99%     3.15ms

--- a/bench/BENCHMARK_DEV.md
+++ b/bench/BENCHMARK_DEV.md
@@ -1,392 +1,391 @@
 # Django-Bolt Benchmark
-Generated: Mon 16 Mar 2026 01:55:21 PM PKT
+Generated: Sun 22 Mar 2026 12:17:48 PM PKT
 Config: 8 processes × 1 workers | C=100 N=10000
 
 ## Root Endpoint Performance
-  Reqs/sec    171169.55   16056.50  185896.20
-  Latency      564.00us   303.04us     5.43ms
+  Reqs/sec    159476.11   16592.72  168822.07
+  Latency      618.78us   355.38us     5.66ms
   Latency Distribution
-     50%   470.00us
-     75%   674.00us
-     90%     0.95ms
-     99%     1.94ms
+     50%   510.00us
+     75%   734.00us
+     90%     1.08ms
+     99%     2.23ms
 
 ## 10kb JSON Response Performance
 ### 10kb JSON (Async) (/10k-json)
-  Reqs/sec    116400.10   12126.23  128467.12
-  Latency      818.78us   331.64us     5.50ms
+  Reqs/sec    114007.19    7955.10  119355.85
+  Latency        0.85ms   407.85us     7.02ms
   Latency Distribution
-     50%   735.00us
-     75%     1.00ms
-     90%     1.28ms
-     99%     2.25ms
+     50%   736.00us
+     75%     1.07ms
+     90%     1.43ms
+     99%     2.69ms
 ### 10kb JSON (Sync) (/sync-10k-json)
-  Reqs/sec    121763.55   10057.24  131016.21
-  Latency      799.02us   337.57us     5.27ms
+  Reqs/sec    113782.36    7956.45  119945.09
+  Latency        0.86ms   465.31us     7.61ms
   Latency Distribution
-     50%   709.00us
-     75%     0.97ms
-     90%     1.29ms
-     99%     2.26ms
+     50%   762.00us
+     75%     1.06ms
+     90%     1.37ms
+     99%     2.75ms
 
 ## Response Type Endpoints
 ### Header Endpoint (/header)
-  Reqs/sec    100342.30    8413.64  106140.17
-  Latency        0.98ms   353.02us     5.02ms
+  Reqs/sec     94583.23    6943.41  101772.41
+  Latency        1.04ms   444.09us     5.55ms
   Latency Distribution
-     50%     0.92ms
-     75%     1.19ms
-     90%     1.47ms
-     99%     2.36ms
+     50%     0.93ms
+     75%     1.28ms
+     90%     1.72ms
+     99%     2.91ms
 ### Cookie Endpoint (/cookie)
-  Reqs/sec     94216.40    6879.64  102200.52
-  Latency        1.05ms   376.90us     5.04ms
+  Reqs/sec     95809.15    7311.43  104935.33
+  Latency        1.04ms   346.51us     4.50ms
   Latency Distribution
-     50%     0.97ms
-     75%     1.30ms
-     90%     1.66ms
-     99%     2.71ms
+     50%     0.96ms
+     75%     1.28ms
+     90%     1.64ms
+     99%     2.54ms
 ### Exception Endpoint (/exc)
-  Reqs/sec    135710.25   12626.48  143277.56
-  Latency      721.08us   304.87us     6.46ms
+  Reqs/sec     90328.33   24211.75  118182.19
+  Latency        1.07ms   767.52us     7.95ms
   Latency Distribution
-     50%   658.00us
-     75%     0.88ms
-     90%     1.14ms
-     99%     1.99ms
+     50%   780.00us
+     75%     1.29ms
+     90%     2.32ms
+     99%     4.78ms
 ### HTML Response (/html)
-  Reqs/sec    150435.91   14115.04  161285.26
-  Latency      643.31us   411.33us     6.22ms
+  Reqs/sec    147223.54    9837.78  157623.14
+  Latency      661.76us   357.48us     5.68ms
   Latency Distribution
-     50%   539.00us
-     75%   735.00us
-     90%     1.13ms
-     99%     3.02ms
+     50%   565.00us
+     75%   785.00us
+     90%     1.14ms
+     99%     2.35ms
 ### Redirect Response (/redirect)
 ### File Static via FileResponse (/file-static)
-  Reqs/sec     35232.17    7367.40   39461.79
-  Latency        2.84ms     1.45ms    21.66ms
+  Reqs/sec     34264.72    6887.41   39494.49
+  Latency        2.92ms     1.55ms    19.55ms
   Latency Distribution
-     50%     2.55ms
-     75%     3.42ms
-     90%     4.44ms
-     99%     8.55ms
+     50%     2.61ms
+     75%     3.52ms
+     90%     4.60ms
+     99%     9.39ms
 
 ## Authentication & Authorization Performance
 ### Auth NO User Access (/auth/no-user-access) - lazy loading, no DB query
-  Reqs/sec     72795.59    5057.83   77449.33
-  Latency        1.35ms   415.92us     5.21ms
+  Reqs/sec     71197.40    6635.75   82337.31
+  Latency        1.40ms   442.41us     5.41ms
   Latency Distribution
-     50%     1.26ms
-     75%     1.63ms
-     90%     2.06ms
-     99%     3.19ms
+     50%     1.31ms
+     75%     1.73ms
+     90%     2.17ms
+     99%     3.34ms
 ### Get Authenticated User (/auth/me) - accesses request.user, triggers DB query
-  Reqs/sec     16906.09    1443.31   19166.16
-  Latency        5.90ms     1.25ms    13.77ms
+  Reqs/sec     16274.47    1700.12   17515.81
+  Latency        6.10ms     2.26ms    20.90ms
   Latency Distribution
-     50%     5.82ms
-     75%     6.84ms
-     90%     7.70ms
-     99%    10.07ms
+     50%     6.01ms
+     75%     7.55ms
+     90%     9.48ms
+     99%    13.19ms
 ### Get User via Dependency (/auth/me-dependency)
- 2975 / 10000 [========================>---------------------------------------------------------]  29.75% 14830/s
- 9075 / 10000 [==========================================================================>-------]  90.75% 15090/s
-  Reqs/sec     15160.46     834.21   16563.58
-  Latency        6.56ms     1.67ms    14.27ms
+  Reqs/sec     14445.48    1497.98   16959.67
+  Latency        6.90ms     2.22ms    33.06ms
   Latency Distribution
-     50%     6.64ms
-     75%     7.92ms
-     90%     9.05ms
-     99%    11.19ms
+     50%     6.50ms
+     75%     8.41ms
+     90%    10.12ms
+     99%    13.77ms
 ### Get Auth Context (/auth/context) validated jwt no db
-  Reqs/sec     79429.55    5639.93   86334.60
-  Latency        1.22ms   429.22us     5.35ms
+  Reqs/sec     79059.59    5436.89   83433.91
+  Latency        1.25ms   421.95us     5.28ms
   Latency Distribution
-     50%     1.09ms
-     75%     1.56ms
-     90%     2.07ms
-     99%     3.09ms
+     50%     1.15ms
+     75%     1.55ms
+     90%     2.03ms
+     99%     3.01ms
 
 ## Items GET Performance (/items/1?q=hello)
-  Reqs/sec    148366.29   18693.95  167775.79
-  Latency      622.61us   322.11us     5.99ms
+  Reqs/sec    137133.39   10319.66  145008.55
+  Latency      709.32us   396.50us     6.43ms
   Latency Distribution
-     50%   576.00us
-     75%   682.00us
-     90%   820.00us
-     99%     2.27ms
+     50%   627.00us
+     75%   837.00us
+     90%     1.17ms
+     99%     2.42ms
 
 ## Items PUT JSON Performance (/items/1)
-  Reqs/sec    142994.39   12642.19  154517.37
-  Latency      665.90us   252.83us     5.18ms
+  Reqs/sec    131091.35   13409.43  140616.87
+  Latency      736.65us   405.54us     5.68ms
   Latency Distribution
-     50%   615.00us
-     75%   758.00us
-     90%     1.02ms
-     99%     1.81ms
+     50%   620.00us
+     75%     0.85ms
+     90%     1.25ms
+     99%     2.71ms
 
 ## ORM Performance
 Seeding 1000 users for benchmark...
 Successfully seeded users
 Validated: 10 users exist in database
 ### Users Full10 (Async) (/users/full10)
-  Reqs/sec     14801.05    1923.87   23929.10
-  Latency        6.83ms     1.56ms    20.71ms
+  Reqs/sec     14607.40    1562.21   18265.54
+  Latency        6.84ms     1.88ms    19.42ms
   Latency Distribution
-     50%     6.98ms
-     75%     8.07ms
-     90%     8.94ms
-     99%    11.32ms
+     50%     6.77ms
+     75%     8.00ms
+     90%     9.28ms
+     99%    13.78ms
 ### Users Full10 (Sync) (/users/sync-full10)
-  Reqs/sec     10317.50    1098.58   13189.40
-  Latency        9.60ms     4.06ms    30.53ms
+  Reqs/sec     10460.55    1306.19   12605.26
+  Latency        9.40ms     4.58ms    36.74ms
   Latency Distribution
-     50%     8.75ms
-     75%    12.03ms
-     90%    15.76ms
-     99%    22.38ms
+     50%     8.71ms
+     75%    12.01ms
+     90%    16.08ms
+     99%    23.91ms
 ### Users Mini10 (Async) (/users/mini10)
-  Reqs/sec     17433.32    2291.05   20092.78
-  Latency        5.58ms     1.51ms    12.77ms
+  Reqs/sec     17842.26     938.88   20155.08
+  Latency        5.57ms     1.48ms    14.88ms
   Latency Distribution
-     50%     5.43ms
-     75%     7.04ms
-     90%     8.06ms
-     99%     9.80ms
+     50%     5.51ms
+     75%     6.75ms
+     90%     7.95ms
+     99%     9.83ms
 ### Users Mini10 (Sync) (/users/sync-mini10)
-  Reqs/sec     11989.54     679.38   13447.85
-  Latency        8.31ms     3.56ms    30.98ms
+ 9475 / 10000 [================================================>--]  94.75% 11811/s
+  Reqs/sec     12030.87    1506.23   19826.67
+  Latency        8.39ms     2.91ms    25.61ms
   Latency Distribution
-     50%     7.66ms
-     75%    10.21ms
-     90%    13.18ms
-     99%    20.89ms
+     50%     7.83ms
+     75%    10.18ms
+     90%    12.75ms
+     99%    18.05ms
 Cleaning up test users...
 
 ## Class-Based Views (CBV) Performance
 ### Simple APIView GET (/cbv-simple)
-  Reqs/sec     98740.96    8391.17  109218.61
-  Latency        0.99ms   321.48us     4.86ms
+  Reqs/sec     98716.13    8290.42  105414.35
+  Latency        0.99ms   363.02us     5.34ms
   Latency Distribution
-     50%     0.93ms
-     75%     1.23ms
-     90%     1.54ms
-     99%     2.36ms
+     50%     0.90ms
+     75%     1.22ms
+     90%     1.61ms
+     99%     2.48ms
 ### Simple APIView POST (/cbv-simple)
-  Reqs/sec    101381.91    6864.73  108580.08
-  Latency        0.97ms   311.64us     4.44ms
+  Reqs/sec     99384.22    7427.84  104149.62
+  Latency        0.99ms   333.29us     5.50ms
   Latency Distribution
-     50%     0.91ms
-     75%     1.20ms
-     90%     1.54ms
-     99%     2.25ms
+     50%     0.92ms
+     75%     1.22ms
+     90%     1.53ms
+     99%     2.27ms
 ### Items100 ViewSet GET (/cbv-items100)
-  Reqs/sec     62061.14    8083.23   68264.80
-  Latency        1.55ms   465.53us     5.87ms
+  Reqs/sec     67244.33    5604.23   73162.28
+  Latency        1.48ms   465.55us     6.66ms
   Latency Distribution
-     50%     1.47ms
-     75%     1.86ms
-     90%     2.32ms
-     99%     3.55ms
+     50%     1.38ms
+     75%     1.73ms
+     90%     2.12ms
+     99%     3.54ms
 
 ## CBV Items - Basic Operations
 ### CBV Items GET (Retrieve) (/cbv-items/1)
-  Reqs/sec     94215.98    8078.48  100194.58
-  Latency        1.05ms   342.78us     4.75ms
+  Reqs/sec     93848.94    7174.00   99444.56
+  Latency        1.05ms   375.02us     6.22ms
+  Latency Distribution
+     50%     0.99ms
+     75%     1.32ms
+     90%     1.66ms
+     99%     2.59ms
+### CBV Items PUT (Update) (/cbv-items/1)
+  Reqs/sec     92910.88    4879.49   96606.64
+  Latency        1.05ms   329.23us     4.51ms
   Latency Distribution
      50%     0.97ms
-     75%     1.32ms
-     90%     1.67ms
-     99%     2.47ms
-### CBV Items PUT (Update) (/cbv-items/1)
-  Reqs/sec    100325.56    7556.51  105825.67
-  Latency        0.98ms   347.79us     6.95ms
-  Latency Distribution
-     50%     0.91ms
-     75%     1.20ms
-     90%     1.52ms
-     99%     2.50ms
+     75%     1.34ms
+     90%     1.68ms
+     99%     2.44ms
 
 ## CBV Additional Benchmarks
 ### CBV Bench Parse (POST /cbv-bench-parse)
-  Reqs/sec    100307.91    8934.32  105465.80
-  Latency        0.98ms   336.91us     4.84ms
+  Reqs/sec     95188.76    6968.43  101098.94
+  Latency        1.03ms   373.27us     6.52ms
   Latency Distribution
-     50%     0.90ms
-     75%     1.23ms
-     90%     1.56ms
-     99%     2.47ms
+     50%     0.96ms
+     75%     1.29ms
+     90%     1.67ms
+     99%     2.39ms
 ### CBV Response Types (/cbv-response)
-  Reqs/sec    109983.00    8781.15  116353.84
-  Latency        0.89ms   269.22us     4.97ms
+  Reqs/sec     98753.72    5203.94  102677.95
+  Latency        0.99ms   383.01us     5.03ms
   Latency Distribution
-     50%     0.85ms
-     75%     1.08ms
-     90%     1.34ms
-     99%     1.91ms
+     50%     0.88ms
+     75%     1.25ms
+     90%     1.62ms
+     99%     2.67ms
 
 ## ORM Performance with CBV
 Seeding 1000 users for CBV benchmark...
 Successfully seeded users
 Validated: 10 users exist in database
 ### Users CBV Mini10 (List) (/users/cbv-mini10)
-  Reqs/sec     16329.43    1265.38   17812.83
-  Latency        6.08ms     1.89ms    19.04ms
+  Reqs/sec     16503.27    1346.14   19294.60
+  Latency        6.05ms     1.31ms    14.51ms
   Latency Distribution
-     50%     5.83ms
-     75%     7.21ms
-     90%     9.07ms
-     99%    12.28ms
+     50%     5.92ms
+     75%     7.02ms
+     90%     8.01ms
+     99%    10.21ms
 Cleaning up test users...
 
 
 ## Form and File Upload Performance
 ### Form Data (POST /form)
-  Reqs/sec    132183.23   13325.76  145831.82
-  Latency      735.06us   336.77us     5.75ms
+  Reqs/sec     88783.02   38334.23  134782.28
+  Latency        1.00ms   737.27us    10.14ms
   Latency Distribution
-     50%   659.00us
-     75%     0.92ms
-     90%     1.15ms
-     99%     2.14ms
+     50%   710.00us
+     75%     1.19ms
+     90%     2.06ms
+     99%     4.29ms
 ### File Upload (POST /upload)
-  Reqs/sec    114217.72    7874.02  123498.49
-  Latency        0.85ms   389.74us     7.59ms
+  Reqs/sec    112500.46   12567.52  128093.35
+  Latency        0.87ms   424.00us     7.16ms
   Latency Distribution
-     50%   768.00us
+     50%   794.00us
      75%     1.03ms
-     90%     1.32ms
-     99%     2.31ms
+     90%     1.43ms
+     99%     2.49ms
 ### Mixed Form with Files (POST /mixed-form)
-  Reqs/sec    115074.67   12009.75  129253.02
-  Latency        0.87ms   347.61us     5.62ms
+  Reqs/sec    108419.11    9046.78  115740.97
+  Latency        0.90ms   343.61us     6.13ms
   Latency Distribution
-     50%   802.00us
-     75%     0.98ms
-     90%     1.31ms
-     99%     2.30ms
+     50%   836.00us
+     75%     1.05ms
+     90%     1.44ms
+     99%     2.44ms
 
 ## Django Middleware Performance
 ### Django Middleware + Messages Framework (/middleware/demo)
 Tests: SessionMiddleware, AuthenticationMiddleware, MessageMiddleware, custom middleware, template rendering
-  Reqs/sec      9304.35     956.13   10764.53
-  Latency       10.72ms     2.58ms    25.52ms
+  Reqs/sec      9305.09    1061.92   10820.41
+  Latency       10.72ms     3.14ms    40.74ms
   Latency Distribution
-     50%    10.71ms
-     75%    12.44ms
-     90%    14.11ms
-     99%    18.67ms
+     50%    10.08ms
+     75%    12.60ms
+     90%    15.05ms
+     99%    21.25ms
 
 ## Django Ninja-style Benchmarks
 ### JSON Parse/Validate (POST /bench/parse)
-  Reqs/sec    146012.25   11713.84  157582.73
-  Latency      650.73us   383.23us     6.11ms
+  Reqs/sec    137484.23   10098.43  144636.42
+  Latency      705.65us   369.61us     5.13ms
   Latency Distribution
-     50%   582.00us
-     75%   754.00us
-     90%     0.96ms
-     99%     2.23ms
+     50%   579.00us
+     75%   837.00us
+     90%     1.26ms
+     99%     2.54ms
 
 ## Serializer Performance Benchmarks
 ### Raw msgspec Serializer (POST /bench/serializer-raw)
-  Reqs/sec     99654.01   10749.75  116292.59
-  Latency        1.02ms   310.02us     4.97ms
+  Reqs/sec     95020.32    8164.93  101173.07
+  Latency        1.04ms   382.06us     6.07ms
   Latency Distribution
-     50%     0.95ms
+     50%     0.96ms
      75%     1.25ms
      90%     1.56ms
-     99%     2.31ms
+     99%     2.56ms
 ### Django-Bolt Serializer with Validators (POST /bench/serializer-validated)
-  Reqs/sec     86046.42    4837.14   91699.58
-  Latency        1.14ms   371.29us     4.74ms
+  Reqs/sec     86538.77    8355.82   92260.57
+  Latency        1.14ms   446.35us     6.36ms
   Latency Distribution
-     50%     1.07ms
-     75%     1.39ms
-     90%     1.76ms
+     50%     1.06ms
+     75%     1.37ms
+     90%     1.68ms
      99%     2.81ms
 ### Users msgspec Serializer (POST /users/bench/msgspec)
-  Reqs/sec     98333.01    8485.81  103738.50
-  Latency        0.99ms   316.39us     5.03ms
+  Reqs/sec     83740.46   14161.86   96996.99
+  Latency        1.17ms   587.38us     6.43ms
   Latency Distribution
-     50%     0.94ms
-     75%     1.21ms
-     90%     1.52ms
-     99%     2.30ms
+     50%     1.01ms
+     75%     1.42ms
+     90%     1.88ms
+     99%     4.29ms
 
 ## Multi-Response Performance
 
 ### Multi-response tuple return (/bench/multi/tuple)
-  Reqs/sec     99671.12    8316.88  107173.43
-  Latency        0.99ms   345.26us     5.08ms
+  Reqs/sec     97255.54    7057.22  102382.83
+  Latency        1.01ms   348.95us     5.08ms
   Latency Distribution
-     50%     0.92ms
-     75%     1.22ms
-     90%     1.53ms
-     99%     2.38ms
+     50%     0.93ms
+     75%     1.28ms
+     90%     1.60ms
+     99%     2.41ms
 
 ### Multi-response bare dict (/bench/multi/dict)
-  Reqs/sec    104526.13    8500.09  109440.41
-  Latency        0.94ms   307.44us     4.54ms
+  Reqs/sec     96798.64    7434.82  103733.11
+  Latency        1.02ms   322.49us     4.45ms
   Latency Distribution
-     50%     0.87ms
-     75%     1.16ms
-     90%     1.45ms
-     99%     2.18ms
+     50%     0.96ms
+     75%     1.30ms
+     90%     1.63ms
+     99%     2.35ms
 
 ## Latency Percentile Benchmarks
 Measures p50/p75/p90/p99 latency for type coercion overhead analysis
 
 ### Baseline - No Parameters (/)
-  Reqs/sec    175552.68   17023.98  185573.53
-  Latency      556.40us   311.83us     5.34ms
+  Reqs/sec    160316.32   16219.53  179658.89
+  Latency      626.84us   353.48us     5.27ms
   Latency Distribution
-     50%   476.00us
-     75%   666.00us
-     90%     0.92ms
-     99%     2.01ms
+     50%   534.00us
+     75%   714.00us
+     90%     1.07ms
+     99%     2.46ms
 
 ### Path Parameter - int (/items/12345)
-  Reqs/sec    158351.48   14701.02  168321.28
-  Latency      614.65us   361.51us     5.47ms
+  Reqs/sec    139801.99   15082.44  150070.37
+  Latency      699.82us   360.94us     5.17ms
   Latency Distribution
-     50%   553.00us
-     75%   687.00us
-     90%     0.88ms
-     99%     2.16ms
+     50%   602.00us
+     75%     0.85ms
+     90%     1.17ms
+     99%     2.38ms
 
 ### Path + Query Parameters (/items/12345?q=hello)
-  Reqs/sec    153661.65   13872.43  167005.27
-  Latency      629.98us   308.63us     6.19ms
+  Reqs/sec    139380.05   10986.36  149147.00
+  Latency      695.66us   321.48us     8.62ms
   Latency Distribution
-     50%   549.00us
-     75%   754.00us
-     90%     0.99ms
-     99%     1.88ms
+     50%   605.00us
+     75%   845.00us
+     90%     1.20ms
+     99%     2.17ms
 
 ### Header Parameter (/header)
-  Reqs/sec    101234.71    8477.51  107710.37
-  Latency        0.97ms   343.10us     6.07ms
+  Reqs/sec     95891.78    7577.74  104317.52
+  Latency        1.01ms   371.23us     6.07ms
   Latency Distribution
-     50%     0.90ms
-     75%     1.17ms
-     90%     1.50ms
-     99%     2.28ms
+     50%     0.95ms
+     75%     1.24ms
+     90%     1.60ms
+     99%     2.44ms
 
 ### Cookie Parameter (/cookie)
-  Reqs/sec    103889.79    9328.12  110016.31
-  Latency        0.94ms   308.42us     4.72ms
+  Reqs/sec     95526.65    5408.54  100943.85
+  Latency        1.04ms   369.34us     5.25ms
   Latency Distribution
-     50%     0.89ms
-     75%     1.17ms
-     90%     1.46ms
-     99%     2.24ms
+     50%     0.95ms
+     75%     1.28ms
+     90%     1.68ms
+     99%     2.52ms
 
 ### Auth Context - JWT validated, no DB (/auth/context)
-  Reqs/sec     83544.84    5808.34   87354.81
-  Latency        1.17ms   501.73us     6.02ms
+  Reqs/sec     78518.53    4630.67   83147.92
+  Latency        1.25ms   359.57us     5.62ms
   Latency Distribution
-     50%     1.02ms
-     75%     1.40ms
-     90%     1.99ms
-     99%     3.56ms
+     50%     1.18ms
+     75%     1.56ms
+     90%     1.91ms
+     99%     2.70ms

--- a/python/django_bolt/admin/static.py
+++ b/python/django_bolt/admin/static.py
@@ -6,8 +6,6 @@ Provides static file serving for Django admin and other static assets.
 
 import mimetypes
 import os
-import sys
-from pathlib import Path
 
 from django.conf import settings
 
@@ -30,31 +28,10 @@ def find_static_file(path: str) -> str | None:
     Returns:
         Absolute path to file if found, None otherwise
     """
-    try:
-        # First try STATIC_ROOT (collected static files in production)
-        if hasattr(settings, "STATIC_ROOT") and settings.STATIC_ROOT:
-            static_root = Path(settings.STATIC_ROOT)
-            file_path = static_root / path
-            if file_path.exists() and file_path.is_file():
-                return str(file_path)
-
-        # Try using Django's static file finders (development mode)
-        if find is not None:
-            found_path = find(path)
-            if found_path:
-                return found_path
-
-        # Fallback: check STATICFILES_DIRS
-        if hasattr(settings, "STATICFILES_DIRS"):
-            for static_dir in settings.STATICFILES_DIRS:
-                if isinstance(static_dir, tuple):
-                    static_dir = static_dir[1]  # (prefix, path) tuple
-                file_path = Path(static_dir) / path
-                if file_path.exists() and file_path.is_file():
-                    return str(file_path)
-
-    except Exception as e:
-        print(f"[django-bolt] Warning: Error finding static file {path}: {e}", file=sys.stderr)
+    if find is not None:
+        found_path = find(path)
+        if found_path:
+            return found_path
 
     return None
 
@@ -104,10 +81,6 @@ async def serve_static_file(path: str) -> tuple[int, list[tuple[str, str]], byte
     Returns:
         Response tuple: (status_code, headers, body)
     """
-    # Security: prevent directory traversal
-    if ".." in path or path.startswith("/"):
-        raise HTTPException(400, "Invalid static file path")
-
     # Find the static file
     file_path = find_static_file(path)
 

--- a/python/django_bolt/auth/backends.py
+++ b/python/django_bolt/auth/backends.py
@@ -24,7 +24,7 @@ from typing import Any
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
-from django.db import OperationalError, InterfaceError
+from django.db import InterfaceError, OperationalError
 
 from .revocation import create_revocation_handler
 

--- a/python/django_bolt/health.py
+++ b/python/django_bolt/health.py
@@ -43,7 +43,7 @@ class HealthCheck:
         results = {}
         all_healthy = True
 
-        for check, result in zip(self._checks, results_list):
+        for check, result in zip(self._checks, results_list, strict=True):
             if isinstance(result, Exception):
                 results[check.__name__] = {
                     "healthy": False,

--- a/python/django_bolt/management/commands/runbolt.py
+++ b/python/django_bolt/management/commands/runbolt.py
@@ -9,6 +9,8 @@ import importlib.util
 import os
 import signal
 import sys
+import warnings
+from pathlib import Path
 
 from django.apps import apps
 from django.conf import settings
@@ -16,11 +18,6 @@ from django.core.management.base import BaseCommand, CommandError
 
 from django_bolt import _core
 from django_bolt.api import BoltAPI, _validate_asgi_mount_conflicts, serve_with_lifespan
-
-try:
-    from django.utils import autoreload
-except ImportError:
-    autoreload = None
 
 try:
     from django_bolt.logging.config import setup_django_logging
@@ -33,6 +30,145 @@ try:
     from django_bolt.admin.admin_detection import detect_admin_url_prefix
 except ImportError:
     detect_admin_url_prefix = None
+
+
+_ENV_DEV_WORKER = "DJANGO_BOLT_DEV_WORKER"
+_ENV_DEV_RELOAD_COUNT = "DJANGO_BOLT_DEV_RELOAD_COUNT"
+
+DEV_RELOAD_IGNORE_DIRS = (
+    ".git",
+    ".hg",
+    ".svn",
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "node_modules",
+    "target",
+)
+
+
+def _get_dev_reload_count() -> int:
+    try:
+        return int(os.environ.get(_ENV_DEV_RELOAD_COUNT, "0"))
+    except ValueError:
+        return 0
+
+
+def _is_dev_reload_restart() -> bool:
+    return os.environ.get(_ENV_DEV_WORKER) == "1" and _get_dev_reload_count() > 0
+
+
+def _path_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _collapse_watch_paths(paths: set[Path]) -> list[Path]:
+    collapsed: list[Path] = []
+
+    for path in sorted(paths, key=lambda item: (len(item.parts), str(item))):
+        if any(_path_within(path, existing) for existing in collapsed):
+            continue
+        collapsed.append(path)
+
+    return collapsed
+
+
+def _build_dev_worker_command(argv: list[str] | None = None, executable: str | None = None) -> list[str]:
+    argv = sys.argv if argv is None else argv
+    executable = sys.executable if executable is None else executable
+
+    command = [executable]
+    saw_processes = False
+    it = iter(argv)
+
+    for arg in it:
+        if arg == "--dev" or arg.startswith("--dev="):
+            continue
+
+        if arg == "--processes":
+            next(it, None)
+            saw_processes = True
+            command.extend(["--processes", "1"])
+            continue
+
+        if arg.startswith("--processes="):
+            saw_processes = True
+            command.append("--processes=1")
+            continue
+
+        command.append(arg)
+
+    if not saw_processes:
+        command.extend(["--processes", "1"])
+
+    return command
+
+
+def _coerce_path(value) -> Path | None:
+    try:
+        return Path(os.fspath(value)).resolve()
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _venv_prefix_paths() -> set[Path]:
+    paths: set[Path] = set()
+    for prefix in {sys.prefix, sys.base_prefix, sys.exec_prefix}:
+        if not prefix:
+            continue
+        path = _coerce_path(prefix)
+        if path is not None and path.exists():
+            paths.add(path)
+    return paths
+
+
+def _collect_dev_watch_paths() -> list[str]:
+    watch_paths: set[Path] = {Path.cwd().resolve()}
+
+    base_dir = _coerce_path(getattr(settings, "BASE_DIR", None))
+    if base_dir is not None and base_dir.exists():
+        watch_paths.add(base_dir)
+
+    template_configs = getattr(settings, "TEMPLATES", [])
+    for config in template_configs:
+        for template_dir in config.get("DIRS", []):
+            path = _coerce_path(template_dir)
+            if path is not None and path.exists():
+                watch_paths.add(path)
+
+    static_dirs = getattr(settings, "STATICFILES_DIRS", [])
+    for static_dir in static_dirs:
+        if isinstance(static_dir, tuple):
+            static_dir = static_dir[1]
+        path = _coerce_path(static_dir)
+        if path is not None and path.exists():
+            watch_paths.add(path)
+
+    prefix_roots = _venv_prefix_paths()
+
+    if apps.ready:
+        for app_config in apps.get_app_configs():
+            app_path = _coerce_path(app_config.path)
+            if app_path is None or not app_path.exists():
+                continue
+
+            if any(_path_within(app_path, prefix_root) for prefix_root in prefix_roots):
+                continue
+
+            watch_paths.add(app_path)
+
+    return [str(path) for path in _collapse_watch_paths(watch_paths)]
+
+
+def _collect_dev_ignore_paths() -> list[str]:
+    return [str(path) for path in sorted(_venv_prefix_paths(), key=str)]
 
 
 def _is_django_bolt_attribute(node: ast.Attribute) -> bool:
@@ -90,10 +226,9 @@ def find_bolt_api_names(module_name: str) -> list[str]:
                     bolt_api_aliases.add("BoltAPI")
         elif isinstance(node, ast.Import):
             for alias in node.names:
-                if "django_bolt" in alias.name:
+                if "django_bolt" in alias.name and alias.asname:
                     # `import django_bolt.api as bolt` → track the alias
-                    if alias.asname:
-                        module_aliases.add(alias.asname)
+                    module_aliases.add(alias.asname)
 
     # Find top-level assignments where RHS is a call to a BoltAPI alias
     names: list[str] = []
@@ -153,9 +288,11 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         processes = options["processes"]
         dev_mode = options.get("dev", False)
+        dev_worker_mode = os.environ.get(_ENV_DEV_WORKER) == "1"
+        effective_dev_mode = dev_mode or dev_worker_mode
 
         # Dev mode: force single process + enable auto-reload
-        if dev_mode:
+        if dev_mode and not dev_worker_mode:
             if processes > 1:
                 self.stdout.write(self.style.WARNING("  Warning: dev mode forces --processes=1 for auto-reload"))
                 options["processes"] = 1
@@ -166,23 +303,23 @@ class Command(BaseCommand):
             if processes > 1:
                 self.start_multiprocess(options)
             else:
-                self.start_single_process(options)
+                self.start_single_process(options, dev_mode=effective_dev_mode)
 
     def run_with_autoreload(self, options):
-        """Run server with auto-reload using Django's autoreload system"""
-        if autoreload is None:
-            self.stdout.write(
-                self.style.ERROR("  Error: Django autoreload not available. Upgrade Django or use --no-dev mode.")
-            )
-            sys.exit(1)
+        """Run the server behind the native dev supervisor."""
+        worker_command = _build_dev_worker_command()
+        watch_paths = _collect_dev_watch_paths()
+        ignore_paths = _collect_dev_ignore_paths()
 
-        # Use Django's autoreload system which is optimized
-        # It only restarts the Python interpreter when necessary
-        # and reuses the same process for faster reloads
-        def run_server():
-            self.start_single_process(options, dev_mode=True)
+        exit_code = _core.run_dev_reloader(
+            worker_command,
+            watch_paths,
+            list(DEV_RELOAD_IGNORE_DIRS),
+            ignore_paths,
+        )
 
-        autoreload.run_with_reloader(run_server)
+        if exit_code:
+            sys.exit(exit_code)
 
     def start_multiprocess(self, options):
         """Start multiple processes with SO_REUSEPORT.
@@ -320,6 +457,15 @@ class Command(BaseCommand):
 
     def start_single_process(self, options, process_id=None, dev_mode=False):
         """Start a single process server"""
+        is_dev_reload_restart = _is_dev_reload_restart()
+
+        if is_dev_reload_restart:
+            warnings.filterwarnings(
+                "ignore",
+                message=r"Sync handler '.*' at .* uses ORM operations .*Running in thread pool\.",
+                category=UserWarning,
+            )
+
         # Setup Django logging once at server startup (one-shot, respects existing LOGGING)
         if setup_django_logging is not None:
             setup_django_logging()
@@ -454,16 +600,19 @@ class Command(BaseCommand):
 
         # Print structured startup banner (only for main process or single-process mode)
         if process_id is None:
-            self._print_startup_banner(
-                options=options,
-                dev_mode=dev_mode,
-                api_routes=_user_route_count,
-                framework_routes=_framework_route_count,
-                ws_routes=len(ws_routes),
-                asgi_mounts=len(merged_api._asgi_mounts),
-                api_count=len(apis),
-                features=features,
-            )
+            if is_dev_reload_restart:
+                self.stdout.write(f"  ✨ Reloaded on http://{options['host']}:{options['port']}")
+            else:
+                self._print_startup_banner(
+                    options=options,
+                    dev_mode=dev_mode,
+                    api_routes=_user_route_count,
+                    framework_routes=_framework_route_count,
+                    ws_routes=len(ws_routes),
+                    asgi_mounts=len(merged_api._asgi_mounts),
+                    api_count=len(apis),
+                    features=features,
+                )
 
         # Collect lifecycle contexts (merged APIs store them, single APIs check directly)
         source_lifespans = merged_api._source_lifespans

--- a/python/example/testproject/api.py
+++ b/python/example/testproject/api.py
@@ -59,6 +59,12 @@ api = BoltAPI(
         enabled=True,
     ),
 )
+@api.get("/", tags=["root"], summary="summary", description="description")
+async def read_root():
+    """
+    Endpoint that returns a simple "Hello World" dictionary.
+    """
+    return {"message": "Hello World"}
 
 #
 # 2. Custom compression with specific settings:
@@ -379,12 +385,6 @@ async def generate_token(token_req: TokenRequest):
     }
 
 
-@api.get("/", tags=["root"], summary="summary", description="description")
-async def read_root():
-    """
-    Endpoint that returns a simple "Hello World" dictionary.
-    """
-    return {"message": "Hello World"}
 
 
 @api.get("/sync", tags=["root"], summary="summary", description="description")

--- a/python/tests/test_runbolt_dev.py
+++ b/python/tests/test_runbolt_dev.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from django_bolt.management.commands import runbolt as runbolt_module
+
+
+def test_build_dev_worker_command_removes_dev_and_forces_single_process():
+    command = runbolt_module._build_dev_worker_command(
+        [
+            "manage.py",
+            "--settings=testproject.settings",
+            "runbolt",
+            "--dev",
+            "--host",
+            "127.0.0.1",
+            "--processes=4",
+        ],
+        executable="/usr/bin/python3",
+    )
+
+    assert command == [
+        "/usr/bin/python3",
+        "manage.py",
+        "--settings=testproject.settings",
+        "runbolt",
+        "--host",
+        "127.0.0.1",
+        "--processes=1",
+    ]
+
+
+def test_collapse_watch_paths_deduplicates_nested_directories(tmp_path):
+    root = tmp_path / "project"
+    nested = root / "app"
+    sibling = tmp_path / "templates"
+    nested.mkdir(parents=True)
+    sibling.mkdir()
+
+    collapsed = runbolt_module._collapse_watch_paths({root, nested, sibling})
+
+    assert collapsed == [root, sibling]
+
+
+def test_collect_dev_watch_paths_prefers_project_paths(settings, tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    templates_root = tmp_path / "templates"
+    static_root = tmp_path / "static"
+    external_app = tmp_path / "shared_app"
+    venv_root = tmp_path / "venv"
+    venv_app = venv_root / "lib" / "site-packages" / "third_party_app"
+
+    for path in (project_root, templates_root, static_root, external_app, venv_app):
+        path.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.chdir(project_root)
+    monkeypatch.setattr(runbolt_module.sys, "prefix", str(venv_root))
+    monkeypatch.setattr(runbolt_module.sys, "base_prefix", str(venv_root))
+    monkeypatch.setattr(runbolt_module.sys, "exec_prefix", str(venv_root))
+    monkeypatch.setattr(
+        runbolt_module,
+        "apps",
+        SimpleNamespace(
+            ready=True,
+            get_app_configs=lambda: [
+                SimpleNamespace(path=str(external_app)),
+                SimpleNamespace(path=str(venv_app)),
+            ],
+        ),
+    )
+
+    settings.BASE_DIR = project_root
+    settings.TEMPLATES = [{"DIRS": [templates_root]}]
+    settings.STATICFILES_DIRS = [static_root]
+
+    watch_paths = set(runbolt_module._collect_dev_watch_paths())
+
+    assert str(project_root) in watch_paths
+    assert str(templates_root) in watch_paths
+    assert str(static_root) in watch_paths
+    assert str(external_app) in watch_paths
+    assert str(venv_app) not in watch_paths

--- a/python/tests/test_static_files.py
+++ b/python/tests/test_static_files.py
@@ -15,11 +15,23 @@ import os
 import tempfile
 
 import pytest
+from django.core.exceptions import SuspiciousFileOperation
+from django.contrib.staticfiles.finders import get_finder
 
 from django_bolt import BoltAPI
-from django_bolt.admin.static import find_static_file
+from django_bolt.admin.static import find_static_file, serve_static_file
+from django_bolt.exceptions import HTTPException
 from django_bolt.shortcuts import render
 from django_bolt.testing import TestClient
+
+
+@pytest.fixture(autouse=True)
+def clear_staticfiles_finder_cache():
+    """Reset Django's cached static finders between tests that mutate settings."""
+    get_finder.cache_clear()
+    yield
+    get_finder.cache_clear()
+
 
 # Create test static files directory
 TEST_STATIC_DIR = tempfile.mkdtemp(prefix="django_bolt_static_")
@@ -123,23 +135,26 @@ class TestFindStaticFile:
     """Tests for the find_static_file function used by Django finders fallback."""
 
     def test_find_file_in_static_root(self, monkeypatch):
-        """Test finding a file in STATIC_ROOT."""
+        """Test that finder-only lookup does not search STATIC_ROOT."""
         from django.conf import settings
 
-        # Temporarily set STATIC_ROOT
         original_root = getattr(settings, "STATIC_ROOT", None)
+        original_dirs = getattr(settings, "STATICFILES_DIRS", None)
         settings.STATIC_ROOT = TEST_STATIC_DIR
+        settings.STATICFILES_DIRS = []
 
         try:
             result = find_static_file("css/style.css")
-            assert result is not None
-            assert result.endswith("css/style.css")
-            assert os.path.isfile(result)
+            assert result is None
         finally:
-            if original_root:
+            if original_root is not None:
                 settings.STATIC_ROOT = original_root
-            else:
+            elif hasattr(settings, "STATIC_ROOT"):
                 delattr(settings, "STATIC_ROOT")
+            if original_dirs is not None:
+                settings.STATICFILES_DIRS = original_dirs
+            elif hasattr(settings, "STATICFILES_DIRS"):
+                delattr(settings, "STATICFILES_DIRS")
 
     def test_find_file_in_staticfiles_dirs(self, monkeypatch):
         """Test finding a file in STATICFILES_DIRS."""
@@ -161,9 +176,9 @@ class TestFindStaticFile:
             assert result is not None
             assert result.endswith("custom.css")
         finally:
-            if original_dirs:
+            if original_dirs is not None:
                 settings.STATICFILES_DIRS = original_dirs
-            else:
+            elif hasattr(settings, "STATICFILES_DIRS"):
                 delattr(settings, "STATICFILES_DIRS")
 
     def test_find_nonexistent_file(self):
@@ -172,12 +187,33 @@ class TestFindStaticFile:
         assert result is None
 
     def test_directory_traversal_blocked(self):
-        """Test that directory traversal attempts are blocked."""
-        result = find_static_file("../etc/passwd")
-        assert result is None
+        """Test that traversal attempts are blocked by the finder."""
+        with pytest.raises(SuspiciousFileOperation):
+            find_static_file("../etc/passwd")
 
         result = find_static_file("..\\windows\\system32")
         assert result is None
+
+    def test_windows_absolute_paths_return_none(self):
+        """Test that Windows absolute paths are not resolved by the finder."""
+        assert find_static_file("C:/Windows/win.ini") is None
+        assert find_static_file("D:/secret.txt") is None
+        assert find_static_file("C:temp/file.txt") is None
+        assert find_static_file("\\\\server\\share\\file.txt") is None
+
+    @pytest.mark.asyncio
+    async def test_serve_static_file_returns_not_found_for_windows_absolute_paths(self):
+        """Test that Windows absolute paths fall through to not found."""
+        with pytest.raises(HTTPException) as exc_info:
+            await serve_static_file("C:/Windows/win.ini")
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_serve_static_file_rejects_traversal_paths(self):
+        """Test that traversal paths raise Django's original error."""
+        with pytest.raises(SuspiciousFileOperation):
+            await serve_static_file("../etc/passwd")
 
 
 class TestStaticFileServing:
@@ -200,6 +236,10 @@ class TestStaticFileServing:
     @pytest.fixture(scope="class")
     def client(self, api_with_static):
         """Create test client."""
+        from django.conf import settings
+
+        settings.STATIC_ROOT = TEST_STATIC_DIR
+        settings.STATIC_URL = "/static/"
         return TestClient(api_with_static, use_http_layer=True)
 
     def test_serve_css_file(self, client, monkeypatch):
@@ -329,9 +369,8 @@ class TestMultipleDirectories:
         with open(os.path.join(dir2, "test.txt"), "w") as f:
             f.write("FROM_DIR2")
 
-        # Set STATIC_ROOT as first priority
-        settings.STATIC_ROOT = dir1
-        settings.STATICFILES_DIRS = [dir2]
+        settings.STATIC_ROOT = None
+        settings.STATICFILES_DIRS = [dir1, dir2]
 
         result = find_static_file("test.txt")
         assert result is not None
@@ -339,7 +378,7 @@ class TestMultipleDirectories:
         with open(result) as f:
             content = f.read()
 
-        # STATIC_ROOT should take priority
+        # STATICFILES_DIRS should preserve order
         assert content == "FROM_DIR1"
 
     def test_fallback_to_second_directory(self, monkeypatch):
@@ -353,8 +392,8 @@ class TestMultipleDirectories:
         with open(os.path.join(dir2, "only_in_dir2.txt"), "w") as f:
             f.write("FOUND")
 
-        settings.STATIC_ROOT = dir1
-        settings.STATICFILES_DIRS = [dir2]
+        settings.STATIC_ROOT = None
+        settings.STATICFILES_DIRS = [dir1, dir2]
 
         result = find_static_file("only_in_dir2.txt")
         assert result is not None
@@ -551,7 +590,8 @@ class TestSymlinkSecurity:
 
         from django.conf import settings
 
-        settings.STATIC_ROOT = setup_symlink_test["safe_dir"]
+        settings.STATIC_ROOT = None
+        settings.STATICFILES_DIRS = [setup_symlink_test["safe_dir"]]
         settings.STATIC_URL = "/static/"
 
         # Test the security check that Rust uses: canonicalize + starts_with
@@ -573,7 +613,8 @@ class TestSymlinkSecurity:
         """Test that regular files within the directory are still accessible."""
         from django.conf import settings
 
-        settings.STATIC_ROOT = setup_symlink_test["safe_dir"]
+        settings.STATIC_ROOT = None
+        settings.STATICFILES_DIRS = [setup_symlink_test["safe_dir"]]
         settings.STATIC_URL = "/static/"
 
         result = find_static_file("safe.txt")
@@ -598,7 +639,8 @@ class TestSymlinkSecurity:
             pytest.skip("Symlink creation failed")
 
         try:
-            settings.STATIC_ROOT = safe_dir
+            settings.STATIC_ROOT = None
+            settings.STATICFILES_DIRS = [safe_dir]
             settings.STATIC_URL = "/static/"
 
             result = find_static_file("internal_link.txt")
@@ -622,6 +664,7 @@ class TestContentSecurityPolicy:
 
         # Configure CSP
         settings.STATIC_ROOT = TEST_STATIC_DIR
+        settings.STATICFILES_DIRS = [TEST_STATIC_DIR]
         settings.STATIC_URL = "/static/"
         settings.BOLT_STATIC_CSP = "default-src 'self'; script-src 'self'"
 
@@ -643,6 +686,7 @@ class TestContentSecurityPolicy:
         from django_bolt.admin.static import register_static_routes
 
         settings.STATIC_ROOT = TEST_STATIC_DIR
+        settings.STATICFILES_DIRS = [TEST_STATIC_DIR]
         settings.STATIC_URL = "/static/"
 
         # Ensure CSP is not configured
@@ -702,6 +746,7 @@ class TestEdgeCases:
         from django.conf import settings
 
         settings.STATIC_ROOT = TEST_STATIC_DIR
+        settings.STATICFILES_DIRS = [TEST_STATIC_DIR]
         settings.STATIC_URL = "/static/"
 
     def test_file_with_spaces_in_name(self):
@@ -817,7 +862,8 @@ class TestDebugModeFinders:
         """Test that explicitly configured directories always work."""
         from django.conf import settings
 
-        settings.STATIC_ROOT = TEST_STATIC_DIR
+        settings.STATIC_ROOT = None
+        settings.STATICFILES_DIRS = [TEST_STATIC_DIR]
         settings.STATIC_URL = "/static/"
 
         # Should work in both debug and non-debug modes

--- a/src/dev_reload.rs
+++ b/src/dev_reload.rs
@@ -1,0 +1,405 @@
+use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use pyo3::prelude::*;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone)]
+struct ReloadFilter {
+    ignore_dir_names: HashSet<String>,
+    ignore_paths: Vec<PathBuf>,
+}
+
+impl ReloadFilter {
+    fn new(ignore_dir_names: Vec<String>, ignore_paths: Vec<String>) -> Self {
+        Self {
+            ignore_dir_names: ignore_dir_names.into_iter().collect(),
+            ignore_paths: ignore_paths
+                .into_iter()
+                .map(|path| normalize_path(PathBuf::from(path)))
+                .collect(),
+        }
+    }
+
+    fn is_relevant(&self, path: &Path) -> bool {
+        !self.is_ignored(path) && !is_temporary_path(path)
+    }
+
+    fn is_ignored(&self, path: &Path) -> bool {
+        let path = normalize_path(path.to_path_buf());
+
+        if self
+            .ignore_paths
+            .iter()
+            .any(|prefix| path.starts_with(prefix))
+        {
+            return true;
+        }
+
+        path.components().any(|component| match component {
+            std::path::Component::Normal(name) => self
+                .ignore_dir_names
+                .contains(name.to_string_lossy().as_ref()),
+            _ => false,
+        })
+    }
+}
+
+fn normalize_path(path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        path
+    } else if let Ok(cwd) = std::env::current_dir() {
+        cwd.join(path)
+    } else {
+        path
+    }
+}
+
+fn is_temporary_path(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+
+    name.ends_with('~')
+        || name.ends_with(".swp")
+        || name.ends_with(".swo")
+        || name.ends_with(".swx")
+        || name.ends_with(".tmp")
+        || name == "4913"
+        || name.starts_with(".#")
+        || (name.starts_with('#') && name.ends_with('#'))
+}
+
+fn first_relevant_path(event: &Event, filter: &ReloadFilter) -> Option<PathBuf> {
+    if matches!(event.kind, EventKind::Access(_)) {
+        return None;
+    }
+
+    event
+        .paths
+        .iter()
+        .find(|path| filter.is_relevant(path))
+        .cloned()
+}
+
+fn py_runtime_error(message: impl Into<String>) -> PyErr {
+    pyo3::exceptions::PyRuntimeError::new_err(message.into())
+}
+
+// Keep in sync with _ENV_DEV_WORKER / _ENV_DEV_RELOAD_COUNT in runbolt.py
+fn spawn_worker(command: &[String], reload_count: u64) -> PyResult<Child> {
+    let Some(program) = command.first() else {
+        return Err(py_runtime_error("Dev worker command cannot be empty"));
+    };
+
+    let mut child = Command::new(program);
+    for arg in &command[1..] {
+        child.arg(arg);
+    }
+
+    child
+        .env("DJANGO_BOLT_DEV_WORKER", "1")
+        .env("DJANGO_BOLT_DEV_RELOAD_COUNT", reload_count.to_string())
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    child.spawn().map_err(|err| {
+        py_runtime_error(format!("Failed to start dev worker '{}': {}", program, err))
+    })
+}
+
+fn wait_for_child_exit(
+    child: &mut Child,
+    timeout: Duration,
+) -> std::io::Result<Option<std::process::ExitStatus>> {
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(Some(status));
+        }
+
+        if Instant::now() >= deadline {
+            return Ok(None);
+        }
+
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn stop_worker(worker: &mut Option<Child>) -> PyResult<()> {
+    let Some(child) = worker.as_mut() else {
+        return Ok(());
+    };
+
+    #[cfg(unix)]
+    {
+        let pid = child.id() as i32;
+
+        unsafe {
+            libc::kill(pid, libc::SIGTERM);
+        }
+
+        if wait_for_child_exit(child, Duration::from_millis(1200))
+            .map_err(|err| py_runtime_error(format!("Failed while stopping dev worker: {}", err)))?
+            .is_none()
+        {
+            unsafe {
+                libc::kill(pid, libc::SIGKILL);
+            }
+            child
+                .wait()
+                .map_err(|err| py_runtime_error(format!("Failed to kill dev worker: {}", err)))?;
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        child
+            .kill()
+            .map_err(|err| py_runtime_error(format!("Failed to stop dev worker: {}", err)))?;
+        child
+            .wait()
+            .map_err(|err| py_runtime_error(format!("Failed to wait for dev worker: {}", err)))?;
+    }
+
+    *worker = None;
+    Ok(())
+}
+
+fn recv_change(
+    rx: &Receiver<notify::Result<Event>>,
+    filter: &ReloadFilter,
+    debounce: Duration,
+    poll_interval: Duration,
+) -> Result<Option<PathBuf>, String> {
+    match rx.recv_timeout(poll_interval) {
+        Ok(Ok(event)) => {
+            let Some(mut changed_path) = first_relevant_path(&event, filter) else {
+                return Ok(None);
+            };
+
+            let deadline = Instant::now() + debounce;
+            while Instant::now() < deadline {
+                match rx.recv_timeout(deadline.saturating_duration_since(Instant::now())) {
+                    Ok(Ok(next_event)) => {
+                        if let Some(next_path) = first_relevant_path(&next_event, filter) {
+                            changed_path = next_path;
+                        }
+                    }
+                    Ok(Err(err)) => return Err(err.to_string()),
+                    Err(RecvTimeoutError::Timeout) => break,
+                    Err(RecvTimeoutError::Disconnected) => break,
+                }
+            }
+
+            Ok(Some(changed_path))
+        }
+        Ok(Err(err)) => Err(err.to_string()),
+        Err(RecvTimeoutError::Timeout) => Ok(None),
+        Err(RecvTimeoutError::Disconnected) => Err("File watcher disconnected".to_string()),
+    }
+}
+
+fn format_exit_status(status: std::process::ExitStatus) -> String {
+    match status.code() {
+        Some(code) => format!("exit code {}", code),
+        None => "terminated by signal".to_string(),
+    }
+}
+
+fn run_dev_reloader_inner(
+    command: Vec<String>,
+    watch_paths: Vec<String>,
+    ignore_dir_names: Vec<String>,
+    ignore_paths: Vec<String>,
+    debounce_ms: u64,
+) -> PyResult<i32> {
+    if watch_paths.is_empty() {
+        return Err(py_runtime_error(
+            "At least one watch path is required for dev reload",
+        ));
+    }
+
+    let filter = ReloadFilter::new(ignore_dir_names, ignore_paths);
+    let debounce = Duration::from_millis(debounce_ms.max(50));
+    let poll_interval = Duration::from_millis(200);
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown_flag = shutdown.clone();
+
+    ctrlc::set_handler(move || {
+        shutdown_flag.store(true, Ordering::SeqCst);
+    })
+    .map_err(|err| {
+        py_runtime_error(format!(
+            "Failed to install dev reload signal handler: {}",
+            err
+        ))
+    })?;
+
+    let (tx, rx) = mpsc::channel();
+    let mut watcher = RecommendedWatcher::new(
+        move |result| {
+            let _ = tx.send(result);
+        },
+        Config::default(),
+    )
+    .map_err(|err| py_runtime_error(format!("Failed to initialize file watcher: {}", err)))?;
+
+    let mut watched = 0usize;
+    for path in watch_paths {
+        let watch_path = PathBuf::from(path);
+        if !watch_path.exists() {
+            continue;
+        }
+
+        watcher
+            .watch(&watch_path, RecursiveMode::Recursive)
+            .map_err(|err| {
+                py_runtime_error(format!(
+                    "Failed to watch '{}': {}",
+                    watch_path.display(),
+                    err
+                ))
+            })?;
+        watched += 1;
+    }
+
+    if watched == 0 {
+        return Err(py_runtime_error(
+            "No valid watch paths were found for dev reload",
+        ));
+    }
+
+    let mut reload_count = 0u64;
+    let mut worker = Some(spawn_worker(&command, reload_count)?);
+    let mut worker_exited = false;
+
+    loop {
+        if shutdown.load(Ordering::SeqCst) {
+            stop_worker(&mut worker)?;
+            return Ok(0);
+        }
+
+        if let Some(child) = worker.as_mut() {
+            if let Some(status) = child
+                .try_wait()
+                .map_err(|err| py_runtime_error(format!("Failed to poll dev worker: {}", err)))?
+            {
+                let exit_detail = format_exit_status(status);
+                eprintln!(
+                    "[django-bolt] Dev worker exited with {}. Waiting for changes...",
+                    exit_detail
+                );
+                worker_exited = true;
+                worker = None;
+            }
+        }
+
+        match recv_change(&rx, &filter, debounce, poll_interval) {
+            Ok(Some(changed_path)) => {
+                eprintln!(
+                    "[django-bolt] 🔄 Reloading ({})",
+                    changed_path.display()
+                );
+                reload_count += 1;
+                stop_worker(&mut worker)?;
+                worker = Some(spawn_worker(&command, reload_count)?);
+                worker_exited = false;
+            }
+            Ok(None) => {}
+            Err(err) => {
+                if shutdown.load(Ordering::SeqCst) {
+                    stop_worker(&mut worker)?;
+                    return Ok(0);
+                }
+
+                if worker_exited {
+                    continue;
+                }
+
+                eprintln!("[django-bolt] Dev reload watcher error: {}", err);
+            }
+        }
+    }
+}
+
+#[pyfunction]
+pub fn run_dev_reloader(
+    py: Python<'_>,
+    command: Vec<String>,
+    watch_paths: Vec<String>,
+    ignore_dir_names: Vec<String>,
+    ignore_paths: Vec<String>,
+    debounce_ms: Option<u64>,
+) -> PyResult<i32> {
+    py.detach(|| {
+        run_dev_reloader_inner(
+            command,
+            watch_paths,
+            ignore_dir_names,
+            ignore_paths,
+            debounce_ms.unwrap_or(125),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{first_relevant_path, is_temporary_path, ReloadFilter};
+    use notify::{event::CreateKind, Event, EventKind};
+    use std::path::PathBuf;
+
+    #[test]
+    fn ignores_paths_inside_ignored_directories() {
+        let filter = ReloadFilter::new(vec!["target".to_string()], vec![]);
+        assert!(!filter.is_relevant(&PathBuf::from("/tmp/project/target/output.txt")));
+        assert!(filter.is_relevant(&PathBuf::from("/tmp/project/src/app.py")));
+    }
+
+    #[test]
+    fn temporary_editor_files_do_not_trigger_reload() {
+        assert!(is_temporary_path(&PathBuf::from(
+            "/tmp/project/main.py.swp"
+        )));
+        assert!(is_temporary_path(&PathBuf::from("/tmp/project/.#main.py")));
+        assert!(!is_temporary_path(&PathBuf::from("/tmp/project/main.py")));
+    }
+
+    #[test]
+    fn ignores_access_only_events() {
+        let filter = ReloadFilter::new(vec![], vec![]);
+        let event = Event {
+            kind: EventKind::Access(notify::event::AccessKind::Close(
+                notify::event::AccessMode::Read,
+            )),
+            paths: vec![PathBuf::from("/tmp/project/main.py")],
+            attrs: Default::default(),
+        };
+
+        assert!(first_relevant_path(&event, &filter).is_none());
+    }
+
+    #[test]
+    fn returns_first_relevant_path_for_change_events() {
+        let filter = ReloadFilter::new(vec!["__pycache__".to_string()], vec![]);
+        let event = Event {
+            kind: EventKind::Create(CreateKind::File),
+            paths: vec![
+                PathBuf::from("/tmp/project/__pycache__/main.pyc"),
+                PathBuf::from("/tmp/project/main.py"),
+            ],
+            attrs: Default::default(),
+        };
+
+        assert_eq!(
+            first_relevant_path(&event, &filter),
+            Some(PathBuf::from("/tmp/project/main.py"))
+        );
+    }
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -540,7 +540,11 @@ async fn build_response_from_parsed(
         ResponseWireBody::FilePath(file_path) => {
             let headers = response_builder::meta_to_headers(meta_ref);
             let mut response = build_file_response(
-                &file_path, parsed.status, headers, skip_compression, is_head_request,
+                &file_path,
+                parsed.status,
+                headers,
+                skip_compression,
+                is_head_request,
             )
             .await;
             mark_skip_cors(&mut response, skip_cors);
@@ -555,7 +559,9 @@ async fn build_response_from_parsed(
             if media_type == "text/event-stream" {
                 if is_head_request {
                     let mut response = response_builder::build_sse_response(
-                        parsed.status, headers, skip_compression,
+                        parsed.status,
+                        headers,
+                        skip_compression,
                     )
                     .body(Vec::<u8>::new());
                     mark_skip_cors(&mut response, skip_cors);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod asgi_http;
 mod asgi_mounts;
 mod cookies;
 mod cors;
+mod dev_reload;
 mod error;
 mod form_parsing;
 mod handler;
@@ -42,6 +43,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[pymodule]
 fn _core(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    use crate::dev_reload::run_dev_reloader;
     use crate::server::{
         register_asgi_mounts, register_middleware_metadata, register_routes,
         register_websocket_routes, start_server,
@@ -58,6 +60,7 @@ fn _core(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(register_asgi_mounts, m)?)?;
     m.add_function(wrap_pyfunction!(register_middleware_metadata, m)?)?;
     m.add_function(wrap_pyfunction!(start_server, m)?)?;
+    m.add_function(wrap_pyfunction!(run_dev_reloader, m)?)?;
 
     // Test infrastructure functions (async-native, uses Actix test utilities)
     m.add_function(wrap_pyfunction!(create_test_app, m)?)?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -71,7 +71,7 @@ pub struct AppState {
     pub route_metadata: Option<Arc<RouteMetadataStore>>, // Route metadata (used by test infrastructure)
     pub asgi_mounts: Option<Arc<Vec<AsgiMount>>>, // ASGI mounts (tests). Production uses GLOBAL_ASGI_MOUNTS.
     pub static_files_config: Option<StaticFilesConfig>, // Static files configuration from Django settings
-    pub access_logger: Option<Py<PyAny>>,       // Python logger instance for access logging (django.server). None when disabled.
+    pub access_logger: Option<Py<PyAny>>, // Python logger instance for access logging (django.server). None when disabled.
 }
 
 pub static GLOBAL_ROUTER: OnceCell<Arc<Router>> = OnceCell::new();


### PR DESCRIPTION

Django's autoreload caused errors when restarting the ASGI server.
The new Rust supervisor uses the `notify` crate for OS-native file
watching (inotify/kqueue), spawning the server as a child process
and cleanly restarting it on changes — avoiding the ASGI reload issue.
