### PR TITLE
feat: Add EventSourceResponse with FastAPI-style SSE support

### DIFF
--- a/docs/src/ref/responses.md
+++ b/docs/src/ref/responses.md
@@ -173,9 +173,97 @@ BOLT_ALLOWED_FILE_PATHS = [
 ]
 ```
 
+## EventSourceResponse
+
+Server-Sent Events response with automatic SSE framing, compression skipping, and keep-alive pings. See the [SSE topic guide](../topics/sse.md) for full documentation.
+
+### Implicit pattern
+
+```python
+from collections.abc import AsyncIterable
+from django_bolt.responses import EventSourceResponse
+
+@api.get("/events", response_class=EventSourceResponse)
+async def events() -> AsyncIterable[dict]:
+    for i in range(10):
+        yield {"count": i}
+        await asyncio.sleep(1)
+```
+
+### Explicit pattern
+
+```python
+from django_bolt.responses import EventSourceResponse
+
+@api.get("/events")
+async def events():
+    async def generate():
+        yield {"count": i}
+    return EventSourceResponse(generate())
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `content` | generator | required | Generator instance |
+| `status_code` | `int` | `200` | HTTP status code |
+| `headers` | `dict` | `None` | Additional response headers |
+| `ping_interval` | `float \| None` | `15.0` | Keep-alive ping interval in seconds (`None` to disable) |
+
+### Automatic behavior
+
+- **SSE framing**: Yielded objects are JSON-serialized and wrapped in `data: ...\n\n`
+- **Compression**: Automatically skipped (no `@no_compress` needed)
+- **Headers**: `Cache-Control`, `X-Accel-Buffering`, `Content-Type` set automatically
+- **Keep-alive**: `: ping` comments sent when idle to prevent proxy timeouts
+
+## ServerSentEvent
+
+Represents a single SSE event with full control over all fields.
+
+```python
+from django_bolt.responses import ServerSentEvent
+
+yield ServerSentEvent(data={"count": 1}, event="update", id="1")
+yield ServerSentEvent(raw_data="plain text", comment="keepalive")
+yield ServerSentEvent(retry=5000)
+```
+
+### Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `data` | `Any` | `None` | JSON-serialized event payload |
+| `raw_data` | `str \| None` | `None` | Raw string payload (mutually exclusive with `data`) |
+| `event` | `str \| None` | `None` | Event type name |
+| `id` | `str \| None` | `None` | Event ID (no null characters) |
+| `retry` | `int \| None` | `None` | Reconnection time in ms (non-negative) |
+| `comment` | `str \| None` | `None` | Comment line (`: ` prefix) |
+
+## format_sse_event
+
+Build SSE wire-format bytes from pre-serialized data.
+
+```python
+from django_bolt.responses import format_sse_event
+
+# Simple data event
+frame = format_sse_event(data_str='{"count": 1}')
+# b'data: {"count": 1}\n\n'
+
+# Full event
+frame = format_sse_event(data_str="payload", event="update", id="42", retry=5000)
+# b'event: update\ndata: payload\nid: 42\nretry: 5000\n\n'
+
+# Pre-encoded bytes (avoids decode/encode round-trip)
+frame = format_sse_event(data_bytes=b'{"count": 1}')
+# b'data: {"count": 1}\n\n'
+```
+
 ## StreamingResponse
 
-Streaming response for generators.
+General-purpose streaming response for generators.
 
 ```python
 from django_bolt import StreamingResponse
@@ -193,9 +281,9 @@ return StreamingResponse(generate(), media_type="text/plain")
 async def async_generate():
     for i in range(100):
         await asyncio.sleep(0.1)
-        yield f"data: {i}\n\n"
+        yield f"chunk {i}\n"
 
-return StreamingResponse(async_generate(), media_type="text/event-stream")
+return StreamingResponse(async_generate(), media_type="text/plain")
 ```
 
 ### Parameters
@@ -212,7 +300,7 @@ return StreamingResponse(async_generate(), media_type="text/event-stream")
 | Type | Use case |
 |------|----------|
 | `text/plain` | Plain text streaming |
-| `text/event-stream` | Server-Sent Events (SSE) |
+| `text/event-stream` | Server-Sent Events (prefer `EventSourceResponse`) |
 | `application/octet-stream` | Binary data |
 | `application/json` | JSON streaming (NDJSON) |
 

--- a/docs/src/topics/middleware.md
+++ b/docs/src/topics/middleware.md
@@ -130,6 +130,10 @@ async def stream():
     return StreamingResponse(generate())
 ```
 
+!!! note
+    `EventSourceResponse` and all SSE streams (`text/event-stream`) skip compression
+    automatically. You only need `@no_compress` for non-SSE streaming.
+
 ### Compression settings
 
 Configure in `settings.py`:

--- a/docs/src/topics/responses.md
+++ b/docs/src/topics/responses.md
@@ -250,149 +250,17 @@ async def async_stream():
 
 ### Server-Sent Events (SSE)
 
-Create SSE endpoints for real-time updates. SSE is a standard for pushing events from server to browser over HTTP.
-
-#### Basic SSE
+For SSE endpoints, see the dedicated [Server-Sent Events guide](sse.md). Django-Bolt provides `EventSourceResponse` with automatic SSE framing, compression skipping, and keep-alive pings:
 
 ```python
-import asyncio
+from collections.abc import AsyncIterable
+from django_bolt.responses import EventSourceResponse
 
