### PR TITLE
fix: preserve handler-set cookies through django_middleware_to_django_response() 

### DIFF
--- a/python/django_bolt/middleware/django_adapter.py
+++ b/python/django_bolt/middleware/django_adapter.py
@@ -970,6 +970,36 @@ def _to_django_response(response: Response) -> HttpResponse:
         for key, value in remaining_headers:
             django_response[key] = value
 
+    # Transfer raw cookies onto the Django HttpResponse so they survive any
+    # downstream Django middleware (e.g. LocaleMiddleware) that returns the
+    # same response object. Without this, _to_bolt_response() harvests an
+    # empty cookie jar and handler-set cookies are silently dropped.
+    #
+    # Write directly to the SimpleCookie morsel instead of HttpResponse.set_cookie:
+    # raw tuples are already validated by Cookie.to_raw_tuple(), so we skip
+    # http_date(time.time()+max_age), int(max_age), samesite validation, and
+    # the unconditional empty-expires write that set_cookie performs.
+    raw_cookies = getattr(response, "_raw_cookies", None)
+    if raw_cookies:
+        cookies = django_response.cookies
+        for name, value, path, max_age, expires, domain, secure, httponly, samesite in raw_cookies:
+            cookies[name] = value
+            morsel = cookies[name]
+            if max_age is not None:
+                morsel["max-age"] = max_age
+            if expires:
+                morsel["expires"] = expires
+            if path:
+                morsel["path"] = path
+            if domain:
+                morsel["domain"] = domain
+            if secure:
+                morsel["secure"] = True
+            if httponly:
+                morsel["httponly"] = True
+            if samesite:
+                morsel["samesite"] = samesite
+
     _store_preserved_body(django_response, preserved_body)
     return django_response
 

--- a/python/tests/test_django_middleware_integration.py
+++ b/python/tests/test_django_middleware_integration.py
@@ -1458,6 +1458,98 @@ class TestMultipleCookieHeaders:
 
 
 # =============================================================================
+# Test Handler-Set Cookies Survive django_middleware
+# =============================================================================
+
+
+class TestHandlerCookiesWithDjangoMiddleware:
+    """
+    Cookies set by the handler (e.g. JSON(...).set_cookie(...)) must survive
+    when django_middleware is configured. Previously they were silently
+    dropped because _to_django_response() built a fresh HttpResponse without
+    carrying _raw_cookies onto it, so Django middleware never saw them and
+    _to_bolt_response() harvested an empty cookie jar.
+    """
+
+    def test_handler_cookies_preserved_through_locale_middleware(self):
+        from django_bolt.responses import JSON
+
+        api = BoltAPI(
+            django_middleware=[
+                "django.middleware.locale.LocaleMiddleware",
+                "django.middleware.common.CommonMiddleware",
+            ]
+        )
+
+        @api.post("/login")
+        async def login():
+            return (
+                JSON({"ok": True})
+                .set_cookie(
+                    name="access_token",
+                    value="access-abc",
+                    max_age=3600,
+                    secure=True,
+                    httponly=True,
+                )
+                .set_cookie(
+                    name="refresh_token",
+                    value="refresh-xyz",
+                    max_age=86400,
+                    secure=True,
+                    httponly=True,
+                )
+            )
+
+        with TestClient(api) as client:
+            response = client.post("/login")
+            assert response.status_code == 200
+
+            set_cookie_headers = [
+                value for key, value in response.headers.multi_items() if key.lower() == "set-cookie"
+            ]
+            joined = "\n".join(set_cookie_headers)
+
+            assert len(set_cookie_headers) >= 2, (
+                f"Expected at least 2 Set-Cookie headers from handler, got {len(set_cookie_headers)}: {set_cookie_headers}"
+            )
+            assert "access_token=access-abc" in joined, (
+                f"access_token cookie missing. Set-Cookie headers: {set_cookie_headers}"
+            )
+            assert "refresh_token=refresh-xyz" in joined, (
+                f"refresh_token cookie missing. Set-Cookie headers: {set_cookie_headers}"
+            )
+
+    def test_handler_cookies_preserved_with_single_django_middleware(self):
+        from django_bolt.responses import JSON
+
+        api = BoltAPI(
+            middleware=[DjangoMiddleware("django.middleware.common.CommonMiddleware")],
+        )
+
+        @api.post("/login")
+        async def login():
+            return JSON({"ok": True}).set_cookie(
+                name="session",
+                value="single-mw-cookie",
+                httponly=True,
+            )
+
+        with TestClient(api) as client:
+            response = client.post("/login")
+            assert response.status_code == 200
+
+            set_cookie_headers = [
+                value for key, value in response.headers.multi_items() if key.lower() == "set-cookie"
+            ]
+            joined = "\n".join(set_cookie_headers)
+
+            assert "session=single-mw-cookie" in joined, (
+                f"Handler-set cookie missing through DjangoMiddleware. Set-Cookie headers: {set_cookie_headers}"
+            )
+
+
+# =============================================================================
 # Test auser Setter for Django alogin() Compatibility
 # =============================================================================
 


### PR DESCRIPTION
built a fresh HttpResponse without carrying _raw_cookies onto it, so any Django middleware (e.g. LocaleMiddleware) that returned the response caused _to_bolt_response() to harvest an empty cookie jar and silently drop JSON(...).set_cookie(...) data. Write raw tuples directly to the SimpleCookie morsel to skip the redundant http_date/int/samesite work that HttpResponse.set_cookie performs on already-validated values.


<!-- Describe the change in 2-3 sentences. Link to any related issue. -->

Fixes https://github.com/dj-bolt/django-bolt/issues/210


