### PR TITLE
fix: handle bare ROOT_URLCONF (e.g. "urls") in API autodiscovery

### DIFF
--- a/python/django_bolt/analysis.py
+++ b/python/django_bolt/analysis.py
@@ -383,9 +383,8 @@ class OrmVisitor(ast.NodeVisitor):
 
     def visit_Subscript(self, node: ast.Subscript) -> None:
         """Detect request['headers'] style access."""
-        if self._is_request_name(node.value) and isinstance(node.slice, ast.Constant):
-            if isinstance(node.slice.value, str):
-                self._mark_request_component_key(node.slice.value)
+        if self._is_request_name(node.value) and isinstance(node.slice, ast.Constant) and isinstance(node.slice.value, str):
+            self._mark_request_component_key(node.slice.value)
 
         self.generic_visit(node)
 

--- a/python/django_bolt/management/commands/runbolt.py
+++ b/python/django_bolt/management/commands/runbolt.py
@@ -267,6 +267,26 @@ def find_bolt_api_names(module_name: str) -> list[str]:
     return names
 
 
+def _project_api_module_names(root_urlconf: str) -> list[str]:
+    """Return project-level API module candidates for a Django URL config."""
+    project_name = root_urlconf.split(".")[0]
+    package_module_names = [f"{project_name}.{suffix}" for suffix in ("api", "bolt_api")]
+
+    # Dotted URLConfs already imply a containing project package.
+    if "." in root_urlconf:
+        return package_module_names
+
+    spec = importlib.util.find_spec(root_urlconf)
+
+    # A bare ROOT_URLCONF like "urls" can refer to either:
+    # - a package (`urls/__init__.py`), where the project API lives at `urls.api`
+    # - a plain module (`urls.py`), where the sibling API lives at top-level `api`
+    if spec is not None and spec.submodule_search_locations is None:
+        return ["api", "bolt_api"]
+
+    return package_module_names
+
+
 class Command(BaseCommand):
     help = "Run Django-Bolt server with autodiscovered APIs"
 
@@ -725,20 +745,16 @@ class Command(BaseCommand):
             return self._deduplicate_apis(apis)
 
         # Try project-level API first (common pattern)
-        project_name = settings.ROOT_URLCONF.split(".")[0]  # Extract project name from ROOT_URLCONF
-
         # Autodiscovery takes the first BoltAPI instance found.
         # Sub-APIs intended for mounting (e.g. files_api mounted via
         # api.mount("/files", files_api)) must not be discovered as
         # standalone instances.  Place the primary BoltAPI assignment
         # before any sub-API assignments in your api.py file.
-        # To register multiple BoltAPI instances explicitly, use the
-        # BOLT_API setting instead.
         project_found = False
-        for module_suffix in ("api", "bolt_api"):
+
+        for module_name in _project_api_module_names(settings.ROOT_URLCONF):
             if project_found:
                 break
-            module_name = f"{project_name}.{module_suffix}"
             attr_names = find_bolt_api_names(module_name)
             for attr_name in attr_names:
                 candidate = f"{module_name}:{attr_name}"

--- a/python/tests/test_runbolt_dev.py
+++ b/python/tests/test_runbolt_dev.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
+import importlib
+import sys
 from types import SimpleNamespace
 
 from django_bolt.management.commands import runbolt as runbolt_module
+
+
+def _clear_modules(monkeypatch, *module_names: str) -> None:
+    for module_name in module_names:
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
+    importlib.invalidate_caches()
 
 
 def test_build_dev_worker_command_removes_dev_and_forces_single_process():
@@ -80,3 +88,33 @@ def test_collect_dev_watch_paths_prefers_project_paths(settings, tmp_path, monke
     assert str(static_root) in watch_paths
     assert str(external_app) in watch_paths
     assert str(venv_app) not in watch_paths
+
+
+def test_autodiscover_apis_uses_top_level_api_for_plain_root_urlconf(settings, tmp_path, monkeypatch):
+    (tmp_path / "urls.py").write_text("urlpatterns = []\n")
+    (tmp_path / "api.py").write_text("from django_bolt.api import BoltAPI\napi = BoltAPI()\n")
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    _clear_modules(monkeypatch, "urls", "api", "urls.api")
+    monkeypatch.setattr(runbolt_module, "apps", SimpleNamespace(get_app_configs=lambda: []))
+    settings.ROOT_URLCONF = "urls"
+
+    apis = runbolt_module.Command().autodiscover_apis()
+
+    assert [api_path for api_path, _ in apis] == ["api:api"]
+
+
+def test_autodiscover_apis_prefers_package_api_for_package_root_urlconf(settings, tmp_path, monkeypatch):
+    urls_package = tmp_path / "urls"
+    urls_package.mkdir()
+    (urls_package / "__init__.py").write_text("urlpatterns = []\n")
+    (urls_package / "api.py").write_text("from django_bolt.api import BoltAPI\napi = BoltAPI()\n")
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    _clear_modules(monkeypatch, "urls", "api", "urls.api")
+    monkeypatch.setattr(runbolt_module, "apps", SimpleNamespace(get_app_configs=lambda: []))
+    settings.ROOT_URLCONF = "urls"
+
+    apis = runbolt_module.Command().autodiscover_apis()
+
+    assert [api_path for api_path, _ in apis] == ["urls.api:api"]


### PR DESCRIPTION
When ROOT_URLCONF is a plain module like "urls" rather than a dotted path like "myproject.urls", autodiscovery now correctly looks for a top-level "api" module instead of incorrectly prefixing it as "urls.api". Extracted _project_api_module_names() to determine the right candidate modules based on whether ROOT_URLCONF is a package or a plain module.

## What does this PR do?

<!-- Describe the change in 2-3 sentences. Link to any related issue. -->

Fixes #


## How was this tested?

- [x] `just lint-lib` and `just test-py` pass
- [ ] If a new feature is added: tested manually in the example project (`python/example/`)


## Performance consideration

<!-- Django-Bolt is a performance-critical framework. Explain why this change does not regress the hot path, or show benchmark numbers if it touches dispatch/serialization/routing. -->