-@api.get("/events")
-async def events():
-    async def generate():
-        for i in range(10):
-            yield f"data: message-{i}\n\n"
-            await asyncio.sleep(1)
-
-    return StreamingResponse(generate(), media_type="text/event-stream")
-```
-
-#### SSE format
-
-Each event is terminated by a double newline (`\n\n`). Fields:
-
-| Field | Description |
-|-------|-------------|
-| `data:` | Event data (required) |
-| `event:` | Event type (optional, default: "message") |
-| `id:` | Event ID for reconnection (optional) |
-| `retry:` | Reconnection time in ms (optional) |
-
-#### Full SSE event format
-
-```python
-@api.get("/sse-events")
-async def sse_events():
-    async def generate():
-        for i in range(5):
-            # Full SSE event with all fields
-            yield f"event: update\nid: {i}\ndata: {{\"count\": {i}}}\n\n"
-            await asyncio.sleep(0.5)
-
-    return StreamingResponse(generate(), media_type="text/event-stream")
-```
-
-Client receives:
-```
-event: update
-id: 0
-data: {"count": 0}
-
-event: update
-id: 1
-data: {"count": 1}
-```
-
-#### Sync generators for SSE
-
-You can use sync generators for CPU-bound operations:
-
-```python
-import time
-
-@api.get("/sync-sse")
-async def sync_sse():
-    def generate():
-        for i in range(5):
-            yield f"data: sync-message-{i}\n\n"
-            time.sleep(0.1)
-
-    return StreamingResponse(generate(), media_type="text/event-stream")
-```
-
-#### Mixed data types
-
-Generators can yield both strings and bytes:
-
-```python
-@api.get("/mixed-sse")
-async def mixed_sse():
-    async def generate():
-        yield "data: string message\n\n"
-        yield b"data: bytes message\n\n"  # Also works
-
-    return StreamingResponse(generate(), media_type="text/event-stream")
-```
-
-#### SSE with cleanup
-
-Use try/finally for resource cleanup when clients disconnect:
-
-```python
-@api.get("/sse-with-cleanup")
-async def sse_with_cleanup():
-    async def generate():
-        try:
-            yield "data: START\n\n"
-            for i in range(100):
-                yield f"data: chunk-{i}\n\n"
-                await asyncio.sleep(0.1)
-            yield "data: END\n\n"
-        finally:
-            # This runs when client disconnects
-            print("Client disconnected, cleaning up")
-
-    return StreamingResponse(generate(), media_type="text/event-stream")
-```
-
-#### SSE headers
-
-SSE endpoints should include these headers for proper behavior:
-
-```python
-@api.get("/sse")
-async def sse():
-    async def generate():
-        for i in range(10):
-            yield f"data: {i}\n\n"
-            await asyncio.sleep(1)
-
-    return StreamingResponse(
-        generate(),
-        media_type="text/event-stream",
-        headers={
-            "Cache-Control": "no-cache",
-            "X-Accel-Buffering": "no",  # Disable nginx buffering
-        }
-    )
-```
-
-### Disabling compression for streams
-
-Streaming responses should not be compressed. Use `@no_compress`:
-
-```python
-from django_bolt.middleware import no_compress
-
-@api.get("/sse")
-@no_compress
-async def sse():
-    async def generate():
-        for i in range(10):
-            yield f"data: {i}\n\n"
-            await asyncio.sleep(1)
-
-    return StreamingResponse(generate(), media_type="text/event-stream")
+@api.get("/events", response_class=EventSourceResponse)
+async def events() -> AsyncIterable[dict]:
+    for i in range(10):
+        yield {"count": i}
+        await asyncio.sleep(1)
 ```
 
 ## Response with custom headers

--- a/docs/src/topics/sse.md
+++ b/docs/src/topics/sse.md
@@ -1,0 +1,253 @@
+# Server-Sent Events (SSE)
+
+Server-Sent Events is a standard for pushing real-time updates from server to client over HTTP. Django-Bolt provides `EventSourceResponse` with automatic SSE framing, compression skipping, and keep-alive pings.
+
+## Quick start
+
+```python
+from collections.abc import AsyncIterable
+from django_bolt import BoltAPI
+from django_bolt.responses import EventSourceResponse
+
+api = BoltAPI()
+
+@api.get("/events", response_class=EventSourceResponse)
+async def events() -> AsyncIterable[dict]:
+    for i in range(10):
+        yield {"count": i}
+        await asyncio.sleep(1)
+```
+
+That's it. Yielded objects are automatically:
+
+- JSON-serialized
+- Wrapped in SSE `data:` framing
+- Sent without compression (handled at the Rust level)
+- Kept alive with `: ping` comments every 15 seconds
+
+## Two patterns
+
+### Implicit (recommended)
+
+The handler itself is a generator. Set `response_class=EventSourceResponse` on the decorator:
+
+```python
+@api.get("/prices", response_class=EventSourceResponse)
+async def stock_prices() -> AsyncIterable[StockPrice]:
+    while True:
+        yield StockPrice(symbol="AAPL", price=await get_price("AAPL"))
+        await asyncio.sleep(1)
+```
+
+Works with any serializable type: dicts, msgspec Structs, lists.
+
+### Explicit
+
+Return `EventSourceResponse` directly when you need control over status code, headers, or ping interval:
+
+```python
+from django_bolt.responses import EventSourceResponse
+
+@api.get("/stream")
+async def stream():
+    async def generate():
+        yield {"message": "hello"}
+        yield {"message": "world"}
+
+    return EventSourceResponse(generate(), ping_interval=30.0)
+```
+
+## ServerSentEvent
+
+For full control over SSE fields (event type, ID, retry, comments), yield `ServerSentEvent` objects:
+
+```python
+from django_bolt.responses import EventSourceResponse, ServerSentEvent
+
+@api.get("/sse-events", response_class=EventSourceResponse)
+async def sse_events() -> AsyncIterable[ServerSentEvent]:
+    for i in range(5):
+        yield ServerSentEvent(
+            data={"count": i},
+            event="update",
+            id=str(i),
+        )
+        await asyncio.sleep(0.5)
+```
+
+Client receives:
+
+```
+event: update
+data: {"count":0}
+id: 0
+
+event: update
+data: {"count":1}
+id: 1
+```
+
+### Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `data` | `Any` | `None` | JSON-serialized event payload |
+| `raw_data` | `str \| None` | `None` | Raw string payload (mutually exclusive with `data`) |
+| `event` | `str \| None` | `None` | Event type (maps to `addEventListener` in browser) |
+| `id` | `str \| None` | `None` | Event ID for reconnection (`Last-Event-ID` header) |
+| `retry` | `int \| None` | `None` | Reconnection time in milliseconds |
+| `comment` | `str \| None` | `None` | Comment line (`: ` prefix, ignored by EventSource clients) |
+
+### Mixing yield types
+
+You can mix plain objects and `ServerSentEvent` in a single stream:
+
+```python
+@api.get("/mixed", response_class=EventSourceResponse)
+async def mixed():
+    yield {"status": "started"}                          # auto-framed as data:
+    yield ServerSentEvent(data={"n": 1}, event="tick")   # full SSE event
+    yield ServerSentEvent(comment="keepalive")            # comment only
+    yield ServerSentEvent(data="done", event="complete")  # string data
+```
+
+### raw_data
+
+Use `raw_data` to send pre-formatted strings without JSON encoding:
+
+```python
+yield ServerSentEvent(raw_data="plain text line")
+# Produces: data: plain text line
+```
+
+Compare with `data`:
+
+```python
+yield ServerSentEvent(data="plain text line")
+# Produces: data: "plain text line"   (JSON-encoded with quotes)
+```
+
+## Sync generators
+
+Both sync and async generators work:
+
+```python
+@api.get("/sync-sse", response_class=EventSourceResponse)
+def sync_sse():
+    for i in range(5):
+        yield {"sync_message": i}
+        time.sleep(0.1)
+```
+
+## Cleanup on disconnect
+
+Use try/finally for resource cleanup when clients disconnect:
+
+```python
+@api.get("/sse-with-cleanup", response_class=EventSourceResponse)
+async def sse_with_cleanup():
+    try:
+        yield {"status": "START"}
+        for i in range(100):
+            yield {"chunk": i}
+            await asyncio.sleep(0.1)
+    finally:
+        print("Client disconnected, cleaning up")
+```
+
+## Keep-alive pings
+
+`EventSourceResponse` sends `: ping` comments every 15 seconds when the generator is idle. This prevents proxies and load balancers from closing the connection.
+
+Configure or disable:
+
+```python
+# Custom interval (seconds)
+return EventSourceResponse(generate(), ping_interval=30.0)
+
+# Disable keep-alive
+return EventSourceResponse(generate(), ping_interval=None)
+```
+
+Keep-alive runs in Rust — no GIL overhead.
+
+## Compression
+
+`EventSourceResponse` automatically skips compression. Compression buffers the entire response before sending, which defeats streaming. No `@no_compress` decorator needed.
+
+This also applies to legacy `StreamingResponse(media_type="text/event-stream")` — all SSE streams skip compression automatically at the Rust level.
+
+## EventSourceResponse parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `content` | generator | required | Generator instance |
+| `status_code` | `int` | `200` | HTTP status code |
+| `headers` | `dict` | `None` | Additional response headers |
+| `ping_interval` | `float \| None` | `15.0` | Keep-alive interval in seconds (`None` to disable) |
+
+## format_sse_event
+
+Low-level function to build SSE wire-format bytes manually:
+
+```python
+from django_bolt.responses import format_sse_event
+
+# Data-only event
+format_sse_event(data_str='{"count": 1}')
+# b'data: {"count": 1}\n\n'
+
+# Pre-encoded bytes (avoids decode/encode round-trip)
+format_sse_event(data_bytes=b'{"count": 1}')
+# b'data: {"count": 1}\n\n'
+
+# Full event with all fields
+format_sse_event(data_str="payload", event="update", id="42", retry=5000)
+# b'event: update\ndata: payload\nid: 42\nretry: 5000\n\n'
+```
+
+## Raw SSE with StreamingResponse
+
+If you need manual control over SSE wire framing, use `StreamingResponse` directly:
+
+```python
+from django_bolt import StreamingResponse
+from django_bolt.middleware import no_compress
+
+@api.get("/raw-sse")
+@no_compress
+async def raw_sse():
+    async def generate():
+        for i in range(10):
+            yield f"event: update\nid: {i}\ndata: {{\"count\": {i}}}\n\n"
+            await asyncio.sleep(1)
+
+    return StreamingResponse(generate(), media_type="text/event-stream")
+```
+
+!!! note
+    With `StreamingResponse` you must manually format SSE frames and add `@no_compress`.
+    Prefer `EventSourceResponse`.
+
+## Testing
+
+```python
+from django_bolt import BoltAPI
+from django_bolt.responses import EventSourceResponse
+from django_bolt.testing import TestClient
+
+api = BoltAPI()
+
+@api.get("/sse", response_class=EventSourceResponse)
+async def sse():
+    yield {"message": "hello"}
+    yield {"message": "world"}
+
+with TestClient(api) as client:
+    response = client.get("/sse")
+    assert response.status_code == 200
+    assert "text/event-stream" in response.headers["content-type"]
+    body = response.content.decode()
+    assert 'data: {"message":"hello"}' in body
+    assert 'data: {"message":"world"}' in body
+```

--- a/docs/src/topics/testing.md
+++ b/docs/src/topics/testing.md
@@ -223,6 +223,27 @@ with TestClient(api) as client:
 
 ## Streaming responses
 
+### SSE with EventSourceResponse
+
+```python
+from django_bolt.responses import EventSourceResponse
+
+@api.get("/sse", response_class=EventSourceResponse)
+async def sse():
+    yield {"message": "hello"}
+    yield {"message": "world"}
+
+with TestClient(api) as client:
+    response = client.get("/sse")
+    assert response.status_code == 200
+    assert "text/event-stream" in response.headers["content-type"]
+    body = response.content.decode()
+    assert 'data: {"message":"hello"}' in body
+    assert 'data: {"message":"world"}' in body
+```
+
+### Raw streaming with StreamingResponse
+
 Test streaming with `stream=True`:
 
 ```python

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -76,6 +76,7 @@ nav = [
     { "Logging" = "topics/logging.md" },
     { "Health Checks" = "topics/health-checks.md" },
     { "Testing" = "topics/testing.md" },
+    { "Server-Sent Events" = "topics/sse.md" },
     { "WebSocket" = "topics/websocket.md" },
     { "OpenAPI" = "topics/openapi.md" },
     { "ASGI Mounts" = "topics/asgi-mounts.md" },

--- a/python/django_bolt/__init__.py
+++ b/python/django_bolt/__init__.py
@@ -128,7 +128,14 @@ from .params import Depends
 
 # Type-safe Request object
 from .request import Request
-from .responses import JSON, Response, StreamingResponse
+from .responses import (
+    JSON,
+    EventSourceResponse,
+    Response,
+    ServerSentEvent,
+    StreamingResponse,
+    format_sse_event,
+)
 from .router import Router
 from .types import (
     APIKeyAuth,
@@ -175,6 +182,9 @@ __all__ = [
     "Response",
     "JSON",
     "StreamingResponse",
+    "EventSourceResponse",
+    "ServerSentEvent",
+    "format_sse_event",
     "CompressionConfig",
     "Cookie",
     "Depends",

--- a/python/django_bolt/api.py
+++ b/python/django_bolt/api.py
@@ -484,6 +484,7 @@ class BoltAPI:
         tags: list[str] | None = None,
         summary: str | None = None,
         description: str | None = None,
+        response_class: type | None = None,
     ):
         return self._route_decorator(
             "GET",
@@ -496,6 +497,7 @@ class BoltAPI:
             tags=tags,
             summary=summary,
             description=description,
+            response_class=response_class,
         )
 
     def post(
@@ -510,6 +512,7 @@ class BoltAPI:
         tags: list[str] | None = None,
         summary: str | None = None,
         description: str | None = None,
+        response_class: type | None = None,
     ):
         return self._route_decorator(
             "POST",
@@ -522,6 +525,7 @@ class BoltAPI:
             tags=tags,
             summary=summary,
             description=description,
+            response_class=response_class,
         )
 
     def put(
@@ -536,6 +540,7 @@ class BoltAPI:
         tags: list[str] | None = None,
         summary: str | None = None,
         description: str | None = None,
+        response_class: type | None = None,
     ):
         return self._route_decorator(
             "PUT",
@@ -548,6 +553,7 @@ class BoltAPI:
             tags=tags,
             summary=summary,
             description=description,
+            response_class=response_class,
         )
 
     def patch(
@@ -562,6 +568,7 @@ class BoltAPI:
         tags: list[str] | None = None,
         summary: str | None = None,
         description: str | None = None,
+        response_class: type | None = None,
     ):
         return self._route_decorator(
             "PATCH",
@@ -574,6 +581,7 @@ class BoltAPI:
             tags=tags,
             summary=summary,
             description=description,
+            response_class=response_class,
         )
 
     def delete(
@@ -588,6 +596,7 @@ class BoltAPI:
         tags: list[str] | None = None,
         summary: str | None = None,
         description: str | None = None,
+        response_class: type | None = None,
     ):
         return self._route_decorator(
             "DELETE",
@@ -600,6 +609,7 @@ class BoltAPI:
             tags=tags,
             summary=summary,
             description=description,
+            response_class=response_class,
         )
 
     def head(
@@ -614,6 +624,7 @@ class BoltAPI:
         tags: list[str] | None = None,
         summary: str | None = None,
         description: str | None = None,
+        response_class: type | None = None,
     ):
         return self._route_decorator(
             "HEAD",
@@ -626,6 +637,7 @@ class BoltAPI:
             tags=tags,
             summary=summary,
             description=description,
+            response_class=response_class,
         )
 
     def options(
@@ -640,6 +652,7 @@ class BoltAPI:
         tags: list[str] | None = None,
         summary: str | None = None,
         description: str | None = None,
+        response_class: type | None = None,
     ):
         return self._route_decorator(
             "OPTIONS",
@@ -652,6 +665,7 @@ class BoltAPI:
             tags=tags,
             summary=summary,
             description=description,
+            response_class=response_class,
         )
 
     def websocket(
@@ -1121,6 +1135,7 @@ class BoltAPI:
         tags: list[str] | None = None,
         summary: str | None = None,
         description: str | None = None,
+        response_class: type | None = None,
         _skip_prefix: bool = False,
         _router_middleware: list[Any] | None = None,
     ):
@@ -1256,6 +1271,7 @@ class BoltAPI:
             else:
                 meta["response_type"] = None
             meta["validate_response"] = route_validate_response
+            meta["response_class"] = response_class
             # Pre-compute stream annotation analysis (registration time only)
             meta["_stream_info"] = _extract_stream_item_type(meta["response_type"])
 

--- a/python/django_bolt/responses.py
+++ b/python/django_bolt/responses.py
@@ -5,6 +5,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
+import msgspec
+
 # Django import - may fail if Django not configured, kept at top for consistency
 try:
     from django.conf import settings as django_settings
@@ -324,3 +326,144 @@ class StreamingResponse(CookieMixin):
             raise TypeError(
                 f"StreamingResponse content must be a generator instance. Received type: {type(content).__name__}"
             )
+
+
+class ServerSentEvent(msgspec.Struct, frozen=True):
+    """Represents a single Server-Sent Event.
+
+    When yielded from a handler using ``response_class=EventSourceResponse``,
+    each ``ServerSentEvent`` is encoded into the SSE wire format
+    (``text/event-stream``).
+
+    Yielding a plain object (dict, Pydantic/msgspec model, etc.) instead
+    auto-JSON-encodes it as the ``data:`` field.
+
+    Examples::
+
+        yield ServerSentEvent(data={"price": 42.5}, event="update", id="1")
+        yield ServerSentEvent(raw_data="plain text line", comment="keepalive")
+        yield ServerSentEvent(retry=5000)
+    """
+
+    data: Any = None
+    raw_data: str | None = None
+    event: str | None = None
+    id: str | None = None
+    retry: int | None = None
+    comment: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.data is not None and self.raw_data is not None:
+            raise ValueError(
+                "Cannot set both 'data' and 'raw_data' on the same "
+                "ServerSentEvent. Use 'data' for JSON-serialized payloads "
+                "or 'raw_data' for pre-formatted strings."
+            )
+        if self.id is not None and "\0" in self.id:
+            raise ValueError("SSE 'id' must not contain null characters")
+        if self.retry is not None and self.retry < 0:
+            raise ValueError("SSE 'retry' must be a non-negative integer")
+
+
+def format_sse_event(
+    *,
+    data_str: str | None = None,
+    data_bytes: bytes | None = None,
+    event: str | None = None,
+    id: str | None = None,
+    retry: int | None = None,
+    comment: str | None = None,
+) -> bytes:
+    """Build SSE wire-format bytes from pre-serialized data.
+
+    The result always ends with ``\\n\\n`` (the event terminator).
+
+    Pass ``data_bytes`` instead of ``data_str`` when the payload is already
+    encoded (e.g. from msgspec) to avoid a decode/encode round-trip.
+    """
+    # Fast path: data-only event with pre-encoded bytes (most common from auto-framing)
+    if (
+        data_bytes is not None
+        and event is None
+        and id is None
+        and retry is None
+        and comment is None
+    ):
+        return b"data: " + data_bytes + b"\n\n"
+
+    lines: list[str] = []
+
+    if comment is not None:
+        for line in comment.splitlines():
+            lines.append(f": {line}")
+
+    if event is not None:
+        lines.append(f"event: {event}")
+
+    if data_str is not None:
+        for line in data_str.splitlines():
+            lines.append(f"data: {line}")
+    elif data_bytes is not None:
+        for line in data_bytes.decode("utf-8").splitlines():
+            lines.append(f"data: {line}")
+
+    if id is not None:
+        lines.append(f"id: {id}")
+
+    if retry is not None:
+        lines.append(f"retry: {retry}")
+
+    lines.append("")
+    lines.append("")
+    return "\n".join(lines).encode("utf-8")
+
+
+# Keep-alive comment per the SSE spec recommendation
+SSE_KEEPALIVE_COMMENT = b": ping\n\n"
+
+# Default seconds between keep-alive pings when the generator is idle
+SSE_DEFAULT_PING_INTERVAL: float = 15.0
+
+
+class EventSourceResponse(StreamingResponse):
+    """Streaming response with ``text/event-stream`` media type.
+
+    Use as ``response_class=EventSourceResponse`` on a route decorator to enable
+    Server-Sent Events with automatic SSE framing, compression skipping, and
+    keep-alive pings.
+
+    Works with **any HTTP method** (GET, POST, etc.), which makes it compatible
+    with protocols like MCP that stream SSE over POST.
+
+    **Implicit (preferred)** — the handler itself is a generator::
+
+        @api.get("/items/stream", response_class=EventSourceResponse)
+        async def stream_items() -> AsyncIterable[Item]:
+            for item in items:
+                yield item
+
+    **Explicit** — full control over the response::
+
+        @api.get("/stream")
+        async def stream():
+            async def gen():
+                yield {"message": "hello"}
+                yield ServerSentEvent(data=item, event="update", id="1")
+            return EventSourceResponse(gen())
+    """
+
+    def __init__(
+        self,
+        content: Any,
+        *,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+        ping_interval: float | None = SSE_DEFAULT_PING_INTERVAL,
+    ):
+        super().__init__(
+            content,
+            status_code=status_code,
+            media_type="text/event-stream",
+            headers=headers,
+        )
+        self.ping_interval = ping_interval

--- a/python/django_bolt/serialization.py
+++ b/python/django_bolt/serialization.py
@@ -35,7 +35,18 @@ from django.http import HttpResponseRedirect as DjangoHttpResponseRedirect
 from . import _json
 from ._kwargs import coerce_to_response_type, coerce_to_response_type_async
 from .cookies import Cookie
-from .responses import HTML, JSON, File, FileResponse, PlainText, Redirect, StreamingResponse
+from .responses import (
+    HTML,
+    JSON,
+    EventSourceResponse,
+    File,
+    FileResponse,
+    PlainText,
+    Redirect,
+    ServerSentEvent,
+    StreamingResponse,
+    format_sse_event,
+)
 from .responses import Response as ResponseClass
 
 if TYPE_CHECKING:
@@ -406,7 +417,50 @@ async def _wrap_async_stream_chunks(content: Any, item_type: Any | None, meta: H
         yield await _serialize_stream_chunk_async(chunk, validator)
 
 
+# ═══════════════════════════════════════════════════════════════════════════
+# SSE (Server-Sent Events) auto-framing
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _serialize_sse_chunk(chunk: Any) -> bytes:
+    """Serialize a single yielded item into SSE wire-format bytes."""
+    if isinstance(chunk, (bytes, bytearray, memoryview)):
+        return bytes(chunk) if not isinstance(chunk, bytes) else chunk
+    if isinstance(chunk, str):
+        return chunk.encode("utf-8")
+    if isinstance(chunk, ServerSentEvent):
+        if chunk.raw_data is not None:
+            return format_sse_event(data_str=chunk.raw_data, event=chunk.event, id=chunk.id, retry=chunk.retry, comment=chunk.comment)
+        return format_sse_event(
+            data_bytes=_json.encode(chunk.data) if chunk.data is not None else None,
+            event=chunk.event,
+            id=chunk.id,
+            retry=chunk.retry,
+            comment=chunk.comment,
+        )
+    # Plain objects (dict, list, msgspec.Struct, etc.)
+    return format_sse_event(data_bytes=_json.encode(chunk))
+
+
+def _wrap_sync_sse_chunks(content: Any):
+    for chunk in content:
+        yield _serialize_sse_chunk(chunk)
+
+
+async def _wrap_async_sse_chunks(content: Any):
+    async for chunk in content:
+        yield _serialize_sse_chunk(chunk)
+
+
 def _to_stream_wire(stream_response: StreamingResponse) -> ResponseWireV1:
+    # Auto-wrap EventSourceResponse generator with SSE framing.
+    # Mutate in place so ping_interval and other attributes are preserved for Rust.
+    if isinstance(stream_response, EventSourceResponse):
+        if stream_response.is_async_generator:
+            stream_response.content = _wrap_async_sse_chunks(stream_response.content)
+        else:
+            stream_response.content = _wrap_sync_sse_chunks(stream_response.content)
+
     custom_headers: dict[str, str] = {"content-type": stream_response.media_type}
     if stream_response.headers:
         custom_headers.update(stream_response.headers)
@@ -420,6 +474,7 @@ def _build_auto_streaming_response(
     stream_info: tuple[bool, Any | None],
     meta: HandlerMetadata | dict[str, Any],
     status_code: int,
+    response_class: type | None = None,
 ) -> StreamingResponse | None:
     """Auto-wrap generator/iterator return values into StreamingResponse."""
     is_stream_annotation, item_type = stream_info
@@ -428,6 +483,11 @@ def _build_auto_streaming_response(
 
     if not is_generator_result and not (is_stream_annotation and _is_stream_protocol_instance(result)):
         return None
+
+    # When response_class=EventSourceResponse, wrap as EventSourceResponse
+    # SSE framing is applied later in _to_stream_wire
+    if response_class is not None and issubclass(response_class, EventSourceResponse):
+        return EventSourceResponse(result, status_code=status_code)
 
     needs_json_chunk_encoding = (
         is_stream_annotation and item_type is not None and item_type not in _RAW_STREAM_CHUNK_TYPES
@@ -460,6 +520,7 @@ def compile_response_handlers(meta: HandlerMetadata | dict[str, Any]) -> None:
 
     default_status_code = meta["default_status_code"]
     stream_info = meta.get("_stream_info", (False, None))
+    response_class = meta.get("response_class")
 
     async def data_handler(result: Any, status_code: int | None = None) -> ResponseWireV1:
         current_status = default_status_code if status_code is None else status_code
@@ -481,7 +542,7 @@ def compile_response_handlers(meta: HandlerMetadata | dict[str, Any]) -> None:
         if isinstance(result, str):
             return _wire_bytes(current_status, _RESPONSE_META_PLAINTEXT, result.encode())
 
-        auto_stream = _build_auto_streaming_response(result, stream_info, meta, current_status)
+        auto_stream = _build_auto_streaming_response(result, stream_info, meta, current_status, response_class)
         if auto_stream is not None:
             return _to_stream_wire(auto_stream)
 
@@ -523,7 +584,7 @@ def compile_response_handlers(meta: HandlerMetadata | dict[str, Any]) -> None:
         if isinstance(result, str):
             return _wire_bytes(current_status, _RESPONSE_META_PLAINTEXT, result.encode())
 
-        auto_stream = _build_auto_streaming_response(result, stream_info, meta, current_status)
+        auto_stream = _build_auto_streaming_response(result, stream_info, meta, current_status, response_class)
         if auto_stream is not None:
             return _to_stream_wire(auto_stream)
 

--- a/python/django_bolt/typing.py
+++ b/python/django_bolt/typing.py
@@ -219,6 +219,10 @@ class HandlerMetadata(TypedDict, total=False):
     handler_pattern: HandlerPattern
     """Handler pattern for specialized injector selection at registration time."""
 
+    # Response class override (e.g., EventSourceResponse for SSE)
+    response_class: type | None
+    """Optional response class override for the route (e.g., EventSourceResponse)."""
+
 
 # Simple scalar types that map to query parameters
 SIMPLE_TYPES = (str, int, float, bool, bytes)

--- a/python/example/testproject/api.py
+++ b/python/example/testproject/api.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import time
+from collections.abc import AsyncIterable
 from contextlib import asynccontextmanager
 from typing import Annotated, Protocol
 
@@ -29,7 +30,7 @@ from django_bolt.health import add_health_check
 from django_bolt.middleware import no_compress
 from django_bolt.openapi import OpenAPIConfig
 from django_bolt.param_functions import Cookie, Depends, File, Form, Header
-from django_bolt.responses import HTML, FileResponse, PlainText, Redirect, StreamingResponse
+from django_bolt.responses import HTML, EventSourceResponse, FileResponse, PlainText, Redirect, ServerSentEvent, StreamingResponse
 from django_bolt.serializers import Serializer, field_validator
 from django_bolt.types import Request
 from django_bolt.views import APIView, ViewSet
@@ -885,6 +886,42 @@ def sse_sync():
             yield f"data: {time.time()}\n\n"
 
     return StreamingResponse(gen(), media_type="text/event-stream")
+
+
+# ==== EventSourceResponse (new SSE syntax) ====
+
+class TimestampEvent(msgspec.Struct):
+    timestamp: float
+    count: int
+
+
+@api.get("/sse-new", response_class=EventSourceResponse)
+async def sse_new() -> AsyncIterable[TimestampEvent]:
+    """Implicit SSE: generator handler + response_class. No @no_compress needed."""
+    count = 0
+    while True:
+        await asyncio.sleep(1)
+        count += 1
+        yield TimestampEvent(timestamp=time.time(), count=count)
+
+
+@api.get("/sse-new-explicit")
+async def sse_new_explicit():
+    """Explicit SSE: return EventSourceResponse with mixed yields."""
+
+    async def gen():
+        yield {"message": "stream started", "time": time.time()}
+        for i in range(5):
+            await asyncio.sleep(1)
+            yield ServerSentEvent(
+                data={"count": i, "time": time.time()},
+                event="tick",
+                id=str(i),
+            )
+        yield ServerSentEvent(comment="stream ending")
+        yield ServerSentEvent(data="done", event="complete")
+
+    return EventSourceResponse(gen())
 
 
 # ==== OpenAI-style Chat Completions (streaming/non-streaming) ====

--- a/python/tests/test_event_source_response.py
+++ b/python/tests/test_event_source_response.py
@@ -1,0 +1,297 @@
+"""Tests for EventSourceResponse, ServerSentEvent, and format_sse_event."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterable
+
+import msgspec
+import pytest
+
+from django_bolt import BoltAPI, EventSourceResponse, ServerSentEvent, format_sse_event
+from django_bolt.testing import TestClient
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Unit tests: format_sse_event
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestFormatSSEEvent:
+    def test_data_only(self):
+        result = format_sse_event(data_str='{"msg":"hello"}')
+        assert result == b'data: {"msg":"hello"}\n\n'
+
+    def test_multiline_data(self):
+        result = format_sse_event(data_str="line1\nline2\nline3")
+        assert result == b"data: line1\ndata: line2\ndata: line3\n\n"
+
+    def test_all_fields(self):
+        result = format_sse_event(
+            data_str="payload",
+            event="update",
+            id="42",
+            retry=5000,
+            comment="keepalive",
+        )
+        assert result == b": keepalive\nevent: update\ndata: payload\nid: 42\nretry: 5000\n\n"
+
+    def test_comment_only(self):
+        result = format_sse_event(comment="ping")
+        assert result == b": ping\n\n"
+
+    def test_event_and_data(self):
+        result = format_sse_event(data_str="hello", event="greeting")
+        assert result == b"event: greeting\ndata: hello\n\n"
+
+    def test_retry_only(self):
+        result = format_sse_event(retry=3000)
+        assert result == b"retry: 3000\n\n"
+
+    def test_empty_event(self):
+        result = format_sse_event()
+        assert result == b"\n"
+
+    def test_multiline_comment(self):
+        result = format_sse_event(comment="line1\nline2")
+        assert result == b": line1\n: line2\n\n"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Unit tests: ServerSentEvent
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestServerSentEvent:
+    def test_data_only(self):
+        event = ServerSentEvent(data={"key": "value"})
+        assert event.data == {"key": "value"}
+        assert event.raw_data is None
+
+    def test_raw_data_only(self):
+        event = ServerSentEvent(raw_data="plain text")
+        assert event.raw_data == "plain text"
+        assert event.data is None
+
+    def test_data_and_raw_data_exclusive(self):
+        with pytest.raises(ValueError, match="Cannot set both"):
+            ServerSentEvent(data="hello", raw_data="world")
+
+    def test_id_no_null(self):
+        with pytest.raises(ValueError, match="must not contain null"):
+            ServerSentEvent(data="x", id="abc\0def")
+
+    def test_retry_negative(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            ServerSentEvent(retry=-1)
+
+    def test_all_fields(self):
+        event = ServerSentEvent(
+            data={"count": 1},
+            event="update",
+            id="1",
+            retry=5000,
+            comment="info",
+        )
+        assert event.event == "update"
+        assert event.id == "1"
+        assert event.retry == 5000
+        assert event.comment == "info"
+
+    def test_frozen(self):
+        event = ServerSentEvent(data="hello")
+        with pytest.raises(AttributeError):
+            event.data = "world"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Integration tests: EventSourceResponse (explicit pattern)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class Item(msgspec.Struct):
+    name: str
+    price: float
+
+
+@pytest.fixture(scope="module")
+def api():
+    api = BoltAPI()
+
+    @api.get("/sse-explicit-dict")
+    async def sse_explicit_dict():
+        async def gen():
+            yield {"message": "hello"}
+            yield {"message": "world"}
+
+        return EventSourceResponse(gen())
+
+    @api.get("/sse-explicit-sse-event")
+    async def sse_explicit_sse_event():
+        async def gen():
+            yield ServerSentEvent(data={"count": 1}, event="update", id="1")
+            yield ServerSentEvent(data={"count": 2}, event="update", id="2")
+
+        return EventSourceResponse(gen())
+
+    @api.get("/sse-explicit-mixed")
+    async def sse_explicit_mixed():
+        async def gen():
+            yield {"auto": True}
+            yield ServerSentEvent(data="manual", event="custom")
+            yield ServerSentEvent(raw_data="raw text line")
+
+        return EventSourceResponse(gen())
+
+    @api.get("/sse-explicit-string")
+    async def sse_explicit_string():
+        """Strings are passed through raw (user controls framing)."""
+
+        async def gen():
+            yield "data: raw-sse\n\n"
+
+        return EventSourceResponse(gen())
+
+    @api.get("/sse-explicit-struct")
+    async def sse_explicit_struct():
+        async def gen():
+            yield Item(name="Widget", price=9.99)
+
+        return EventSourceResponse(gen())
+
+    # ── Implicit pattern: response_class=EventSourceResponse ──
+
+    @api.get("/sse-implicit", response_class=EventSourceResponse)
+    async def sse_implicit() -> AsyncIterable[dict]:
+        yield {"message": "implicit-hello"}
+        yield {"message": "implicit-world"}
+
+    @api.get("/sse-implicit-struct", response_class=EventSourceResponse)
+    async def sse_implicit_struct() -> AsyncIterable[Item]:
+        yield Item(name="Gadget", price=19.99)
+        yield Item(name="Doohickey", price=4.50)
+
+    @api.get("/sse-implicit-sse-event", response_class=EventSourceResponse)
+    async def sse_implicit_sse_event() -> AsyncIterable[ServerSentEvent]:
+        yield ServerSentEvent(data={"n": 1}, event="tick", id="1")
+        yield ServerSentEvent(data={"n": 2}, event="tick", id="2")
+
+    # ── Sync generators ──
+
+    @api.get("/sse-sync-explicit")
+    def sse_sync_explicit():
+        def gen():
+            yield {"sync": True}
+            yield {"sync": False}
+
+        return EventSourceResponse(gen())
+
+    @api.get("/sse-sync-implicit", response_class=EventSourceResponse)
+    def sse_sync_implicit():
+        yield {"sync": "implicit"}
+
+    return api
+
+
+@pytest.fixture(scope="module")
+def client(api):
+    with TestClient(api) as c:
+        yield c
+
+
+# ── Explicit pattern tests ──
+
+
+class TestExplicitEventSourceResponse:
+    def test_dict_yield(self, client):
+        response = client.get("/sse-explicit-dict")
+        assert response.status_code == 200
+        assert "text/event-stream" in response.headers["content-type"]
+        body = response.content.decode()
+        assert 'data: {"message":"hello"}' in body
+        assert 'data: {"message":"world"}' in body
+
+    def test_server_sent_event_yield(self, client):
+        response = client.get("/sse-explicit-sse-event")
+        assert response.status_code == 200
+        body = response.content.decode()
+        assert "event: update" in body
+        assert "id: 1" in body
+        assert 'data: {"count":1}' in body
+        assert "id: 2" in body
+        assert 'data: {"count":2}' in body
+
+    def test_mixed_yield(self, client):
+        response = client.get("/sse-explicit-mixed")
+        assert response.status_code == 200
+        body = response.content.decode()
+        # Dict auto-framed
+        assert 'data: {"auto":true}' in body
+        # ServerSentEvent with event type
+        assert "event: custom" in body
+        assert 'data: "manual"' in body
+        # ServerSentEvent with raw_data
+        assert "data: raw text line" in body
+
+    def test_string_passthrough(self, client):
+        response = client.get("/sse-explicit-string")
+        assert response.status_code == 200
+        body = response.content.decode()
+        assert "data: raw-sse\n\n" in body
+
+    def test_struct_yield(self, client):
+        response = client.get("/sse-explicit-struct")
+        assert response.status_code == 200
+        body = response.content.decode()
+        assert 'data: {"name":"Widget","price":9.99}' in body
+
+    def test_sse_headers(self, client):
+        response = client.get("/sse-explicit-dict")
+        assert "text/event-stream" in response.headers["content-type"]
+
+
+# ── Implicit pattern tests ──
+
+
+class TestImplicitEventSourceResponse:
+    def test_dict_yield(self, client):
+        response = client.get("/sse-implicit")
+        assert response.status_code == 200
+        assert "text/event-stream" in response.headers["content-type"]
+        body = response.content.decode()
+        assert 'data: {"message":"implicit-hello"}' in body
+        assert 'data: {"message":"implicit-world"}' in body
+
+    def test_struct_yield(self, client):
+        response = client.get("/sse-implicit-struct")
+        assert response.status_code == 200
+        body = response.content.decode()
+        assert 'data: {"name":"Gadget","price":19.99}' in body
+        assert 'data: {"name":"Doohickey","price":4.5}' in body
+
+    def test_sse_event_yield(self, client):
+        response = client.get("/sse-implicit-sse-event")
+        assert response.status_code == 200
+        body = response.content.decode()
+        assert "event: tick" in body
+        assert "id: 1" in body
+        assert 'data: {"n":1}' in body
+
+
+# ── Sync generator tests ──
+
+
+class TestSyncEventSourceResponse:
+    def test_sync_explicit(self, client):
+        response = client.get("/sse-sync-explicit")
+        assert response.status_code == 200
+        assert "text/event-stream" in response.headers["content-type"]
+        body = response.content.decode()
+        assert 'data: {"sync":true}' in body
+        assert 'data: {"sync":false}' in body
+
+    def test_sync_implicit(self, client):
+        response = client.get("/sse-sync-implicit")
+        assert response.status_code == 200
+        assert "text/event-stream" in response.headers["content-type"]
+        body = response.content.decode()
+        assert 'data: {"sync":"implicit"}' in body

--- a/python/tests/test_middleware_server.py
+++ b/python/tests/test_middleware_server.py
@@ -2,6 +2,7 @@
 Integration test for middleware with TestClient
 """
 
+import anyio
 import time
 
 import django
@@ -96,6 +97,15 @@ def api():
         async def agen():
             for i in range(3):
                 yield f"async-chunk{i},"
+
+        return StreamingResponse(agen(), media_type="text/plain")
+
+    @api.get("/stream-with-task-group")
+    async def stream_with_task_group():
+        async def agen():
+            async with anyio.create_task_group():
+                yield b"inside,"
+            yield b"after,"
 
         return StreamingResponse(agen(), media_type="text/plain")
 
@@ -258,6 +268,13 @@ def test_streaming_with_cors(client):
     assert response.status_code == 200
     assert response.headers.get("content-type", "").startswith("text/plain")
     assert response.content == b"async-chunk0,async-chunk1,async-chunk2,"
+
+
+def test_async_stream_preserves_task_affinity(http_client):
+    """Async streaming should keep context-manager enter/exit on the same Python task."""
+    response = http_client.get("/stream-with-task-group")
+    assert response.status_code == 200
+    assert response.content == b"inside,after,"
 
 
 def test_sse_with_cors(client):

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use futures_util::stream;
 use futures_util::StreamExt;
 use pyo3::prelude::*;
-use pyo3::pybacked::PyBackedBytes;
+use pyo3::pybacked::{PyBackedBytes, PyBackedStr};
 use pyo3::sync::PyOnceLock;
 use pyo3::types::{PyBytes, PyDict, PyList, PyTuple};
 use std::collections::HashMap;
@@ -377,9 +377,10 @@ enum ResponseWireBody {
     ZeroCopyBytes(PyBackedBytes),
     FilePath(String),
     Stream {
-        media_type: String,
+        media_type: PyBackedStr,
         content_obj: Py<PyAny>,
         is_async_generator: bool,
+        ping_interval: Option<f64>,
     },
 }
 
@@ -458,20 +459,30 @@ fn parse_response_wire(py: Python<'_>, result_obj: &Py<PyAny>) -> PyResult<Parse
                     "stream payload must be StreamingResponse",
                 ));
             }
-            let media_type: String = payload
+            let media_type: PyBackedStr = payload
                 .getattr(pyo3::intern!(py, "media_type"))?
-                .extract()
-                .unwrap_or_else(|_| "application/octet-stream".to_string());
+                .extract()?;
             let content_obj: Py<PyAny> = payload.getattr(pyo3::intern!(py, "content"))?.unbind();
             let is_async_generator: bool = payload
                 .getattr(pyo3::intern!(py, "is_async_generator"))?
                 .extract()
                 .unwrap_or(false);
 
+            // For SSE streams, extract optional keep-alive ping interval
+            let ping_interval: Option<f64> = if media_type == "text/event-stream" {
+                payload
+                    .getattr(pyo3::intern!(py, "ping_interval"))
+                    .ok()
+                    .and_then(|v| v.extract().ok())
+            } else {
+                None
+            };
+
             ResponseWireBody::Stream {
                 media_type,
                 content_obj,
                 is_async_generator,
+                ping_interval,
             }
         }
         2 => ResponseWireBody::FilePath(payload.extract::<String>()?), // file
@@ -554,6 +565,7 @@ async fn build_response_from_parsed(
             media_type,
             content_obj,
             is_async_generator,
+            ping_interval,
         } => {
             let headers = response_builder::meta_to_headers(meta_ref);
             if media_type == "text/event-stream" {
@@ -567,7 +579,8 @@ async fn build_response_from_parsed(
                     mark_skip_cors(&mut response, skip_cors);
                     return response;
                 }
-                let stream = create_sse_stream(content_obj, is_async_generator);
+                let stream =
+                    create_sse_stream(content_obj, is_async_generator, ping_interval);
                 let mut response =
                     response_builder::build_sse_response(parsed.status, headers, skip_compression)
                         .streaming(stream);

--- a/src/response_builder.rs
+++ b/src/response_builder.rs
@@ -15,7 +15,7 @@ use crate::response_meta::ResponseMeta;
 pub fn build_sse_response(
     status: StatusCode,
     custom_headers: Vec<(String, String)>,
-    skip_compression: bool,
+    _skip_compression: bool,
 ) -> HttpResponseBuilder {
     let mut builder = HttpResponse::build(status);
 
@@ -32,9 +32,9 @@ pub fn build_sse_response(
     builder.insert_header(("Pragma", "no-cache"));
     builder.insert_header(("Expires", "0"));
 
-    if skip_compression {
-        builder.insert_header(("Content-Encoding", "identity"));
-    }
+    // Always skip compression for SSE — buffering defeats streaming.
+    // The compression middleware checks for Content-Encoding: identity and skips.
+    builder.insert_header(("Content-Encoding", "identity"));
 
     builder
 }

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1,11 +1,17 @@
 use actix_web::web::Bytes;
-use futures_util::future::join_all;
-use futures_util::{stream, Stream};
+use futures_util::{stream, Stream, StreamExt};
 use pyo3::prelude::*;
-use pyo3::types::{PyByteArray, PyBytes, PyMemoryView, PyString};
+use pyo3::pybacked::PyBackedBytes;
+use pyo3::sync::PyOnceLock;
+use pyo3::types::{PyByteArray, PyDict, PyMemoryView, PyModule, PyString};
+use pyo3::IntoPyObjectExt;
+use pyo3_async_runtimes::TaskLocals;
+use std::ffi::CString;
 use std::pin::Pin;
 use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TrySendError;
 
 use crate::state::{get_max_sync_streaming_threads, ACTIVE_SYNC_STREAMING_THREADS, TASK_LOCALS};
 // Streaming uses direct_stream only in higher-level handler; not directly here
@@ -18,10 +24,13 @@ use crate::state::{get_max_sync_streaming_threads, ACTIVE_SYNC_STREAMING_THREADS
 
 #[inline(always)]
 pub fn convert_python_chunk(value: &Bound<'_, PyAny>) -> Option<Bytes> {
-    if let Ok(py_bytes) = value.cast::<PyBytes>() {
-        return Some(Bytes::copy_from_slice(py_bytes.as_bytes()));
+    // Zero-copy path: PyBackedBytes holds a reference to the Python bytes object.
+    // Bytes::from_owner wraps it without memcpy.
+    if let Ok(backed) = value.extract::<PyBackedBytes>() {
+        return Some(Bytes::from_owner(backed));
     }
     if let Ok(py_bytearray) = value.cast::<PyByteArray>() {
+        // bytearray is mutable so we must copy
         return Some(Bytes::copy_from_slice(unsafe { py_bytearray.as_bytes() }));
     }
     if let Ok(py_str) = value.cast::<PyString>() {
@@ -33,20 +42,19 @@ pub fn convert_python_chunk(value: &Bound<'_, PyAny>) -> Option<Bytes> {
     }
     if let Ok(memory_view) = value.cast::<PyMemoryView>() {
         if let Ok(bytes_obj) = memory_view.call_method0("tobytes") {
-            if let Ok(py_bytes) = bytes_obj.cast::<PyBytes>() {
-                return Some(Bytes::copy_from_slice(py_bytes.as_bytes()));
+            if let Ok(backed) = bytes_obj.extract::<PyBackedBytes>() {
+                return Some(Bytes::from_owner(backed));
             }
         }
     }
-    // OPTIMIZATION: Use interned strings for attribute checks
     let py = value.py();
     if value
         .hasattr(pyo3::intern!(py, "__bytes__"))
         .unwrap_or(false)
     {
         if let Ok(buffer) = value.call_method0(pyo3::intern!(py, "__bytes__")) {
-            if let Ok(py_bytes) = buffer.cast::<PyBytes>() {
-                return Some(Bytes::copy_from_slice(py_bytes.as_bytes()));
+            if let Ok(backed) = buffer.extract::<PyBackedBytes>() {
+                return Some(Bytes::from_owner(backed));
             }
         }
     }
@@ -55,6 +63,131 @@ pub fn convert_python_chunk(value: &Bound<'_, PyAny>) -> Option<Bytes> {
         return Some(Bytes::from(s.into_bytes()));
     }
     None
+}
+
+const ASYNC_STREAM_FORWARDER: &str = r#"
+import inspect
+
+async def forward(gen, sender):
+    iterator = gen.__aiter__() if hasattr(gen, "__aiter__") else gen
+    try:
+        while True:
+            item = await iterator.__anext__()
+            should_continue = sender.send(item)
+            if inspect.isawaitable(should_continue):
+                should_continue = await should_continue
+            if should_continue:
+                continue
+            break
+    except StopAsyncIteration:
+        pass
+    except Exception:
+        # Match the existing behavior of terminating the stream when the Python
+        # iterator raises. The response body simply ends instead of surfacing a
+        # noisy "Task exception was never retrieved" diagnostic.
+        pass
+    finally:
+        try:
+            aclose = getattr(iterator, "aclose", None)
+            if aclose is not None:
+                maybe_awaitable = aclose()
+                if inspect.isawaitable(maybe_awaitable):
+                    await maybe_awaitable
+        except Exception:
+            pass
+        sender.close()
+"#;
+
+#[pyclass]
+struct AsyncStreamSender {
+    locals: TaskLocals,
+    tx: Arc<Mutex<Option<mpsc::Sender<Result<Bytes, std::io::Error>>>>>,
+}
+
+#[pymethods]
+impl AsyncStreamSender {
+    fn send(&mut self, item: Py<PyAny>) -> PyResult<Py<PyAny>> {
+        Python::attach(|py| {
+            let bytes = convert_python_chunk(&item.bind(py)).ok_or_else(|| {
+                pyo3::exceptions::PyTypeError::new_err(
+                    "StreamingResponse async iterator yielded an unsupported chunk type",
+                )
+            })?;
+            let tx = self.tx.lock().unwrap().as_ref().cloned();
+            let Some(tx) = tx else {
+                return false.into_py_any(py);
+            };
+
+            // try_send consumes the value, so we only clone if the channel is
+            // full and we need to retry with the async path.
+            match tx.try_send(Ok(bytes)) {
+                Ok(()) => true.into_py_any(py),
+                Err(TrySendError::Full(Ok(bytes))) => {
+                    pyo3_async_runtimes::tokio::future_into_py_with_locals(
+                        py,
+                        self.locals.clone(),
+                        async move { Ok(tx.send(Ok(bytes)).await.is_ok()) },
+                    )
+                    .map(Bound::unbind)
+                }
+                Err(TrySendError::Full(_) | TrySendError::Closed(_)) => false.into_py_any(py),
+            }
+        })
+    }
+
+    fn close(&mut self) {
+        self.tx.lock().unwrap().take();
+    }
+}
+
+fn get_async_stream_forwarder(py: Python<'_>) -> PyResult<&Bound<'_, PyAny>> {
+    static FORWARDER_MODULE: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+
+    let module = FORWARDER_MODULE.get_or_try_init(py, || -> PyResult<Py<PyAny>> {
+        let code = CString::new(ASYNC_STREAM_FORWARDER).expect("valid async stream forwarder");
+        let file = CString::new("django_bolt/async_stream_forwarder.py").expect("valid filename");
+        let name = CString::new("django_bolt_async_stream_forwarder").expect("valid module name");
+        Ok(
+            PyModule::from_code(py, code.as_c_str(), file.as_c_str(), name.as_c_str())?
+                .into_any()
+                .unbind(),
+        )
+    })?;
+
+    Ok(module.bind(py))
+}
+
+fn schedule_async_stream_forwarder(
+    py: Python<'_>,
+    content: &Py<PyAny>,
+    tx: mpsc::Sender<Result<Bytes, std::io::Error>>,
+) -> PyResult<()> {
+    let locals = TASK_LOCALS
+        .get()
+        .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("Asyncio loop not initialized"))?
+        .clone();
+    let sender = Py::new(
+        py,
+        AsyncStreamSender {
+            locals: locals.clone(),
+            tx: Arc::new(Mutex::new(Some(tx))),
+        },
+    )?;
+    let forwarder = get_async_stream_forwarder(py)?;
+    let coroutine =
+        forwarder.call_method1(pyo3::intern!(py, "forward"), (content.bind(py), sender))?;
+    let event_loop = locals.event_loop(py);
+    let kwargs = PyDict::new(py);
+    kwargs.set_item(pyo3::intern!(py, "context"), locals.context(py))?;
+    event_loop.call_method(
+        pyo3::intern!(py, "call_soon_threadsafe"),
+        (
+            event_loop.getattr(pyo3::intern!(py, "create_task"))?,
+            coroutine,
+        ),
+        Some(&kwargs),
+    )?;
+    Ok(())
 }
 
 /// Create a stream with default batch sizes from environment
@@ -76,17 +209,50 @@ pub fn create_python_stream(
 }
 
 /// Create a stream for SSE that sends items immediately (batch_size=1)
+/// with optional keep-alive pings when idle.
 pub fn create_sse_stream(
     content: Py<PyAny>,
     is_async_generator: bool,
+    ping_interval: Option<f64>,
 ) -> Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>> {
-    create_python_stream_with_config(content, 1, 1, is_async_generator)
+    let inner = create_python_stream_with_config(content, 1, 1, is_async_generator);
+
+    match ping_interval {
+        Some(interval) if interval > 0.0 => {
+            Box::pin(keepalive_stream(inner, interval))
+        }
+        _ => inner,
+    }
+}
+
+/// Wrap a stream with keep-alive ping injection.
+/// Emits `: ping\n\n` when the inner stream is idle for `interval_secs`.
+fn keepalive_stream(
+    inner: Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>>,
+    interval_secs: f64,
+) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Send {
+    let duration = std::time::Duration::from_secs_f64(interval_secs);
+    let keepalive_bytes: Bytes = Bytes::from_static(b": ping\n\n");
+
+    stream::unfold(
+        (inner, duration, keepalive_bytes),
+        |(mut inner, duration, keepalive_bytes)| async move {
+            match tokio::time::timeout(duration, inner.next()).await {
+                Ok(Some(item)) => Some((item, (inner, duration, keepalive_bytes))),
+                Ok(None) => None,
+                Err(_) => Some((
+                    Ok(keepalive_bytes.clone()),
+                    (inner, duration, keepalive_bytes),
+                )),
+            }
+        },
+    )
 }
 
 /// Internal function with configurable batch sizes
 fn create_python_stream_with_config(
     content: Py<PyAny>,
-    async_batch_size: usize,
+    _async_batch_size: usize,
     sync_batch_size: usize,
     is_async_from_metadata: bool,
 ) -> Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>> {
@@ -95,11 +261,6 @@ fn create_python_stream_with_config(
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|&n| n > 0)
         .unwrap_or(32);
-    let fast_path_threshold: usize = std::env::var("DJANGO_BOLT_STREAM_FAST_PATH_THRESHOLD")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .filter(|&n| n > 0)
-        .unwrap_or(10);
     // Note: content is guaranteed to be a generator instance (not a callable)
     // because StreamingResponse validates this in Python at instantiation time.
     // The is_async_generator flag was pre-computed from Python's inspect.
@@ -111,208 +272,16 @@ fn create_python_stream_with_config(
     let is_async_final = is_async_iter;
 
     if is_async_final {
-        let fast_path = fast_path_threshold;
-        tokio::spawn(async move {
-            let is_optimized_batcher = Python::attach(|py| {
-                if let Ok(name) = resolved_target_final.bind(py).get_type().name() {
-                    name.to_string().contains("OptimizedStreamBatcher")
-                } else {
-                    false
-                }
-            });
-
-            // OPTIMIZATION: Use interned strings for iterator protocol checks
-            let async_iter: Option<Py<PyAny>> = Python::attach(|py| {
-                let b = resolved_target_final.bind(py);
-                if b.hasattr(pyo3::intern!(py, "__aiter__")).unwrap_or(false) {
-                    match b.call_method0(pyo3::intern!(py, "__aiter__")) {
-                        Ok(it) => Some(it.unbind()),
-                        Err(_) => None,
-                    }
-                } else if b.hasattr(pyo3::intern!(py, "__anext__")).unwrap_or(false) {
-                    Some(resolved_target_final.clone_ref(py))
-                } else {
-                    None
-                }
-            });
-
-            if async_iter.is_none() {
-                let _ = tx
-                    .send(Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        "Failed to initialize async iterator",
-                    )))
-                    .await;
-                return;
-            }
-            let async_iter = async_iter.unwrap();
-
-            let mut exhausted = false;
-            let mut batch_futures = Vec::with_capacity(async_batch_size);
-            let mut consecutive_small_batches = 0u8;
-            let mut current_batch_size = std::cmp::min(async_batch_size, fast_path);
-
-            while !exhausted {
-                batch_futures.clear();
-                Python::attach(|py| {
-                    // Reuse the global event loop locals initialized at server startup
-                    let locals = match TASK_LOCALS.get() {
-                        Some(l) => l,
-                        None => {
-                            exhausted = true;
-                            return;
-                        }
-                    };
-
-                    let iterations = if is_optimized_batcher {
-                        1
-                    } else {
-                        current_batch_size
-                    };
-                    for _ in 0..iterations {
-                        // OPTIMIZATION: Use interned string for __anext__
-                        match async_iter
-                            .bind(py)
-                            .call_method0(pyo3::intern!(py, "__anext__"))
-                        {
-                            Ok(awaitable) => {
-                                match pyo3_async_runtimes::into_future_with_locals(
-                                    locals, awaitable,
-                                ) {
-                                    Ok(f) => batch_futures.push(f),
-                                    Err(_) => {
-                                        exhausted = true;
-                                        break;
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                if e.is_instance_of::<pyo3::exceptions::PyStopAsyncIteration>(py) {
-                                    exhausted = true;
-                                }
-                                break;
-                            }
-                        }
-                    }
-                });
-
-                if batch_futures.len() < current_batch_size / 2 {
-                    consecutive_small_batches += 1;
-                    if consecutive_small_batches >= 3 && current_batch_size > 1 {
-                        current_batch_size = std::cmp::max(1, current_batch_size / 2);
-                        consecutive_small_batches = 0;
-                    }
-                } else if batch_futures.len() == current_batch_size
-                    && current_batch_size < async_batch_size
-                {
-                    current_batch_size = std::cmp::min(async_batch_size, current_batch_size * 2);
-                    consecutive_small_batches = 0;
-                }
-
-                if batch_futures.is_empty() {
-                    break;
-                }
-
-                let results = join_all(batch_futures.drain(..)).await;
-
-                let mut got_stop_iteration = false;
-                for result in results {
-                    match result {
-                        Ok(obj) => {
-                            let bytes_opt = Python::attach(|py| {
-                                let v = obj.bind(py);
-                                if is_optimized_batcher {
-                                    if let Ok(py_bytes) = v.cast::<PyBytes>() {
-                                        Some(Bytes::copy_from_slice(py_bytes.as_bytes()))
-                                    } else {
-                                        super::streaming::convert_python_chunk(&v)
-                                    }
-                                } else {
-                                    super::streaming::convert_python_chunk(&v)
-                                }
-                            });
-                            if let Some(bytes) = bytes_opt {
-                                if tx.send(Ok(bytes)).await.is_err() {
-                                    // Client disconnected - close the async generator to run cleanup code
-                                    let close_result = Python::attach(|py| {
-                                        let iter_bound = async_iter.bind(py);
-                                        // OPTIMIZATION: Use interned string for aclose
-                                        if iter_bound
-                                            .hasattr(pyo3::intern!(py, "aclose"))
-                                            .unwrap_or(false)
-                                        {
-                                            if let Ok(awaitable) =
-                                                iter_bound.call_method0(pyo3::intern!(py, "aclose"))
-                                            {
-                                                if let Some(locals) = TASK_LOCALS.get() {
-                                                    return pyo3_async_runtimes::into_future_with_locals(locals, awaitable).ok();
-                                                } else {
-                                                    eprintln!("[SSE WARNING] Unable to get task locals for async generator cleanup on disconnect");
-                                                }
-                                            } else {
-                                                eprintln!("[SSE WARNING] Failed to call aclose() on async generator during disconnect cleanup");
-                                            }
-                                        }
-                                        None
-                                    });
-                                    // Await the cleanup if we got a future
-                                    if let Some(close_future) = close_result {
-                                        if let Err(e) = close_future.await {
-                                            eprintln!("[SSE WARNING] Error during async generator cleanup on client disconnect: {}", e);
-                                        }
-                                    }
-                                    exhausted = true;
-                                    break;
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            Python::attach(|py| {
-                                if e.is_instance_of::<pyo3::exceptions::PyStopAsyncIteration>(py) {
-                                    got_stop_iteration = true;
-                                    exhausted = true;
-                                }
-                            });
-                        }
-                    }
-                }
-                if got_stop_iteration {
-                    exhausted = true;
-                }
-            }
-
-            // Ensure async generator cleanup runs
-            let close_result = Python::attach(|py| {
-                let iter_bound = async_iter.bind(py);
-                // OPTIMIZATION: Use interned string for aclose
-                if iter_bound
-                    .hasattr(pyo3::intern!(py, "aclose"))
-                    .unwrap_or(false)
-                {
-                    if let Ok(awaitable) = iter_bound.call_method0(pyo3::intern!(py, "aclose")) {
-                        if let Some(locals) = TASK_LOCALS.get() {
-                            return pyo3_async_runtimes::into_future_with_locals(locals, awaitable)
-                                .ok();
-                        } else {
-                            eprintln!("[SSE WARNING] Unable to get task locals for async generator cleanup at end of stream");
-                        }
-                    } else {
-                        eprintln!("[SSE WARNING] Failed to call aclose() on async generator at end of stream cleanup");
-                    }
-                }
-                None
-            });
-            if let Some(close_future) = close_result {
-                if let Err(e) = close_future.await {
-                    eprintln!(
-                        "[SSE WARNING] Error during async generator cleanup at end of stream: {}",
-                        e
-                    );
-                }
-            }
+        let start_result = Python::attach(|py| {
+            schedule_async_stream_forwarder(py, &resolved_target_final, tx.clone())
         });
+        if let Err(err) = start_result {
+            let _ = tx.try_send(Err(std::io::Error::other(format!(
+                "Failed to initialize async stream forwarder: {err}"
+            ))));
+        }
+        drop(tx);
 
-        // Async streaming successful, return stream
         let s = stream::unfold(rx, |mut rx| async move {
             match rx.recv().await {
                 Some(item) => Some((item, rx)),


### PR DESCRIPTION
- EventSourceResponse with auto SSE framing, compression skip, keep-alive pings
- ServerSentEvent struct for full control over event/id/retry/comment fields
- response_class parameter on all HTTP method decorators
- Rust: zero-copy chunks via PyBackedBytes, PyBackedStr for media_type
- Rust: always skip compression for text/event-stream streams
- Rust: keepalive ping stream wrapper using tokio::time::timeout
- Dedicated SSE documentation page

fix: Resolve task affinity bug in async streaming (fixes opentelemetry/anyio errors)

Rewrote async stream forwarding to schedule the Python generator iteration on the same asyncio event loop task that created the generator context. The previous approach used tokio::spawn + join_all which drove the generator from a different task, breaking anyio cancel scopes and opentelemetry context propagation (ContextVar tokens created in one task couldn't be detached in another).


<!-- Describe the change in 2-3 sentences. Link to any related issue. -->

Fixes #


## How was this tested?

- [x] `just lint-lib` and `just test-py` pass
- [x] If Rust was changed: `just rebuild` succeeds
- [x] If a new feature is added: tested manually in the example project (`python/example/`)


## Performance consideration

<!-- Django-Bolt is a performance-critical framework. Explain why this change does not regress the hot path, or show benchmark numbers if it touches dispatch/serialization/routing. -->





