### PR TITLE
ci: add prek lint workflow and SHA-pin all GitHub Actions + hooks

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,7 +2,7 @@
 
 github: #
 patreon: # Replace with a single Patreon username
-open_collective: django-bolt 
+open_collective: django-bolt
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,8 +14,3 @@ Fixes #
 ## Performance consideration
 
 <!-- Django-Bolt is a performance-critical framework. Explain why this change does not regress the hot path, or show benchmark numbers if it touches dispatch/serialization/routing. -->
-
-
-
-
-

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,10 +24,10 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
 
@@ -37,7 +37,9 @@ jobs:
           uv venv
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
 
       - name: Install dependencies
         run: |
@@ -55,15 +57,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 
@@ -71,7 +73,9 @@ jobs:
         run: uv venv
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
 
       - name: Install dependencies
         run: uv pip install -e ".[dev]"
@@ -91,15 +95,15 @@ jobs:
         python-version: ["3.12", "3.14"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -107,7 +111,9 @@ jobs:
         run: uv venv
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
 
       - name: Install dependencies
         run: uv pip install -e ".[dev]"
@@ -128,15 +134,15 @@ jobs:
         os: ["macos-latest", "windows-latest"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 
@@ -144,7 +150,9 @@ jobs:
         run: uv venv
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
 
       - name: Install dependencies
         run: uv pip install -e ".[dev]"
@@ -161,7 +169,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Free disk space
         run: |
@@ -169,7 +177,7 @@ jobs:
           docker volume prune -f
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: x86_64
           args: --release --out dist --interpreter 3.12 3.13 3.14
@@ -178,7 +186,7 @@ jobs:
           docker-options: --pull always
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: wheels-linux-x86_64
           path: dist
@@ -189,17 +197,17 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: universal2-apple-darwin
           args: --release --out dist --interpreter 3.12 3.13 3.14
           sccache: "true"
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: wheels-macos-universal2
           path: dist
@@ -210,17 +218,17 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: x64
           args: --release --out dist --interpreter 3.12 3.13 3.14
           sccache: "true"
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: wheels-windows-x64
           path: dist
@@ -231,7 +239,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Free disk space
         run: |
@@ -239,13 +247,13 @@ jobs:
           docker volume prune -f
 
       - name: Build sdist
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           command: sdist
           args: --out dist
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: wheels-sdist
           path: dist
@@ -257,10 +265,10 @@ jobs:
     needs: [linux, macos, windows, sdist]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: wheels-*
           path: dist
@@ -286,15 +294,15 @@ jobs:
         artifact-kind: ["wheel", "sdist"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 
@@ -302,7 +310,9 @@ jobs:
         run: uv venv
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
 
       - name: Install dependencies
         run: uv pip install -e ".[dev]"
@@ -312,14 +322,14 @@ jobs:
 
       - name: Download Linux wheel artifact
         if: matrix.artifact-kind == 'wheel'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: wheels-linux-x86_64
           path: dist
 
       - name: Download source artifact
         if: matrix.artifact-kind == 'sdist'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: wheels-sdist
           path: dist
@@ -355,10 +365,10 @@ jobs:
       contents: write # Required for GitHub release
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: wheels-*
           path: dist
@@ -374,7 +384,7 @@ jobs:
         run: uv publish --trusted-publishing always
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: dist/*
           generate_release_notes: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
@@ -58,6 +60,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
@@ -96,6 +100,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
@@ -135,6 +141,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
@@ -170,6 +178,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Free disk space
         run: |
@@ -198,6 +208,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
@@ -219,6 +231,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
@@ -240,6 +254,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Free disk space
         run: |
@@ -266,6 +282,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Download all artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -295,6 +313,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
@@ -366,6 +386,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Download all artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,6 +44,8 @@ jobs:
         # share across the Python matrix: the abi3 build is version-agnostic
         # (one artifact for 3.12/3.13/3.14), so cached deps are identical.
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          rustflags: "" # action defaults to -D warnings; don't block tests on warnings
 
       - name: Install dependencies
         run: |
@@ -84,6 +86,8 @@ jobs:
         # share across the Python matrix: the abi3 build is version-agnostic
         # (one artifact for 3.12/3.13/3.14), so cached deps are identical.
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          rustflags: "" # action defaults to -D warnings; don't block tests on warnings
 
       - name: Install dependencies
         run: uv pip install -e ".[dev]"
@@ -126,6 +130,8 @@ jobs:
         # share across the Python matrix: the abi3 build is version-agnostic
         # (one artifact for 3.12/3.13/3.14), so cached deps are identical.
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          rustflags: "" # action defaults to -D warnings; don't block tests on warnings
 
       - name: Install dependencies
         run: uv pip install -e ".[dev]"
@@ -169,6 +175,8 @@ jobs:
         # share across the Python matrix: the abi3 build is version-agnostic
         # (one artifact for 3.12/3.13/3.14), so cached deps are identical.
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          rustflags: "" # action defaults to -D warnings; don't block tests on warnings
 
       - name: Install dependencies
         run: uv pip install -e ".[dev]"
@@ -309,6 +317,40 @@ jobs:
       - name: List all wheels
         run: ls -lh dist/
 
+  # Supply-chain gate: a vulnerable dep compiled into the wheel (Rust) or
+  # resolved at install (Python) passes manual release review. This catches it;
+  # it blocks release via `needs` below.
+  audit:
+    name: Security audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          rustflags: ""
+
+      - name: cargo audit (Rust deps in Cargo.lock)
+        run: |
+          cargo install cargo-audit --locked
+          # RUSTSEC-2023-0071 (rsa Marvin attack): no fixed release exists. rsa is
+          # transitive via jsonwebtoken, and the timing oracle targets RSA
+          # private-key decryption, not the public-key path JWT verification uses.
+          cargo audit --ignore RUSTSEC-2023-0071
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: "latest"
+
+      - name: pip-audit (Python deps in uv.lock)
+        run: |
+          uv export --no-emit-project --no-dev --format requirements-txt --output-file audit-reqs.txt
+          uvx pip-audit --requirement audit-reqs.txt --no-deps
+
   artifact_smoke:
     name: Artifact Smoke ${{ matrix.artifact-kind }}
     if: startsWith(github.ref, 'refs/tags/v')
@@ -343,6 +385,8 @@ jobs:
         # share across the Python matrix: the abi3 build is version-agnostic
         # (one artifact for 3.12/3.13/3.14), so cached deps are identical.
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          rustflags: "" # action defaults to -D warnings; don't block tests on warnings
 
       - name: Install dependencies
         run: uv pip install -e ".[dev]"
@@ -386,7 +430,7 @@ jobs:
     name: Release to PyPI
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [test, validate, server_smoke_linux, server_integration_linux, platform_smoke, artifact_smoke]
+    needs: [test, validate, audit, server_smoke_linux, server_integration_linux, platform_smoke, artifact_smoke]
     environment:
       name: pypi
       url: https://pypi.org/project/django-bolt/

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,10 +40,10 @@ jobs:
 
       - name: Install Rust
         # Toolchain (channel + rustfmt) comes from rust-toolchain.toml — omit
-        # `toolchain` so the action reads the file instead of defaulting to stable.
+        # `toolchain` so the action reads the file. Default rust-cache is safe to
+        # share across the Python matrix: the abi3 build is version-agnostic
+        # (one artifact for 3.12/3.13/3.14), so cached deps are identical.
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-        with:
-          cache: false
 
       - name: Install dependencies
         run: |
@@ -80,10 +80,10 @@ jobs:
 
       - name: Install Rust
         # Toolchain (channel + rustfmt) comes from rust-toolchain.toml — omit
-        # `toolchain` so the action reads the file instead of defaulting to stable.
+        # `toolchain` so the action reads the file. Default rust-cache is safe to
+        # share across the Python matrix: the abi3 build is version-agnostic
+        # (one artifact for 3.12/3.13/3.14), so cached deps are identical.
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-        with:
-          cache: false
 
       - name: Install dependencies
         run: uv pip install -e ".[dev]"
@@ -122,10 +122,10 @@ jobs:
 
       - name: Install Rust
         # Toolchain (channel + rustfmt) comes from rust-toolchain.toml — omit
-        # `toolchain` so the action reads the file instead of defaulting to stable.
+        # `toolchain` so the action reads the file. Default rust-cache is safe to
+        # share across the Python matrix: the abi3 build is version-agnostic
+        # (one artifact for 3.12/3.13/3.14), so cached deps are identical.
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-        with:
-          cache: false
 
       - name: Install dependencies
         run: uv pip install -e ".[dev]"
@@ -165,10 +165,10 @@ jobs:
 
       - name: Install Rust
         # Toolchain (channel + rustfmt) comes from rust-toolchain.toml — omit
-        # `toolchain` so the action reads the file instead of defaulting to stable.
+        # `toolchain` so the action reads the file. Default rust-cache is safe to
+        # share across the Python matrix: the abi3 build is version-agnostic
+        # (one artifact for 3.12/3.13/3.14), so cached deps are identical.
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-        with:
-          cache: false
 
       - name: Install dependencies
         run: uv pip install -e ".[dev]"
@@ -339,10 +339,10 @@ jobs:
 
       - name: Install Rust
         # Toolchain (channel + rustfmt) comes from rust-toolchain.toml — omit
-        # `toolchain` so the action reads the file instead of defaulting to stable.
+        # `toolchain` so the action reads the file. Default rust-cache is safe to
+        # share across the Python matrix: the abi3 build is version-agnostic
+        # (one artifact for 3.12/3.13/3.14), so cached deps are identical.
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-        with:
-          cache: false
 
       - name: Install dependencies
         run: uv pip install -e ".[dev]"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,9 +39,11 @@ jobs:
           uv venv
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        # Toolchain (channel + rustfmt) comes from rust-toolchain.toml — omit
+        # `toolchain` so the action reads the file instead of defaulting to stable.
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          toolchain: stable
+          cache: false
 
       - name: Install dependencies
         run: |
@@ -77,9 +79,11 @@ jobs:
         run: uv venv
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        # Toolchain (channel + rustfmt) comes from rust-toolchain.toml — omit
+        # `toolchain` so the action reads the file instead of defaulting to stable.
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          toolchain: stable
+          cache: false
 
       - name: Install dependencies
         run: uv pip install -e ".[dev]"
@@ -117,9 +121,11 @@ jobs:
         run: uv venv
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        # Toolchain (channel + rustfmt) comes from rust-toolchain.toml — omit
+        # `toolchain` so the action reads the file instead of defaulting to stable.
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          toolchain: stable
+          cache: false
 
       - name: Install dependencies
         run: uv pip install -e ".[dev]"
@@ -158,9 +164,11 @@ jobs:
         run: uv venv
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        # Toolchain (channel + rustfmt) comes from rust-toolchain.toml — omit
+        # `toolchain` so the action reads the file instead of defaulting to stable.
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          toolchain: stable
+          cache: false
 
       - name: Install dependencies
         run: uv pip install -e ".[dev]"
@@ -330,9 +338,11 @@ jobs:
         run: uv venv
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        # Toolchain (channel + rustfmt) comes from rust-toolchain.toml — omit
+        # `toolchain` so the action reads the file instead of defaulting to stable.
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          toolchain: stable
+          cache: false
 
       - name: Install dependencies
         run: uv pip install -e ".[dev]"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.x

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,16 +19,16 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/configure-pages@v5
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.x
       - run: pip install zensical
       - run: zensical build --clean
         working-directory: docs
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: docs/site
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
         id: deployment

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,9 +23,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      # Provide `cargo`/`rustfmt` for the local cargo-fmt hook in .pre-commit-config.yaml.
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: stable
-          components: rustfmt
+      # The cargo-fmt hook (.pre-commit-config.yaml) runs via the runner's
+      # preinstalled rustup, which auto-installs the toolchain + rustfmt pinned
+      # in rust-toolchain.toml — so CI and local formatting never drift.
       - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,9 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      # The cargo-fmt hook (.pre-commit-config.yaml) runs via the runner's
-      # preinstalled rustup, which auto-installs the toolchain + rustfmt pinned
-      # in rust-toolchain.toml — so CI and local formatting never drift.
+      # Install the toolchain pinned in rust-toolchain.toml (incl. rustfmt) for the
+      # cargo-fmt hook, so CI and local formatting stay on the same version.
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          cache: false
       - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prek:
+    name: prek
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: j178/prek-action@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,5 +16,5 @@ jobs:
     name: prek
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: j178/prek-action@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      # Provide `cargo`/`rustfmt` for the local cargo-fmt hook in .pre-commit-config.yaml.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+          components: rustfmt
       - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,12 +11,18 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   prek:
     name: prek
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       # Provide `cargo`/`rustfmt` for the local cargo-fmt hook in .pre-commit-config.yaml.
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,12 @@ repos:
       # Ensure every file ends with exactly one newline.
       - id: end-of-file-fixer
         exclude: '^python/example/(test_data|media|static)/'
+      # Validate config-file syntax (Cargo.toml, pyproject.toml, workflows, etc.).
+      - id: check-toml
+      - id: check-yaml
+      # Block accidental commits of conflict markers and private keys.
+      - id: check-merge-conflict
+      - id: detect-private-key
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 3b3f7c3f57fe9925356faf5fe6230835138be230  # frozen: v0.15.17

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,16 @@ repos:
         args: [--fix]
       # Format.
       - id: ruff-format
+
+  # Rust formatting gate. System hook — needs `cargo` on PATH: contributors
+  # have it locally, and the Lint workflow installs the stable toolchain
+  # (with rustfmt) before running prek. Runs once over the whole workspace
+  # whenever any .rs file changes.
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+# Pre-commit hooks, run with prek (https://github.com/j178/prek) — a fast,
+# drop-in replacement for pre-commit that reads this same config file.
+#
+#   prek install          # enable the git pre-commit hook locally
+#   prek run --all-files   # run every hook against the whole repo
+#
+# CI runs `prek run --all-files` via .github/workflows/lint.yml.
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      # Strip trailing whitespace, but keep hard line breaks in Markdown.
+      # Exclude size-sensitive benchmark/upload fixtures (e.g. test_data/100B.txt
+      # must stay exactly 100 bytes); the .py files there are still covered by ruff.
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+        exclude: '^python/example/(test_data|media|static)/'
+      # Ensure every file ends with exactly one newline.
+      - id: end-of-file-fixer
+        exclude: '^python/example/(test_data|media|static)/'
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.17
+    hooks:
+      # Lint (autofix what is safe). Keep before the formatter per ruff guidance.
+      - id: ruff-check
+        args: [--fix]
+      # Format.
+      - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@
 # CI runs `prek run --all-files` via .github/workflows/lint.yml.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       # Strip trailing whitespace, but keep hard line breaks in Markdown.
       # Exclude size-sensitive benchmark/upload fixtures (e.g. test_data/100B.txt
@@ -20,7 +20,7 @@ repos:
         exclude: '^python/example/(test_data|media|static)/'
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.17
+    rev: 3b3f7c3f57fe9925356faf5fe6230835138be230  # frozen: v0.15.17
     hooks:
       # Lint (autofix what is safe). Keep before the formatter per ruff guidance.
       - id: ruff-check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "smallvec",
  "tokio",
@@ -148,7 +148,7 @@ dependencies = [
  "log",
  "memchr",
  "mime",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "serde_plain",
@@ -1213,7 +1213,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.4",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -1553,7 +1553,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
@@ -1810,7 +1810,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -2084,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf3ccafdf54c050be48a3a086d372f77ba6615f5057211607cd30e5ac5cec6d"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -2098,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7364a95bf00e8377bbf9b0f09d7ff9715a29d8fcf93b47d1a967363b973178"
+checksum = "b3ef68daa7316a3fac65e5e18b2203f010346de1c1c53456811a2624673ab046"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -2112,18 +2112,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972720a441c91fd9c49f212a1d2d74c6e3803b231ebc8d66c51efbd7ccab11c8"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5994456d9dab8934d600d3867571b6410f24fbd6002570ad56356733eb54859b"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2131,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ce9cc8d81b3c4969748807604d92b4eef363c5bb82b1a1bdb34ec6f1093a18"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2143,13 +2143,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf4b60036a154d23282679b658e3cc7d88d3b8c9a40b43824785f232d2e1b98"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.114",
 ]
@@ -2192,9 +2191,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2203,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2389,7 +2388,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ jemalloc = ["dep:tikv-jemallocator"]
 mimalloc = ["dep:mimalloc"]
 
 [dependencies]
-pyo3 = { version = "0.28", features = ["extension-module", "abi3-py312"] }
-pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py312"] }
+pyo3-async-runtimes = { version = "0.29", features = ["tokio-runtime"] }
 actix-web = { version = "4", features = ["compress-gzip", "compress-brotli", "compress-zstd", "cookies"] }
 cookie = "0.18"  # RFC 6265 compliant cookie handling
 actix-http = "3"

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -362,4 +362,3 @@ link = "https://github.com/FarhanAliRaza/django-bolt"
 [[project.extra.social]]
 icon = "fontawesome/brands/python"
 link = "https://pypi.org/project/django-bolt/"
-

--- a/justfile
+++ b/justfile
@@ -14,7 +14,7 @@ default:
 
 # Build Rust extension in release mode
 build:
-    uv run maturin develop 
+    uv run maturin develop
 
 # Build Rust extension in release mode
 build-release:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dev = [
     "pydantic>=2",
     "pyyaml>=5.2",
     "maturin>=1.9.6",
-    "django==6.0.2",
+    "django==6.0.6",
     "ruff>=0.8",
     "vulture>=2.11", #for dead code detection
     "nanodjango>=0.16",

--- a/python/tests/test_jwt_auth.py
+++ b/python/tests/test_jwt_auth.py
@@ -287,12 +287,15 @@ async def test_get_user_reraises_operational_error():
     """
     auth = JWTAuthentication(secret="test-secret")
 
-    with patch.object(
-        auth._get_user_model().objects,
-        "aget",
-        new_callable=AsyncMock,
-        side_effect=OperationalError("connection reset"),
-    ), pytest.raises(OperationalError):
+    with (
+        patch.object(
+            auth._get_user_model().objects,
+            "aget",
+            new_callable=AsyncMock,
+            side_effect=OperationalError("connection reset"),
+        ),
+        pytest.raises(OperationalError),
+    ):
         await auth.get_user("1", {})
 
 
@@ -304,12 +307,15 @@ async def test_get_user_reraises_interface_error():
     """
     auth = JWTAuthentication(secret="test-secret")
 
-    with patch.object(
-        auth._get_user_model().objects,
-        "aget",
-        new_callable=AsyncMock,
-        side_effect=InterfaceError("connection closed"),
-    ), pytest.raises(InterfaceError):
+    with (
+        patch.object(
+            auth._get_user_model().objects,
+            "aget",
+            new_callable=AsyncMock,
+            side_effect=InterfaceError("connection closed"),
+        ),
+        pytest.raises(InterfaceError),
+    ):
         await auth.get_user("1", {})
 
 
@@ -320,11 +326,14 @@ def test_get_user_sync_reraises_operational_error():
     """
     auth = JWTAuthentication(secret="test-secret")
 
-    with patch.object(
-        auth._get_user_model().objects,
-        "get",
-        side_effect=OperationalError("connection reset"),
-    ), pytest.raises(OperationalError):
+    with (
+        patch.object(
+            auth._get_user_model().objects,
+            "get",
+            side_effect=OperationalError("connection reset"),
+        ),
+        pytest.raises(OperationalError),
+    ):
         auth.get_user_sync("1")
 
 
@@ -335,11 +344,14 @@ def test_get_user_sync_reraises_interface_error():
     """
     auth = JWTAuthentication(secret="test-secret")
 
-    with patch.object(
-        auth._get_user_model().objects,
-        "get",
-        side_effect=InterfaceError("connection closed"),
-    ), pytest.raises(InterfaceError):
+    with (
+        patch.object(
+            auth._get_user_model().objects,
+            "get",
+            side_effect=InterfaceError("connection closed"),
+        ),
+        pytest.raises(InterfaceError),
+    ):
         auth.get_user_sync("1")
 
 

--- a/python/tests/test_openapi_schema_accuracy.py
+++ b/python/tests/test_openapi_schema_accuracy.py
@@ -353,10 +353,7 @@ def test_component_schema_strips_docstring_indentation():
         name: str
 
     schema = _get_response_component_schema(MultiLineStruct)
-    assert schema["description"] == (
-        "Summary line.\n\n"
-        "Continuation paragraph that explains the struct in more detail."
-    )
+    assert schema["description"] == ("Summary line.\n\nContinuation paragraph that explains the struct in more detail.")
 
 
 def test_component_schema_omits_description_when_no_docstring():

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":enablePreCommit"
   ],
   "labels": [
     "dependencies"
@@ -40,6 +41,13 @@
       ],
       "groupName": "github actions",
       "automerge": true
+    },
+    {
+      "description": "Group pre-commit hooks (ruff, pre-commit-hooks)",
+      "matchManagers": [
+        "pre-commit"
+      ],
+      "groupName": "pre-commit hooks"
     },
     {
       "description": "Core framework deps - never automerge",

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
   ],
   "timezone": "UTC",
   "dependencyDashboard": true,
+  "automerge": false,
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [
@@ -40,16 +41,14 @@
       "matchManagers": [
         "github-actions"
       ],
-      "groupName": "github actions",
-      "automerge": true
+      "groupName": "github actions"
     },
     {
       "description": "Group pre-commit hooks (ruff, pre-commit-hooks)",
       "matchManagers": [
         "pre-commit"
       ],
-      "groupName": "pre-commit hooks",
-      "automerge": true
+      "groupName": "pre-commit hooks"
     },
     {
       "description": "Core framework deps - never automerge",
@@ -79,24 +78,6 @@
         "breaking"
       ],
       "automerge": false
-    },
-    {
-      "description": "Minor and patch can automerge (except core)",
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "automerge": true,
-      "matchPackageNames": [
-        "!pyo3",
-        "!pyo3-async-runtimes",
-        "!actix-web",
-        "!actix-http",
-        "!tokio",
-        "!Django",
-        "!msgspec",
-        "!maturin"
-      ]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,8 @@
       "matchManagers": [
         "pre-commit"
       ],
-      "groupName": "pre-commit hooks"
+      "groupName": "pre-commit hooks",
+      "automerge": true
     },
     {
       "description": "Core framework deps - never automerge",

--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,8 @@
     {
       "description": "Group all Rust dependencies",
       "matchManagers": [
-        "cargo"
+        "cargo",
+        "rust-toolchain"
       ],
       "groupName": "rust dependencies"
     },

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+# Pin the Rust toolchain so local builds, CI, and the `cargo fmt` gate all use
+# one version — no rustfmt drift between contributors and CI. rustup reads this
+# automatically for every cargo/rustfmt invocation in the repo. Renovate keeps
+# the channel current via its built-in rust-toolchain manager.
+[toolchain]
+channel = "1.96.0"
+profile = "minimal"
+components = ["rustfmt"]

--- a/scripts/install_hey.sh
+++ b/scripts/install_hey.sh
@@ -43,7 +43,7 @@ curl -L "$DOWNLOAD_URL" -o ~/.local/bin/hey
 if [ $? -eq 0 ]; then
     chmod +x ~/.local/bin/hey
     echo "✅ hey installed to ~/.local/bin/hey"
-    
+
     # Check if ~/.local/bin is in PATH
     if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
         echo ""
@@ -52,7 +52,7 @@ if [ $? -eq 0 ]; then
         echo ""
         echo "Add this to your ~/.bashrc or ~/.zshrc to make it permanent"
     fi
-    
+
     # Test installation
     if ~/.local/bin/hey -h &> /dev/null; then
         echo "✅ hey is working!"

--- a/src/form_parsing.rs
+++ b/src/form_parsing.rs
@@ -390,11 +390,7 @@ pub async fn parse_multipart(
             // Type coercion
             let type_hint = type_hints.get(&field_name).copied().unwrap_or(TYPE_STRING);
             let coerced = coerce_param(&value, type_hint).map_err(|e| {
-                ValidationError::type_coercion_error(
-                    &field_name,
-                    type_hint_name(type_hint),
-                    &e,
-                )
+                ValidationError::type_coercion_error(&field_name, type_hint_name(type_hint), &e)
             })?;
 
             // Preserve duplicate keys (e.g. multi-select) as FormValue::Multi.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -398,8 +398,7 @@ pub fn form_result_to_py(
                 }
             }
             FormValue::Multi(vs) => {
-                let items: Vec<Py<PyAny>> =
-                    vs.iter().map(|v| coerced_value_to_py(py, v)).collect();
+                let items: Vec<Py<PyAny>> = vs.iter().map(|v| coerced_value_to_py(py, v)).collect();
                 let list = PyList::new(py, items)?;
                 form_dict.set_item(key, list)?;
             }
@@ -553,9 +552,7 @@ fn parse_response_wire(py: Python<'_>, result_obj: &Py<PyAny>) -> PyResult<Parse
 
 /// Borrow the global `CompressionConfig` from `AppState` attached to the
 /// request. Returns `None` when no `BoltAPI(compression=...)` was configured.
-fn compression_config_from_req(
-    req: &HttpRequest,
-) -> Option<&crate::metadata::CompressionConfig> {
+fn compression_config_from_req(req: &HttpRequest) -> Option<&crate::metadata::CompressionConfig> {
     req.app_data::<actix_web::web::Data<std::sync::Arc<crate::state::AppState>>>()
         .and_then(|s| s.global_compression_config.as_deref())
 }
@@ -664,12 +661,8 @@ async fn build_response_from_parsed(
                     mark_skip_cors(&mut response, skip_cors);
                     return response;
                 }
-                let stream = create_sse_stream(
-                    content_obj,
-                    is_async_generator,
-                    ping_interval,
-                    codec,
-                );
+                let stream =
+                    create_sse_stream(content_obj, is_async_generator, ping_interval, codec);
                 let mut response = response_builder::build_sse_response(
                     parsed.status,
                     headers,

--- a/src/middleware/compression.rs
+++ b/src/middleware/compression.rs
@@ -291,14 +291,20 @@ mod select_encoding_tests {
 
     #[test]
     fn missing_accept_encoding_returns_identity() {
-        assert_eq!(select_encoding(None, Some(&cfg_brotli())), ContentEncoding::Identity);
+        assert_eq!(
+            select_encoding(None, Some(&cfg_brotli())),
+            ContentEncoding::Identity
+        );
     }
 
     #[test]
     fn missing_config_returns_identity() {
         // `compression=None` on BoltAPI → AppState.global_compression_config = None.
         // Buffered middleware must not silently compress in that case.
-        assert_eq!(select_encoding(Some("br, gzip"), None), ContentEncoding::Identity);
+        assert_eq!(
+            select_encoding(Some("br, gzip"), None),
+            ContentEncoding::Identity
+        );
     }
 
     #[test]

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -30,11 +30,8 @@ use crate::state::{ScopeConfig, ServeMode};
 /// exfiltrate but cannot execute, and forcing CSS to download would be
 /// gratuitous for the common "let users upload theme overrides" case.
 const DANGEROUS_MEDIA_EXTS: &[&str] = &[
-    "html", "htm", "xhtml", "xhtm", "shtml", "shtm", "htc", "hta",
-    "svg", "svgz",
-    "xml", "xsl", "xslt",
-    "js", "mjs", "cjs",
-    "wasm",
+    "html", "htm", "xhtml", "xhtm", "shtml", "shtm", "htc", "hta", "svg", "svgz", "xml", "xsl",
+    "xslt", "js", "mjs", "cjs", "wasm",
 ];
 
 fn is_dangerous_media_ext(path: &Path) -> bool {
@@ -319,11 +316,8 @@ mod tests {
     fn test_is_dangerous_media_ext() {
         // Script-bearing extensions must be flagged regardless of case.
         for ext in &[
-            "html", "HTM", "xhtml", "xhtm", "shtml", "shtm", "htc", "hta",
-            "svg", "SVGZ",
-            "xml", "xsl", "xslt",
-            "js", "MJS", "cjs",
-            "wasm",
+            "html", "HTM", "xhtml", "xhtm", "shtml", "shtm", "htc", "hta", "svg", "SVGZ", "xml",
+            "xsl", "xslt", "js", "MJS", "cjs", "wasm",
         ] {
             let p = Path::new(&format!("upload.{}", ext)).to_path_buf();
             assert!(
@@ -333,7 +327,9 @@ mod tests {
             );
         }
         // Inert types stay inline so legitimate avatars/images keep working.
-        for ext in &["png", "jpg", "jpeg", "gif", "webp", "pdf", "txt", "json", "css"] {
+        for ext in &[
+            "png", "jpg", "jpeg", "gif", "webp", "pdf", "txt", "json", "css",
+        ] {
             let p = Path::new(&format!("upload.{}", ext)).to_path_buf();
             assert!(
                 !is_dangerous_media_ext(&p),

--- a/src/streaming_compression.rs
+++ b/src/streaming_compression.rs
@@ -82,7 +82,9 @@ pub fn select_stream_encoding(
         }
     }
     if cfg.gzip_fallback && accepts_encoding(ae, "gzip") {
-        return Some(StreamCodec::Gzip { level: cfg.gzip_level });
+        return Some(StreamCodec::Gzip {
+            level: cfg.gzip_level,
+        });
     }
     None
 }
@@ -93,8 +95,12 @@ fn codec_for_backend(backend: &str, cfg: &CompressionConfig) -> Option<StreamCod
             quality: cfg.brotli_level,
             lgwin: cfg.brotli_lgwin,
         }),
-        "gzip" => Some(StreamCodec::Gzip { level: cfg.gzip_level }),
-        "zstd" => Some(StreamCodec::Zstd { level: cfg.zstd_level }),
+        "gzip" => Some(StreamCodec::Gzip {
+            level: cfg.gzip_level,
+        }),
+        "zstd" => Some(StreamCodec::Zstd {
+            level: cfg.zstd_level,
+        }),
         _ => None,
     }
 }
@@ -172,7 +178,9 @@ struct SinkWriter {
 
 impl SinkWriter {
     fn new() -> Self {
-        SinkWriter { buf: Vec::with_capacity(SINK_BUF_CAPACITY) }
+        SinkWriter {
+            buf: Vec::with_capacity(SINK_BUF_CAPACITY),
+        }
     }
 
     /// Yield the current buffer, leaving a fresh 4 KiB-capacity `Vec` in place.
@@ -386,8 +394,10 @@ mod tests {
     use std::io::Read;
 
     async fn collect_compressed(codec: StreamCodec, events: Vec<&'static [u8]>) -> Vec<Bytes> {
-        let items: Vec<Result<Bytes, std::io::Error>> =
-            events.into_iter().map(|b| Ok(Bytes::from_static(b))).collect();
+        let items: Vec<Result<Bytes, std::io::Error>> = events
+            .into_iter()
+            .map(|b| Ok(Bytes::from_static(b)))
+            .collect();
         let inner = stream::iter(items);
         let mut wrapped = EncoderStream::new(inner, codec);
         let mut out = Vec::new();
@@ -410,32 +420,53 @@ mod tests {
     #[tokio::test]
     async fn brotli_roundtrip_decodes_to_concatenated_input() {
         let chunks = collect_compressed(
-            StreamCodec::Brotli { quality: 5, lgwin: 18 },
+            StreamCodec::Brotli {
+                quality: 5,
+                lgwin: 18,
+            },
             vec![b"data: one\n\n", b"data: two\n\n", b"data: three\n\n"],
         )
         .await;
         let compressed = concat(&chunks);
         let mut decoded = Vec::new();
-        Decompressor::new(&compressed[..], 4096).read_to_end(&mut decoded).unwrap();
+        Decompressor::new(&compressed[..], 4096)
+            .read_to_end(&mut decoded)
+            .unwrap();
         assert_eq!(decoded, b"data: one\n\ndata: two\n\ndata: three\n\n");
     }
 
     #[tokio::test]
     async fn brotli_emits_per_event_chunks() {
         let chunks = collect_compressed(
-            StreamCodec::Brotli { quality: 5, lgwin: 18 },
+            StreamCodec::Brotli {
+                quality: 5,
+                lgwin: 18,
+            },
             vec![b"data: one\n\n", b"data: two\n\n", b"data: three\n\n"],
         )
         .await;
-        assert!(chunks.len() >= 3, "expected per-event flush, got {} chunks", chunks.len());
+        assert!(
+            chunks.len() >= 3,
+            "expected per-event flush, got {} chunks",
+            chunks.len()
+        );
     }
 
     #[tokio::test]
     async fn brotli_empty_stream() {
-        let chunks = collect_compressed(StreamCodec::Brotli { quality: 5, lgwin: 18 }, vec![]).await;
+        let chunks = collect_compressed(
+            StreamCodec::Brotli {
+                quality: 5,
+                lgwin: 18,
+            },
+            vec![],
+        )
+        .await;
         let compressed = concat(&chunks);
         let mut decoded = Vec::new();
-        Decompressor::new(&compressed[..], 4096).read_to_end(&mut decoded).unwrap();
+        Decompressor::new(&compressed[..], 4096)
+            .read_to_end(&mut decoded)
+            .unwrap();
         assert!(decoded.is_empty());
     }
 
@@ -450,7 +481,9 @@ mod tests {
         .await;
         let compressed = concat(&chunks);
         let mut decoded = Vec::new();
-        GzDecoder::new(&compressed[..]).read_to_end(&mut decoded).unwrap();
+        GzDecoder::new(&compressed[..])
+            .read_to_end(&mut decoded)
+            .unwrap();
         assert_eq!(decoded, b"data: one\n\ndata: two\n\ndata: three\n\n");
     }
 
@@ -461,7 +494,11 @@ mod tests {
             vec![b"data: one\n\n", b"data: two\n\n", b"data: three\n\n"],
         )
         .await;
-        assert!(chunks.len() >= 3, "expected per-event flush, got {} chunks", chunks.len());
+        assert!(
+            chunks.len() >= 3,
+            "expected per-event flush, got {} chunks",
+            chunks.len()
+        );
     }
 
     // ─── Zstd ─────────────────────────────────────────────────────────
@@ -485,7 +522,11 @@ mod tests {
             vec![b"data: one\n\n", b"data: two\n\n", b"data: three\n\n"],
         )
         .await;
-        assert!(chunks.len() >= 3, "expected per-event flush, got {} chunks", chunks.len());
+        assert!(
+            chunks.len() >= 3,
+            "expected per-event flush, got {} chunks",
+            chunks.len()
+        );
     }
 
     // ─── Accept-Encoding parser ────────────────────────────────────────

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -254,7 +254,9 @@ pub fn create_test_app(
     };
 
     let global_compression_config = match compression_config {
-        Some(d) => Some(Arc::new(crate::metadata::CompressionConfig::from_python_dict(d.as_any())?)),
+        Some(d) => Some(Arc::new(
+            crate::metadata::CompressionConfig::from_python_dict(d.as_any())?,
+        )),
         None => None,
     };
 

--- a/uv.lock
+++ b/uv.lock
@@ -137,16 +137,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "6.0.2"
+version = "6.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/3e/a1c4207c5dea4697b7a3387e26584919ba987d8f9320f59dc0b5c557a4eb/django-6.0.2.tar.gz", hash = "sha256:3046a53b0e40d4b676c3b774c73411d7184ae2745fe8ce5e45c0f33d3ddb71a7", size = 10886874, upload-time = "2026-02-03T13:50:31.596Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/29/ac41e16097af67066d97a7d5775c5d8e7efc5d0284f6b0a159e07b9adb92/django-6.0.6.tar.gz", hash = "sha256:ad03916ba59523d781ae5c3f631960c23d69a9d9c43cecda52fc23b47e953713", size = 10905525, upload-time = "2026-06-03T13:02:46.503Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/ba/a6e2992bc5b8c688249c00ea48cb1b7a9bc09839328c81dc603671460928/django-6.0.2-py3-none-any.whl", hash = "sha256:610dd3b13d15ec3f1e1d257caedd751db8033c5ad8ea0e2d1219a8acf446ecc6", size = 8339381, upload-time = "2026-02-03T13:50:15.501Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/50/23f9dc45483419a3cc2085b498b25adfbf10642b2941c73e6d2dfaffc9ab/django-6.0.6-py3-none-any.whl", hash = "sha256:25148b1194c47c2e685e5f5e9c5d59c78b075dfd282cb9618861ba6c1708f4d2", size = 8373354, upload-time = "2026-06-03T13:02:41.72Z" },
 ]
 
 [[package]]
@@ -209,7 +209,7 @@ provides-extras = ["yaml", "nanodjango"]
 [package.metadata.requires-dev]
 dev = [
     { name = "bolt-mcp", editable = "python/bolt-mcp" },
-    { name = "django", specifier = "==6.0.2" },
+    { name = "django", specifier = "==6.0.6" },
     { name = "maturin", specifier = ">=1.9.6" },
     { name = "nanodjango", specifier = ">=0.16" },
     { name = "openapi-spec-validator", specifier = ">=0.8.5" },
@@ -287,11 +287,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -678,11 +678,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Sets up [prek](https://github.com/j178/prek) — a fast, drop-in pre-commit runner — to run **ruff** (lint + format), file-hygiene checks, and a **Rust formatting gate**, wired into CI as a `Lint` workflow and kept current by Renovate. Also hardens the supply chain by pinning **all** GitHub Actions and pre-commit hooks to immutable commit SHAs, and pins the **Rust toolchain** for reproducible builds/formatting.

**Hooks (`.pre-commit-config.yaml`)**

- **ruff** — `ruff-check --fix` + `ruff-format`.
- **whitespace/EOF** — `trailing-whitespace` + `end-of-file-fixer`. Size-sensitive benchmark/upload fixtures under `python/example/{test_data,media,static}` are excluded so they keep their exact byte sizes (e.g. `100B.txt` stays 100 bytes); the `.py` files there are still covered by ruff.
- **config validation** — `check-toml`, `check-yaml`.
- **safety** — `check-merge-conflict`, `detect-private-key`.
- **`cargo fmt --check`** — local hook that runs once over the workspace whenever a `.rs` file changes. Toolchain comes from `rust-toolchain.toml`.
- All hook `rev`s are SHA-pinned with `# frozen: vX` comments.

**Rust toolchain (`rust-toolchain.toml`)** — pins the channel to `1.96.0` with the `rustfmt` component. rustup reads it for every cargo/rustfmt call in the repo, so local builds, the `cargo fmt` gate, and CI all use one toolchain — eliminating rustfmt drift. Renovate's built-in `rust-toolchain` manager keeps it current (grouped with Rust deps). Both workflows install it via `actions-rust-lang/setup-rust-toolchain` (the `toolchain` input is omitted so the action reads the file).

**Workflow (`.github/workflows/lint.yml`)** — installs the pinned toolchain via `actions-rust-lang/setup-rust-toolchain`, then runs `prek run --all-files` via `j178/prek-action`. `concurrency` cancels superseded runs. Triggers on push to `master`/`main`, PRs, and manual dispatch.

**Renovate (`renovate.json`)** — enables the pre-commit manager (`:enablePreCommit`, off by default even under `config:recommended`) and the `rust-toolchain` manager; groups pre-commit hooks (explicit `automerge: true`) and folds toolchain bumps into the Rust group. Minor/patch automerge, major manual, gated by this Lint check.

**SHA pinning + checkout hardening (repo-wide)** — every `uses:` in `CI.yml`, `docs.yml`, and `lint.yml` is pinned to a 40-char commit SHA with a `# vX.Y.Z` comment (`bolt-mcp.yml` was already pinned). CI.yml's Rust setup uses `actions-rust-lang/setup-rust-toolchain` (reads `rust-toolchain.toml`). All `actions/checkout` steps set `persist-credentials: false` (matching `bolt-mcp.yml`).

**One-time conformance changes** (so the gates pass immediately):
- Whitespace/final-newline cleanups + formatting-only `ruff-format` on two tests.
- `cargo fmt` applied to `src/` (6 files, whitespace/layout only — no behavior change), isolated in its own commit `style: apply cargo fmt to src/`.

## How was this tested?

- `prek run --all-files` → exit 0; all nine hooks pass
- `cargo fmt --all -- --check` → clean; `rustup show` confirms `rust-toolchain.toml` governs the toolchain (1.96.0)
- `renovate-config-validator` (latest) → config valid
- All workflow YAML re-parses; grep confirms no `uses:` ref on a mutable tag

## Notes / for reviewers

- **Toolchain blast radius:** `rust-toolchain.toml` governs **all** in-repo cargo invocations, including the maturin release-wheel builds (manylinux / macOS / Windows) and CI test jobs — they now build with `1.96.0`. Worth a glance at the wheel-build jobs on the next release to confirm the pinned version provisions cleanly in those containers. Bumping the pin (or letting Renovate do it) moves everything together.
- **CI build caching:** the CI.yml compile jobs use the action's default `Swatinem/rust-cache` to speed up `maturin develop --release`. Sharing one cache across the Python-version matrix is safe because the extension is built with abi3 (`abi3-py312`) — a single version-agnostic artifact for 3.12/3.13/3.14, so the cached dependency artifacts are identical. The fmt-only Lint job keeps `cache: false` (nothing compiles).
- **Renovate + pinned Actions:** the github-actions manager keeps digests + `# vX.Y.Z` comments current automatically (as it already does for `bolt-mcp.yml`).
- **Renovate + pinned hooks:** Renovate's pre-commit manager is beta and doesn't clearly document digest updates, so SHA-pinned hook `rev`s may need a periodic manual `pre-commit autoupdate --freeze`.
- **Deferred to CI jobs (not pre-commit):** clippy, vulture, and `ty` need the build/project environment and are better run in CI.yml's existing jobs than in the lightweight Lint hook.

## Performance consideration

N/A — tooling, CI, and mechanical Rust formatting only; no runtime or hot-path logic changes.
