### PR TITLE
make MAX_PARAM_LENGTH customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ INSTALLED_APPS = [
 python manage.py runbolt --dev
 ```
 
+### Runtime environment variables
+
+#### `DJANGO_BOLT_MAX_PARAM_LENGTH`
+
+Maximum allowed size (in bytes) for path/query/form parameter values.
+
+- **Default:** `8192`
+- **Read once at startup:** value is resolved and cached on first access
+- **Fallback behavior:** missing, empty, non-numeric, or `0` values fall back to `8192`
+
+```bash
+export DJANGO_BOLT_MAX_PARAM_LENGTH=65536
+```
+
 ---
 
 **Key Features:**

--- a/docs/src/ref/settings.md
+++ b/docs/src/ref/settings.md
@@ -104,20 +104,6 @@ BOLT_MAX_UPLOAD_SIZE = FileSize.MB_10
 
 ## ASGI mount settings
 
-## Runtime environment variables
-
-### DJANGO_BOLT_MAX_PARAM_LENGTH
-
-Maximum allowed size for path/query/form parameter values, in bytes. Requests that exceed this limit are rejected with HTTP `422`.
-
-```bash
-export DJANGO_BOLT_MAX_PARAM_LENGTH=65536
-```
-
-**Default:** `8192`
-
-This value is read once at startup (first access) and then cached. Missing, empty, non-integer, or `0` values are ignored and the default is used.
-
 ### BOLT_ASGI_MOUNT_TIMEOUT
 
 Maximum time (seconds) to wait for a mounted ASGI app to complete.
@@ -148,6 +134,20 @@ This setting controls memory usage during file uploads:
 !!! tip "When to adjust"
     - Set higher (e.g., 5-10 MB) if you frequently receive medium-sized files and have sufficient memory
     - Set lower (e.g., 256 KB) on memory-constrained systems or when handling many concurrent uploads
+
+## Runtime environment variables
+
+### DJANGO_BOLT_MAX_PARAM_LENGTH
+
+Maximum allowed size for path/query/form parameter values, in bytes. Requests that exceed this limit are rejected with HTTP `422`.
+
+```bash
+export DJANGO_BOLT_MAX_PARAM_LENGTH=65536
+```
+
+**Default:** `8192`
+
+This value is read once at startup (first access) and then cached. Missing, empty, non-integer, or `0` values are ignored and the default is used.
 
 ## File serving settings
 

--- a/docs/src/ref/settings.md
+++ b/docs/src/ref/settings.md
@@ -147,6 +147,8 @@ export DJANGO_BOLT_MAX_PARAM_LENGTH=65536
 
 **Default:** `8192`
 
+**Maximum:** `1048576` (1 MB). Values above this are clamped down to the maximum so a misconfiguration can never effectively disable the limit.
+
 This value is read once at startup (first access) and then cached. Missing, empty, non-integer, or `0` values are ignored and the default is used.
 
 ## File serving settings
@@ -400,4 +402,4 @@ api = BoltAPI(
 | `SECURE_CSP` | `dict` | `None` | CSP directives for static files ([Django 6.0+](https://docs.djangoproject.com/en/6.0/ref/csp/)) |
 | `BOLT_AUTHENTICATION_CLASSES` | `list` | `[]` | Default authentication backends |
 | `BOLT_DEFAULT_PERMISSION_CLASSES` | `list` | `[AllowAny()]` | Default permission guards |
-| `DJANGO_BOLT_MAX_PARAM_LENGTH` | `int` (env var) | `8192` | Max path/query/form parameter size in bytes (requests over the limit return `422`) |
+| `DJANGO_BOLT_MAX_PARAM_LENGTH` | `int` (env var) | `8192` | Max path/query/form parameter size in bytes, clamped to `1048576` (1 MB); requests over the limit return `422` |

--- a/docs/src/ref/settings.md
+++ b/docs/src/ref/settings.md
@@ -400,3 +400,4 @@ api = BoltAPI(
 | `SECURE_CSP` | `dict` | `None` | CSP directives for static files ([Django 6.0+](https://docs.djangoproject.com/en/6.0/ref/csp/)) |
 | `BOLT_AUTHENTICATION_CLASSES` | `list` | `[]` | Default authentication backends |
 | `BOLT_DEFAULT_PERMISSION_CLASSES` | `list` | `[AllowAny()]` | Default permission guards |
+| `DJANGO_BOLT_MAX_PARAM_LENGTH` | `int` (env var) | `8192` | Max path/query/form parameter size in bytes (requests over the limit return `422`) |

--- a/docs/src/ref/settings.md
+++ b/docs/src/ref/settings.md
@@ -104,6 +104,20 @@ BOLT_MAX_UPLOAD_SIZE = FileSize.MB_10
 
 ## ASGI mount settings
 
+## Runtime environment variables
+
+### DJANGO_BOLT_MAX_PARAM_LENGTH
+
+Maximum allowed size for path/query/form parameter values, in bytes. Requests that exceed this limit are rejected with HTTP `422`.
+
+```bash
+export DJANGO_BOLT_MAX_PARAM_LENGTH=65536
+```
+
+**Default:** `8192`
+
+This value is read once at startup (first access) and then cached. Missing, empty, non-integer, or `0` values are ignored and the default is used.
+
 ### BOLT_ASGI_MOUNT_TIMEOUT
 
 Maximum time (seconds) to wait for a mounted ASGI app to complete.

--- a/python/tests/integration/test_max_param_length_env_server_integration.py
+++ b/python/tests/integration/test_max_param_length_env_server_integration.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.server_integration
+
+
+def test_runbolt_uses_default_max_param_length_without_env(make_server_project):
+    project = make_server_project(
+        project_api_body="""
+        @api.get("/echo/{value}")
+        async def echo(value: str):
+            return {"length": len(value)}
+        """
+    )
+
+    too_long = "a" * 8193
+    with project.start() as server:
+        response = server.get(f"/echo/{too_long}")
+
+    assert response.status_code == 422
+    assert "max 8192 bytes" in response.text
+
+
+def test_runbolt_honors_django_bolt_max_param_length_env(make_server_project):
+    project = make_server_project(
+        project_api_body="""
+        @api.get("/echo/{value}")
+        async def echo(value: str):
+            return {"length": len(value)}
+        """
+    )
+
+    accepted = "a" * 10000
+    rejected = "a" * 16385
+    with project.start(env={"DJANGO_BOLT_MAX_PARAM_LENGTH": "16384"}) as server:
+        accepted_response = server.get(f"/echo/{accepted}")
+        rejected_response = server.get(f"/echo/{rejected}")
+
+    assert accepted_response.status_code == 200
+    assert accepted_response.json() == {"length": len(accepted)}
+    assert rejected_response.status_code == 422
+    assert "max 16384 bytes" in rejected_response.text

--- a/python/tests/integration/test_max_param_length_env_server_integration.py
+++ b/python/tests/integration/test_max_param_length_env_server_integration.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import pytest
 
+from .helpers import ServerProject
+
 pytestmark = pytest.mark.server_integration
 
 
-def _make_project(make_server_project):
+def _make_project(make_server_project) -> ServerProject:
     """Project exposing every parameter surface the limit is enforced on:
     HTTP path, HTTP query, urlencoded form and multipart form."""
     return make_server_project(

--- a/python/tests/integration/test_max_param_length_env_server_integration.py
+++ b/python/tests/integration/test_max_param_length_env_server_integration.py
@@ -5,14 +5,36 @@ import pytest
 pytestmark = pytest.mark.server_integration
 
 
-def test_runbolt_uses_default_max_param_length_without_env(make_server_project):
-    project = make_server_project(
+def _make_project(make_server_project):
+    """Project exposing every parameter surface the limit is enforced on:
+    HTTP path, HTTP query, urlencoded form and multipart form."""
+    return make_server_project(
         project_api_body="""
+        from typing import Annotated
+
+        from django_bolt.param_functions import Form, Query
+
+
         @api.get("/echo/{value}")
-        async def echo(value: str):
+        async def echo_path(value: str):
+            return {"length": len(value)}
+
+        @api.get("/echo-query")
+        async def echo_query(value: str = Query()):
+            return {"length": len(value)}
+
+        @api.post("/echo-form")
+        async def echo_form(value: Annotated[str, Form()]):
             return {"length": len(value)}
         """
     )
+
+
+# --- Path parameters ---
+
+
+def test_runbolt_uses_default_max_param_length_without_env(make_server_project):
+    project = _make_project(make_server_project)
 
     too_long = "a" * 8193
     with project.start() as server:
@@ -23,13 +45,7 @@ def test_runbolt_uses_default_max_param_length_without_env(make_server_project):
 
 
 def test_runbolt_honors_django_bolt_max_param_length_env(make_server_project):
-    project = make_server_project(
-        project_api_body="""
-        @api.get("/echo/{value}")
-        async def echo(value: str):
-            return {"length": len(value)}
-        """
-    )
+    project = _make_project(make_server_project)
 
     accepted = "a" * 10000
     rejected = "a" * 16385
@@ -41,3 +57,61 @@ def test_runbolt_honors_django_bolt_max_param_length_env(make_server_project):
     assert accepted_response.json() == {"length": len(accepted)}
     assert rejected_response.status_code == 422
     assert "max 16384 bytes" in rejected_response.text
+
+
+# --- Query params + form fields (default limit) ---
+
+
+def test_default_limit_rejects_oversized_query_and_form(make_server_project):
+    """The default 8192-byte limit is enforced on query params and both form
+    encodings, not just path params."""
+    project = _make_project(make_server_project)
+
+    too_long = "a" * 8193
+    with project.start() as server:
+        query = server.get(f"/echo-query?value={too_long}")
+        urlencoded = server.request("POST", "/echo-form", data={"value": too_long})
+        multipart = server.request("POST", "/echo-form", files={"value": (None, too_long)})
+
+    assert query.status_code == 422, query.text
+    assert "max 8192 bytes" in query.text
+    assert urlencoded.status_code == 422, urlencoded.text
+    assert "max 8192 bytes" in urlencoded.text
+    assert multipart.status_code == 422, multipart.text
+    assert "max 8192 bytes" in multipart.text
+
+
+# --- Query params + form fields (env override) ---
+
+
+def test_env_override_applies_to_query_and_form(make_server_project):
+    """The configured limit flows through to query params and both form encodings:
+    values under the raised limit are accepted, values above it are rejected."""
+    project = _make_project(make_server_project)
+
+    accepted = "a" * 10000  # over default 8192, under configured 16384
+    rejected = "a" * 16385  # over configured 16384
+    with project.start(env={"DJANGO_BOLT_MAX_PARAM_LENGTH": "16384"}) as server:
+        query_ok = server.get(f"/echo-query?value={accepted}")
+        query_bad = server.get(f"/echo-query?value={rejected}")
+
+        urlencoded_ok = server.request("POST", "/echo-form", data={"value": accepted})
+        urlencoded_bad = server.request("POST", "/echo-form", data={"value": rejected})
+
+        multipart_ok = server.request("POST", "/echo-form", files={"value": (None, accepted)})
+        multipart_bad = server.request("POST", "/echo-form", files={"value": (None, rejected)})
+
+    assert query_ok.status_code == 200, query_ok.text
+    assert query_ok.json() == {"length": len(accepted)}
+    assert query_bad.status_code == 422
+    assert "max 16384 bytes" in query_bad.text
+
+    assert urlencoded_ok.status_code == 200, urlencoded_ok.text
+    assert urlencoded_ok.json() == {"length": len(accepted)}
+    assert urlencoded_bad.status_code == 422
+    assert "max 16384 bytes" in urlencoded_bad.text
+
+    assert multipart_ok.status_code == 200, multipart_ok.text
+    assert multipart_ok.json() == {"length": len(accepted)}
+    assert multipart_bad.status_code == 422
+    assert "max 16384 bytes" in multipart_bad.text

--- a/python/tests/integration/test_websocket_param_length_server_integration.py
+++ b/python/tests/integration/test_websocket_param_length_server_integration.py
@@ -1,0 +1,124 @@
+"""Integration tests for WebSocket parameter length enforcement.
+
+These exercise the *production* WebSocket upgrade path in
+`src/websocket/handler.rs::build_scope` over a real TCP handshake against a
+`runbolt` server. The in-process `WebSocketTestClient` tests only reach
+`src/testing.rs::handle_test_websocket`, so this is the only coverage for the
+production builder rejecting oversized path/query params with an HTTP 400 instead
+of passing the raw string through to Python.
+"""
+
+from __future__ import annotations
+
+import base64
+import secrets
+import socket
+
+import pytest
+
+from .helpers import SimpleWebSocketClient
+
+pytestmark = pytest.mark.server_integration
+
+
+def _attempt_ws_upgrade(host: str, port: int, path: str, *, timeout: float = 5.0) -> tuple[str, str]:
+    """Send a raw WebSocket upgrade request and return (status_line, body_text).
+
+    Unlike `SimpleWebSocketClient`, this captures the full response (including
+    the error body) so a *rejected* upgrade can be inspected rather than
+    asserting a 101 handshake.
+    """
+    key = base64.b64encode(secrets.token_bytes(16)).decode()
+    request = "\r\n".join(
+        [
+            f"GET {path} HTTP/1.1",
+            f"Host: {host}:{port}",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            f"Sec-WebSocket-Key: {key}",
+            "Sec-WebSocket-Version: 13",
+            "",
+            "",
+        ]
+    )
+
+    with socket.create_connection((host, port), timeout=timeout) as sock:
+        sock.settimeout(timeout)
+        sock.sendall(request.encode("utf-8"))
+
+        buf = bytearray()
+        while b"\r\n\r\n" not in buf:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            buf.extend(chunk)
+
+        header_part, _, body_part = bytes(buf).partition(b"\r\n\r\n")
+        header_text = header_part.decode("utf-8", errors="replace")
+
+        content_length = 0
+        for line in header_text.splitlines()[1:]:
+            if line.lower().startswith("content-length:"):
+                content_length = int(line.split(":", 1)[1].strip())
+                break
+
+        body = bytearray(body_part)
+        while len(body) < content_length:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            body.extend(chunk)
+
+    status_line = header_text.splitlines()[0] if header_text else ""
+    return status_line, body.decode("utf-8", errors="replace")
+
+
+def _make_ws_project(make_server_project):
+    return make_server_project(
+        project_api_body="""
+        @api.websocket("/ws/path/{value}")
+        async def path_ws(websocket: WebSocket, value: str):
+            await websocket.accept()
+            await websocket.send_text("connected")
+
+        @api.websocket("/ws/plain")
+        async def plain_ws(websocket: WebSocket):
+            await websocket.accept()
+            await websocket.send_text("connected")
+        """
+    )
+
+
+def test_websocket_oversized_path_param_rejects_upgrade(make_server_project):
+    """An oversized path param rejects the upgrade with 400 instead of upgrading."""
+    project = _make_ws_project(make_server_project)
+    oversized = "a" * 9000  # exceeds the default 8192-byte limit
+
+    with project.start() as server:
+        status_line, body = _attempt_ws_upgrade(server.host, server.port, f"/ws/path/{oversized}")
+
+    assert "400" in status_line, f"Expected 400 rejection, got status={status_line!r} body={body!r}"
+    assert "Parameter too long" in body, f"body={body!r}"
+
+
+def test_websocket_oversized_query_param_rejects_upgrade(make_server_project):
+    """An oversized query param rejects the upgrade with 400 instead of upgrading."""
+    project = _make_ws_project(make_server_project)
+    oversized = "a" * 9000
+
+    with project.start() as server:
+        status_line, body = _attempt_ws_upgrade(server.host, server.port, f"/ws/plain?value={oversized}")
+
+    assert "400" in status_line, f"Expected 400 rejection, got status={status_line!r} body={body!r}"
+    assert "Parameter too long" in body, f"body={body!r}"
+
+
+def test_websocket_normal_path_param_completes_handshake(make_server_project):
+    """Positive control: a normal-sized path param still upgrades and runs the handler."""
+    project = _make_ws_project(make_server_project)
+
+    with (
+        project.start() as server,
+        SimpleWebSocketClient(server.host, server.port, "/ws/path/hello") as websocket,
+    ):
+        assert websocket.receive_text() == "connected"

--- a/python/tests/integration/test_websocket_param_length_server_integration.py
+++ b/python/tests/integration/test_websocket_param_length_server_integration.py
@@ -122,3 +122,24 @@ def test_websocket_normal_path_param_completes_handshake(make_server_project):
         SimpleWebSocketClient(server.host, server.port, "/ws/path/hello") as websocket,
     ):
         assert websocket.receive_text() == "connected"
+
+
+def test_websocket_honors_django_bolt_max_param_length_env(make_server_project):
+    """The upgrade limit is driven by DJANGO_BOLT_MAX_PARAM_LENGTH, not hard-coded to 8192.
+
+    Exercises the production startup path with the env override set: a value that
+    would be rejected under the default limit now completes the handshake, while a
+    value over the *raised* limit is still rejected before the upgrade.
+    """
+    project = _make_ws_project(make_server_project)
+
+    accepted = "a" * 10000  # over the default 8192, under the configured 16384
+    rejected = "a" * 16385  # over the configured 16384
+
+    with project.start(env={"DJANGO_BOLT_MAX_PARAM_LENGTH": "16384"}) as server:
+        status_line, body = _attempt_ws_upgrade(server.host, server.port, f"/ws/path/{rejected}")
+        assert "400" in status_line, f"Expected 400 rejection, got status={status_line!r} body={body!r}"
+        assert "Parameter too long" in body, f"body={body!r}"
+
+        with SimpleWebSocketClient(server.host, server.port, f"/ws/path/{accepted}") as websocket:
+            assert websocket.receive_text() == "connected"

--- a/python/tests/test_type_coercion_security.py
+++ b/python/tests/test_type_coercion_security.py
@@ -143,7 +143,9 @@ class TestParameterLengthLimits:
 
     Security measure: max param length is configurable via DJANGO_BOLT_MAX_PARAM_LENGTH
     (default: 8192 bytes) in src/type_coercion.rs
-    Note: Length limit is enforced during type coercion, so only typed params are checked.
+    Note: The length limit is applied to all path/query parameters in the request
+    pipeline (typed and plain-string alike), not only to params that go through
+    type coercion.
     """
 
     def test_typed_path_param_at_limit_succeeds(self, client):

--- a/python/tests/test_type_coercion_security.py
+++ b/python/tests/test_type_coercion_security.py
@@ -2,7 +2,7 @@
 Security tests for type coercion in Django-Bolt.
 
 Tests cover:
-- DoS prevention via parameter length limits (8KB max for ALL params)
+- DoS prevention via parameter length limits (default 8KB max for ALL params)
 - Integer overflow/underflow at i64 boundaries
 - Float special values (infinity, NaN)
 - Boolean validation (strict accepted values, empty string rejected)
@@ -133,7 +133,7 @@ def client(api):
 
 
 # =============================================================================
-# 1. Parameter Length DoS Tests (8KB Limit)
+# 1. Parameter Length DoS Tests (default 8KB limit)
 # =============================================================================
 
 
@@ -141,7 +141,8 @@ class TestParameterLengthLimits:
     """
     Test parameter length limits that prevent memory exhaustion DoS attacks.
 
-    Security measure: MAX_PARAM_LENGTH = 8192 bytes in src/type_coercion.rs
+    Security measure: max param length is configurable via DJANGO_BOLT_MAX_PARAM_LENGTH
+    (default: 8192 bytes) in src/type_coercion.rs
     Note: Length limit is enforced during type coercion, so only typed params are checked.
     """
 

--- a/python/tests/websockets/test_websocket_security.py
+++ b/python/tests/websockets/test_websocket_security.py
@@ -172,7 +172,7 @@ async def test_websocket_oversized_query_param_rejected():
 
     oversized = "a" * 9000  # exceeds the default 8192-byte limit
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match=r"Parameter too long"):
         async with WebSocketTestClient(
             api,
             "/ws/echo",
@@ -181,8 +181,6 @@ async def test_websocket_oversized_query_param_rejected():
             read_django_settings=False,
         ):
             pass
-
-    assert "Parameter too long" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -197,7 +195,7 @@ async def test_websocket_oversized_path_param_rejected():
 
     oversized = "a" * 9000  # exceeds the default 8192-byte limit
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match=r"Parameter too long"):
         async with WebSocketTestClient(
             api,
             f"/ws/{oversized}",
@@ -205,8 +203,6 @@ async def test_websocket_oversized_path_param_rejected():
             read_django_settings=False,
         ):
             pass
-
-    assert "Parameter too long" in str(exc_info.value)
 
 
 # --- Rate Limiting Tests ---

--- a/python/tests/websockets/test_websocket_security.py
+++ b/python/tests/websockets/test_websocket_security.py
@@ -153,6 +153,62 @@ async def test_websocket_no_cors_config_allows_same_origin():
         assert msg == "connected"
 
 
+# --- Parameter Length Limit Tests ---
+
+
+@pytest.mark.asyncio
+async def test_websocket_oversized_query_param_rejected():
+    """Oversized query param rejects the upgrade instead of passing a raw string through.
+
+    Before the fix, a length-limit violation was swallowed by the string fallback,
+    so the oversized value reached the handler. Now it is a hard error.
+    """
+    api = BoltAPI()
+
+    @api.websocket("/ws/echo")
+    async def echo_handler(websocket: WebSocket):
+        await websocket.accept()
+        await websocket.send_text("connected")
+
+    oversized = "a" * 9000  # exceeds the default 8192-byte limit
+
+    with pytest.raises(ValueError) as exc_info:
+        async with WebSocketTestClient(
+            api,
+            "/ws/echo",
+            query_string=f"value={oversized}",
+            cors_allowed_origins=["*"],
+            read_django_settings=False,
+        ):
+            pass
+
+    assert "Parameter too long" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_websocket_oversized_path_param_rejected():
+    """Oversized path param rejects the upgrade instead of passing a raw string through."""
+    api = BoltAPI()
+
+    @api.websocket("/ws/{value}")
+    async def echo_handler(websocket: WebSocket):
+        await websocket.accept()
+        await websocket.send_text("connected")
+
+    oversized = "a" * 9000  # exceeds the default 8192-byte limit
+
+    with pytest.raises(ValueError) as exc_info:
+        async with WebSocketTestClient(
+            api,
+            f"/ws/{oversized}",
+            cors_allowed_origins=["*"],
+            read_django_settings=False,
+        ):
+            pass
+
+    assert "Parameter too long" in str(exc_info.value)
+
+
 # --- Rate Limiting Tests ---
 
 

--- a/src/form_parsing.rs
+++ b/src/form_parsing.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::io::Write;
 use tempfile::NamedTempFile;
 
-use crate::type_coercion::{coerce_param, CoercedValue, TYPE_STRING};
+use crate::type_coercion::{coerce_param_with_limit, CoercedValue, TYPE_STRING};
 
 /// Memory limit for in-memory file storage (1MB default)
 pub const DEFAULT_MEMORY_LIMIT: usize = 1024 * 1024;
@@ -210,13 +210,14 @@ pub struct FormParseResult {
 ///
 /// ```
 /// use std::collections::HashMap;
-/// let result = parse_urlencoded(b"name=alice&age=30", &HashMap::new()).unwrap();
+/// let result = parse_urlencoded(b"name=alice&age=30", &HashMap::new(), 8192).unwrap();
 /// assert!(matches!(result.get("name").unwrap(), FormValue::Single(_)));
 /// assert!(matches!(result.get("age").unwrap(), FormValue::Single(_)));
 /// ```
 pub fn parse_urlencoded(
     body: &[u8],
     type_hints: &HashMap<String, u8>,
+    max_param_length: usize,
 ) -> Result<HashMap<String, FormValue>, ValidationError> {
     let mut result: HashMap<String, FormValue> = HashMap::new();
 
@@ -230,7 +231,7 @@ pub fn parse_urlencoded(
 
     for (key, value) in parsed {
         let type_hint = type_hints.get(&key).copied().unwrap_or(TYPE_STRING);
-        let coerced = coerce_param(&value, type_hint).map_err(|e| {
+        let coerced = coerce_param_with_limit(&value, type_hint, max_param_length).map_err(|e| {
             ValidationError::type_coercion_error(&key, type_hint_name(type_hint), &e)
         })?;
 
@@ -276,6 +277,7 @@ pub fn parse_urlencoded(
 ///         /* max_upload_size */ 10 * 1024 * 1024,
 ///         /* memory_limit */ 1024 * 1024,
 ///         /* max_parts */ 1000,
+///         /* max_param_length */ 8192,
 ///     ).await;
 ///
 ///     match result {
@@ -295,6 +297,7 @@ pub async fn parse_multipart(
     max_upload_size: usize,
     memory_limit: usize,
     max_parts: usize,
+    max_param_length: usize,
 ) -> Result<FormParseResult, ValidationError> {
     let mut form_map: HashMap<String, FormValue> = HashMap::new();
     let mut files_map: HashMap<String, Vec<FileInfo>> = HashMap::new();
@@ -389,9 +392,14 @@ pub async fn parse_multipart(
 
             // Type coercion
             let type_hint = type_hints.get(&field_name).copied().unwrap_or(TYPE_STRING);
-            let coerced = coerce_param(&value, type_hint).map_err(|e| {
-                ValidationError::type_coercion_error(&field_name, type_hint_name(type_hint), &e)
-            })?;
+            let coerced =
+                coerce_param_with_limit(&value, type_hint, max_param_length).map_err(|e| {
+                    ValidationError::type_coercion_error(
+                        &field_name,
+                        type_hint_name(type_hint),
+                        &e,
+                    )
+                })?;
 
             // Preserve duplicate keys (e.g. multi-select) as FormValue::Multi.
             // First occurrence is Single — zero extra alloc for the common case.
@@ -605,7 +613,9 @@ mod tests {
         type_hints.insert("age".to_string(), crate::type_coercion::TYPE_INT);
         type_hints.insert("active".to_string(), crate::type_coercion::TYPE_BOOL);
 
-        let result = parse_urlencoded(&body, &type_hints).unwrap();
+        let result =
+            parse_urlencoded(&body, &type_hints, crate::type_coercion::DEFAULT_MAX_PARAM_LENGTH)
+                .unwrap();
 
         assert!(matches!(
             result.get("name"),
@@ -630,7 +640,7 @@ mod tests {
     /// let body = Bytes::from("tag=a&tag=b&tag=c&name=John");
     /// let type_hints = HashMap::new();
     ///
-    /// let result = parse_urlencoded(&body, &type_hints).unwrap();
+    /// let result = parse_urlencoded(&body, &type_hints, 8192).unwrap();
     ///
     /// match result.get("tag") {
     ///     Some(FormValue::Multi(v)) => {
@@ -654,7 +664,9 @@ mod tests {
         let body = Bytes::from("tag=a&tag=b&tag=c&name=John");
         let type_hints = HashMap::new();
 
-        let result = parse_urlencoded(&body, &type_hints).unwrap();
+        let result =
+            parse_urlencoded(&body, &type_hints, crate::type_coercion::DEFAULT_MAX_PARAM_LENGTH)
+                .unwrap();
 
         match result.get("tag") {
             Some(FormValue::Multi(v)) => {

--- a/src/form_parsing.rs
+++ b/src/form_parsing.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::io::Write;
 use tempfile::NamedTempFile;
 
-use crate::type_coercion::{coerce_param_with_limit, CoercedValue, TYPE_STRING};
+use crate::type_coercion::{coerce_param_with_limit, CoerceError, CoercedValue, TYPE_STRING};
 
 /// Memory limit for in-memory file storage (1MB default)
 pub const DEFAULT_MEMORY_LIMIT: usize = 1024 * 1024;
@@ -232,7 +232,7 @@ pub fn parse_urlencoded(
     for (key, value) in parsed {
         let type_hint = type_hints.get(&key).copied().unwrap_or(TYPE_STRING);
         let coerced = coerce_param_with_limit(&value, type_hint, max_param_length).map_err(|e| {
-            ValidationError::type_coercion_error(&key, type_hint_name(type_hint), &e)
+            ValidationError::type_coercion_error(&key, type_hint_name(type_hint), &e.to_string())
         })?;
 
         match result.entry(key) {
@@ -377,6 +377,7 @@ pub async fn parse_multipart(
             }
         } else {
             // Regular form field
+            let type_hint = type_hints.get(&field_name).copied().unwrap_or(TYPE_STRING);
             let mut value_bytes = Vec::new();
             while let Some(chunk) = field.next().await {
                 let data = chunk.map_err(|e| ValidationError {
@@ -385,19 +386,31 @@ pub async fn parse_multipart(
                     msg: format!("Failed to read field data: {}", e),
                     ctx: HashMap::new(),
                 })?;
+                // Security: enforce the length limit incrementally so an oversized
+                // field is rejected before the entire body is buffered into memory.
+                if value_bytes.len() + data.len() > max_param_length {
+                    return Err(ValidationError::type_coercion_error(
+                        &field_name,
+                        type_hint_name(type_hint),
+                        &CoerceError::TooLong {
+                            len: value_bytes.len() + data.len(),
+                            max: max_param_length,
+                        }
+                        .to_string(),
+                    ));
+                }
                 value_bytes.extend_from_slice(&data);
             }
 
             let value = String::from_utf8_lossy(&value_bytes).to_string();
 
             // Type coercion
-            let type_hint = type_hints.get(&field_name).copied().unwrap_or(TYPE_STRING);
             let coerced =
                 coerce_param_with_limit(&value, type_hint, max_param_length).map_err(|e| {
                     ValidationError::type_coercion_error(
                         &field_name,
                         type_hint_name(type_hint),
-                        &e,
+                        &e.to_string(),
                     )
                 })?;
 
@@ -694,5 +707,130 @@ mod tests {
         assert_eq!(json["loc"], serde_json::json!(["body", "avatar"]));
         assert_eq!(json["ctx"]["max_size"], 1024);
         assert_eq!(json["ctx"]["actual_size"], 2048);
+    }
+
+    /// A stream of pre-built byte chunks that records how many chunks were
+    /// actually polled, and applies backpressure by returning `Pending` after
+    /// each chunk.
+    ///
+    /// The backpressure is essential: actix-multipart's internal `PayloadBuffer`
+    /// greedily drains the underlying stream until it sees `Pending` (or EOF).
+    /// An always-ready stream would therefore be fully buffered up-front, hiding
+    /// whether *our* loop aborted early. Yielding one chunk then `Pending` (with
+    /// an immediate self-wake so the task is re-polled) makes the parser pull
+    /// chunks strictly on demand, so the counter reflects what our loop consumed.
+    struct CountingStream {
+        chunks: std::collections::VecDeque<Bytes>,
+        consumed: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        yield_pending: bool,
+    }
+
+    impl futures_util::Stream for CountingStream {
+        type Item = Result<Bytes, actix_web::error::PayloadError>;
+
+        fn poll_next(
+            self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<Self::Item>> {
+            let this = self.get_mut();
+            if this.yield_pending {
+                // Force actix-multipart to stop buffering ahead after one chunk.
+                this.yield_pending = false;
+                cx.waker().wake_by_ref();
+                return std::task::Poll::Pending;
+            }
+            match this.chunks.pop_front() {
+                Some(chunk) => {
+                    this.consumed
+                        .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    this.yield_pending = true;
+                    std::task::Poll::Ready(Some(Ok(chunk)))
+                }
+                None => std::task::Poll::Ready(None),
+            }
+        }
+    }
+
+    /// The multipart text-field reader must enforce `max_param_length`
+    /// *incrementally* — an oversized field is rejected before its entire body
+    /// is buffered into memory. We feed the field as many small chunks and
+    /// assert the parser stops consuming the stream long before draining all of
+    /// them. A post-buffer implementation would drain every chunk first, so this
+    /// test fails for that (vulnerable) behavior.
+    #[test]
+    fn test_multipart_rejects_oversized_field_before_buffering() {
+        use actix_web::http::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
+        use std::collections::VecDeque;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let boundary = "TESTBOUNDARY";
+        let chunk_size = 1000usize;
+        let n_data_chunks = 200usize;
+        let max_param_length = 1000usize;
+
+        let header = format!(
+            "--{b}\r\nContent-Disposition: form-data; name=\"value\"\r\n\r\n",
+            b = boundary
+        );
+        let closing = format!("\r\n--{b}--\r\n", b = boundary);
+
+        let mut chunks: VecDeque<Bytes> = VecDeque::new();
+        chunks.push_back(Bytes::from(header));
+        for _ in 0..n_data_chunks {
+            chunks.push_back(Bytes::from(vec![b'a'; chunk_size]));
+        }
+        chunks.push_back(Bytes::from(closing));
+        let total_chunks = chunks.len();
+
+        let consumed = Arc::new(AtomicUsize::new(0));
+        let stream = CountingStream {
+            chunks,
+            consumed: Arc::clone(&consumed),
+            yield_pending: false,
+        };
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("multipart/form-data; boundary=TESTBOUNDARY"),
+        );
+
+        let multipart = Multipart::new(&headers, stream);
+        let type_hints: HashMap<String, u8> = HashMap::new();
+        let file_constraints: HashMap<String, FileFieldConstraints> = HashMap::new();
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = runtime.block_on(parse_multipart(
+            multipart,
+            &type_hints,
+            &file_constraints,
+            10 * 1024 * 1024,
+            DEFAULT_MEMORY_LIMIT,
+            DEFAULT_MAX_PARTS,
+            max_param_length,
+        ));
+
+        // The oversized field is rejected as "too long".
+        let err = match result {
+            Ok(_) => panic!("oversized field should be rejected"),
+            Err(e) => e,
+        };
+        assert!(
+            err.msg.contains("Parameter too long"),
+            "unexpected error message: {}",
+            err.msg
+        );
+
+        // Crucially: it aborted *before* draining the whole field — far fewer
+        // chunks consumed than were provided.
+        let consumed_chunks = consumed.load(Ordering::SeqCst);
+        assert!(
+            consumed_chunks < total_chunks,
+            "parser drained {consumed_chunks} of {total_chunks} chunks — it buffered the whole field instead of aborting early"
+        );
     }
 }

--- a/src/form_parsing.rs
+++ b/src/form_parsing.rs
@@ -231,9 +231,14 @@ pub fn parse_urlencoded(
 
     for (key, value) in parsed {
         let type_hint = type_hints.get(&key).copied().unwrap_or(TYPE_STRING);
-        let coerced = coerce_param_with_limit(&value, type_hint, max_param_length).map_err(|e| {
-            ValidationError::type_coercion_error(&key, type_hint_name(type_hint), &e.to_string())
-        })?;
+        let coerced =
+            coerce_param_with_limit(&value, type_hint, max_param_length).map_err(|e| {
+                ValidationError::type_coercion_error(
+                    &key,
+                    type_hint_name(type_hint),
+                    &e.to_string(),
+                )
+            })?;
 
         match result.entry(key) {
             std::collections::hash_map::Entry::Vacant(e) => {
@@ -626,9 +631,12 @@ mod tests {
         type_hints.insert("age".to_string(), crate::type_coercion::TYPE_INT);
         type_hints.insert("active".to_string(), crate::type_coercion::TYPE_BOOL);
 
-        let result =
-            parse_urlencoded(&body, &type_hints, crate::type_coercion::DEFAULT_MAX_PARAM_LENGTH)
-                .unwrap();
+        let result = parse_urlencoded(
+            &body,
+            &type_hints,
+            crate::type_coercion::DEFAULT_MAX_PARAM_LENGTH,
+        )
+        .unwrap();
 
         assert!(matches!(
             result.get("name"),
@@ -677,9 +685,12 @@ mod tests {
         let body = Bytes::from("tag=a&tag=b&tag=c&name=John");
         let type_hints = HashMap::new();
 
-        let result =
-            parse_urlencoded(&body, &type_hints, crate::type_coercion::DEFAULT_MAX_PARAM_LENGTH)
-                .unwrap();
+        let result = parse_urlencoded(
+            &body,
+            &type_hints,
+            crate::type_coercion::DEFAULT_MAX_PARAM_LENGTH,
+        )
+        .unwrap();
 
         match result.get("tag") {
             Some(FormValue::Multi(v)) => {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -901,12 +901,16 @@ pub async fn handle_request<const ACCESS_LOG: bool>(
 
     let needs_body = plan.map_or(true, |p| p.needs_body());
 
+    // Max parameter length resolved once at startup; read the plain field here.
+    let max_param_length = state.max_param_length;
+
     // Type validation for path and query parameters (Rust-native, no GIL)
     let (path_coerced, query_coerced) = if let Some(route_meta) = route_metadata {
         match validate_and_cache_typed_params(
             path_params.as_ref(),
             query_params.as_ref(),
             &route_meta.param_types,
+            max_param_length,
         ) {
             Ok(cached) => cached,
             Err(response) => return response,
@@ -1078,6 +1082,7 @@ pub async fn handle_request<const ACCESS_LOG: bool>(
                 max_upload_size,
                 memory_spool_threshold,
                 DEFAULT_MAX_PARTS,
+                max_param_length,
             )
             .await
             {
@@ -1110,7 +1115,7 @@ pub async fn handle_request<const ACCESS_LOG: bool>(
                     .map(|m| &m.form_type_hints)
                     .unwrap_or(&empty_form_type_hints);
 
-                match parse_urlencoded(&body_vec, form_type_hints) {
+                match parse_urlencoded(&body_vec, form_type_hints, max_param_length) {
                     Ok(form_map) => {
                         let result = FormParseResult {
                             form_map,
@@ -1184,7 +1189,7 @@ pub async fn handle_request<const ACCESS_LOG: bool>(
 
         let headers_py: Option<Py<PyDict>> = if needs_headers {
             if let Some(headers_map) = headers.as_ref() {
-                Some(params_to_py_dict(py, headers_map, param_types)?.unbind())
+                Some(params_to_py_dict(py, headers_map, param_types, max_param_length)?.unbind())
             } else {
                 Some(PyDict::new(py).unbind())
             }
@@ -1193,7 +1198,7 @@ pub async fn handle_request<const ACCESS_LOG: bool>(
         };
         let cookies_py: Option<Py<PyDict>> = if needs_cookies {
             if let Some(cookies_map) = cookies.as_ref() {
-                Some(params_to_py_dict(py, cookies_map, param_types)?.unbind())
+                Some(params_to_py_dict(py, cookies_map, param_types, max_param_length)?.unbind())
             } else {
                 Some(PyDict::new(py).unbind())
             }

--- a/src/request_pipeline.rs
+++ b/src/request_pipeline.rs
@@ -8,7 +8,7 @@ use ahash::AHashMap;
 use std::collections::HashMap;
 
 use crate::responses;
-use crate::type_coercion::{coerce_param, CoercedValue, MAX_PARAM_LENGTH, TYPE_STRING};
+use crate::type_coercion::{coerce_param, max_param_length, CoercedValue, TYPE_STRING};
 
 /// Validate and pre-coerce path/query parameters against type hints.
 ///
@@ -27,17 +27,18 @@ pub fn validate_and_cache_typed_params(
 > {
     let mut path_coerced: Option<AHashMap<String, CoercedValue>> = None;
     let mut query_coerced: Option<AHashMap<String, CoercedValue>> = None;
+    let max_length = max_param_length();
 
     // Validate path parameters - always check length, type validation for non-strings
     if let Some(path_params) = path_params {
         for (name, value) in path_params {
             // Security: Always validate length for ALL parameters (including strings)
-            if value.len() > MAX_PARAM_LENGTH {
+            if value.len() > max_length {
                 return Err(responses::error_422_validation(&format!(
                     "Path parameter '{}': Parameter too long: {} bytes (max {} bytes)",
                     name,
                     value.len(),
-                    MAX_PARAM_LENGTH
+                    max_length
                 )));
             }
 
@@ -66,12 +67,12 @@ pub fn validate_and_cache_typed_params(
     if let Some(query_params) = query_params {
         for (name, value) in query_params {
             // Security: Always validate length for ALL parameters (including strings)
-            if value.len() > MAX_PARAM_LENGTH {
+            if value.len() > max_length {
                 return Err(responses::error_422_validation(&format!(
                     "Query parameter '{}': Parameter too long: {} bytes (max {} bytes)",
                     name,
                     value.len(),
-                    MAX_PARAM_LENGTH
+                    max_length
                 )));
             }
 

--- a/src/request_pipeline.rs
+++ b/src/request_pipeline.rs
@@ -8,7 +8,7 @@ use ahash::AHashMap;
 use std::collections::HashMap;
 
 use crate::responses;
-use crate::type_coercion::{coerce_param, max_param_length, CoercedValue, TYPE_STRING};
+use crate::type_coercion::{coerce_param_with_limit, CoercedValue, TYPE_STRING};
 
 /// Validate and pre-coerce path/query parameters against type hints.
 ///
@@ -18,6 +18,7 @@ pub fn validate_and_cache_typed_params(
     path_params: Option<&AHashMap<String, String>>,
     query_params: Option<&AHashMap<String, String>>,
     param_types: &HashMap<String, u8>,
+    max_length: usize,
 ) -> Result<
     (
         Option<AHashMap<String, CoercedValue>>,
@@ -27,7 +28,6 @@ pub fn validate_and_cache_typed_params(
 > {
     let mut path_coerced: Option<AHashMap<String, CoercedValue>> = None;
     let mut query_coerced: Option<AHashMap<String, CoercedValue>> = None;
-    let max_length = max_param_length();
 
     // Validate path parameters - always check length, type validation for non-strings
     if let Some(path_params) = path_params {
@@ -45,7 +45,7 @@ pub fn validate_and_cache_typed_params(
             // Type validation for non-string types
             if let Some(&type_hint) = param_types.get(name) {
                 if type_hint != TYPE_STRING {
-                    match coerce_param(value, type_hint) {
+                    match coerce_param_with_limit(value, type_hint, max_length) {
                         Ok(coerced) => {
                             path_coerced
                                 .get_or_insert_with(AHashMap::new)
@@ -79,7 +79,7 @@ pub fn validate_and_cache_typed_params(
             // Type validation for non-string types
             if let Some(&type_hint) = param_types.get(name) {
                 if type_hint != TYPE_STRING {
-                    match coerce_param(value, type_hint) {
+                    match coerce_param_with_limit(value, type_hint, max_length) {
                         Ok(coerced) => {
                             query_coerced
                                 .get_or_insert_with(AHashMap::new)

--- a/src/server.rs
+++ b/src/server.rs
@@ -774,12 +774,16 @@ pub fn start_server(
         }
     });
 
+    // Resolve DJANGO_BOLT_MAX_PARAM_LENGTH once at startup, not per request.
+    let max_param_length = crate::type_coercion::resolve_max_param_length();
+
     let app_state = Arc::new(AppState {
         dispatch: dispatch.into(),
         dispatch_sync: dispatch_sync.into(),
         debug,
         max_header_size,
         max_payload_size,
+        max_param_length,
         asgi_mount_timeout,
         global_cors_config,
         cors_origin_regexes,

--- a/src/state.rs
+++ b/src/state.rs
@@ -88,6 +88,10 @@ pub struct AppState {
     pub debug: bool,
     pub max_header_size: usize,
     pub max_payload_size: usize,
+    /// Max byte length for path/query/form/header/cookie parameter values.
+    /// Resolved once at startup from DJANGO_BOLT_MAX_PARAM_LENGTH (see
+    /// `type_coercion::resolve_max_param_length`); read directly on the hot path.
+    pub max_param_length: usize,
     pub asgi_mount_timeout: Duration,
     pub global_cors_config: Option<CorsConfig>, // Global CORS configuration from Django settings
     pub cors_origin_regexes: Vec<Regex>,        // Compiled regex patterns for origin matching

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -45,7 +45,7 @@ use crate::handler::{
 };
 use crate::request_pipeline::validate_and_cache_typed_params;
 use crate::static_files::handle_file;
-use crate::type_coercion::{coerce_param, params_to_py_dict, TYPE_STRING};
+use crate::type_coercion::{coerce_param_with_limit, params_to_py_dict, TYPE_STRING};
 
 static ASYNC_RUNTIME_INITIALIZED: std::sync::Once = std::sync::Once::new();
 
@@ -124,6 +124,9 @@ pub struct TestAppState {
     pub global_compression_config: Option<Arc<crate::metadata::CompressionConfig>>,
     pub debug: bool,
     pub max_payload_size: usize,
+    /// Max byte length for parameter values (resolved once from
+    /// DJANGO_BOLT_MAX_PARAM_LENGTH), mirroring production `AppState`.
+    pub max_param_length: usize,
     pub asgi_mount_timeout: Duration,
     /// Trailing slash handling mode: "strip", "append", or "keep"
     pub trailing_slash: String,
@@ -342,6 +345,7 @@ pub fn create_test_app(
         global_compression_config,
         debug,
         max_payload_size,
+        max_param_length: crate::type_coercion::resolve_max_param_length(),
         asgi_mount_timeout,
         trailing_slash: trailing_slash.unwrap_or_else(|| "strip".to_string()),
         static_files_config: static_config,
@@ -505,6 +509,7 @@ pub fn test_request(
                 global_compression_config,
                 debug,
                 max_payload_size,
+                max_param_length,
                 asgi_mount_timeout,
                 _trailing_slash,
                 static_files_config,
@@ -520,6 +525,7 @@ pub fn test_request(
                     state.global_compression_config.clone(),
                     state.debug,
                     state.max_payload_size,
+                    state.max_param_length,
                     state.asgi_mount_timeout,
                     state.trailing_slash.clone(),
                     state.static_files_config.clone(),
@@ -534,6 +540,7 @@ pub fn test_request(
                 debug,
                 max_header_size: 8192,
                 max_payload_size,
+                max_param_length,
                 asgi_mount_timeout,
                 global_cors_config: global_cors_config.clone(),
                 cors_origin_regexes: vec![],
@@ -771,12 +778,16 @@ async fn handle_test_request_internal(
         None
     };
 
+    // Max parameter length resolved once at startup; read the plain field here.
+    let max_param_length = state.max_param_length;
+
     // Validate typed parameters before GIL acquisition and cache non-string coerced values.
     let (path_coerced, query_coerced) = if let Some(ref meta) = route_meta {
         match validate_and_cache_typed_params(
             path_params.as_ref(),
             query_params.as_ref(),
             &meta.param_types,
+            max_param_length,
         ) {
             Ok(cached) => cached,
             Err(response) => return response,
@@ -900,6 +911,7 @@ async fn handle_test_request_internal(
                 max_upload_size,
                 memory_spool_threshold,
                 DEFAULT_MAX_PARTS,
+                max_param_length,
             )
             .await
             {
@@ -940,7 +952,7 @@ async fn handle_test_request_internal(
                     .cloned()
                     .unwrap_or_default();
 
-                match parse_urlencoded(&body, &form_type_hints) {
+                match parse_urlencoded(&body, &form_type_hints, max_param_length) {
                     Ok(form_map) => {
                         let result = FormParseResult {
                             form_map,
@@ -1023,11 +1035,11 @@ async fn handle_test_request_internal(
         };
 
         let headers_dict = match &headers_for_python {
-            Some(h) => Some(params_to_py_dict(py, h, &param_types)?),
+            Some(h) => Some(params_to_py_dict(py, h, &param_types, max_param_length)?),
             None => None,
         };
         let cookies_dict = if needs_cookies {
-            Some(params_to_py_dict(py, &cookies, &param_types)?)
+            Some(params_to_py_dict(py, &cookies, &param_types, max_param_length)?)
         } else {
             None
         };
@@ -1266,10 +1278,11 @@ pub fn handle_test_websocket(
         .unwrap_or_default();
 
     // Build path_params dict with type coercion
+    let max_param_length = app.max_param_length;
     let path_params_dict = pyo3::types::PyDict::new(py);
     for (k, v) in path_params.iter() {
         let type_hint = param_types.get(k).copied().unwrap_or(TYPE_STRING);
-        match coerce_param(v, type_hint) {
+        match coerce_param_with_limit(v, type_hint, max_param_length) {
             Ok(coerced) => {
                 let py_value = coerced_value_to_py(py, &coerced);
                 path_params_dict.set_item(k, py_value)?;
@@ -1299,7 +1312,7 @@ pub fn handle_test_websocket(
                         .copied()
                         .unwrap_or(TYPE_STRING);
 
-                    match coerce_param(&decoded_value, type_hint) {
+                    match coerce_param_with_limit(&decoded_value, type_hint, max_param_length) {
                         Ok(coerced) => {
                             let py_value = coerced_value_to_py(py, &coerced);
                             query_dict.set_item(decoded_key.as_ref(), py_value)?;

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -45,7 +45,7 @@ use crate::handler::{
 };
 use crate::request_pipeline::validate_and_cache_typed_params;
 use crate::static_files::handle_file;
-use crate::type_coercion::{coerce_param_with_limit, params_to_py_dict, TYPE_STRING};
+use crate::type_coercion::{coerce_param_with_limit, params_to_py_dict, CoerceError, TYPE_STRING};
 
 static ASYNC_RUNTIME_INITIALIZED: std::sync::Once = std::sync::Once::new();
 
@@ -1287,7 +1287,12 @@ pub fn handle_test_websocket(
                 let py_value = coerced_value_to_py(py, &coerced);
                 path_params_dict.set_item(k, py_value)?;
             }
-            Err(_) => {
+            // Oversized values are a hard error — never fall back to the raw string.
+            Err(e @ CoerceError::TooLong { .. }) => {
+                return Err(pyo3::exceptions::PyValueError::new_err(e.to_string()));
+            }
+            // Genuine type-coercion failure: fall back to the raw string.
+            Err(CoerceError::Invalid(_)) => {
                 path_params_dict.set_item(k, v)?;
             }
         }
@@ -1317,7 +1322,12 @@ pub fn handle_test_websocket(
                             let py_value = coerced_value_to_py(py, &coerced);
                             query_dict.set_item(decoded_key.as_ref(), py_value)?;
                         }
-                        Err(_) => {
+                        // Oversized values are a hard error — never fall back to raw string.
+                        Err(e @ CoerceError::TooLong { .. }) => {
+                            return Err(pyo3::exceptions::PyValueError::new_err(e.to_string()));
+                        }
+                        // Genuine type-coercion failure: fall back to the raw string.
+                        Err(CoerceError::Invalid(_)) => {
                             query_dict.set_item(decoded_key.as_ref(), decoded_value.as_ref())?;
                         }
                     }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1039,7 +1039,12 @@ async fn handle_test_request_internal(
             None => None,
         };
         let cookies_dict = if needs_cookies {
-            Some(params_to_py_dict(py, &cookies, &param_types, max_param_length)?)
+            Some(params_to_py_dict(
+                py,
+                &cookies,
+                &param_types,
+                max_param_length,
+            )?)
         } else {
             None
         };

--- a/src/type_coercion.rs
+++ b/src/type_coercion.rs
@@ -98,7 +98,11 @@ fn parse_max_param_length(value: Option<&str>) -> usize {
 /// field — no env access, no lock, no atomics. Missing, empty, non-integer, or
 /// `0` values fall back to [`DEFAULT_MAX_PARAM_LENGTH`].
 pub fn resolve_max_param_length() -> usize {
-    parse_max_param_length(std::env::var("DJANGO_BOLT_MAX_PARAM_LENGTH").ok().as_deref())
+    parse_max_param_length(
+        std::env::var("DJANGO_BOLT_MAX_PARAM_LENGTH")
+            .ok()
+            .as_deref(),
+    )
 }
 
 /// Type hint constants (must match Python's get_type_hint_id() in compiler.py)

--- a/src/type_coercion.rs
+++ b/src/type_coercion.rs
@@ -75,11 +75,18 @@ fn get_time_class(py: Python<'_>) -> &Py<PyAny> {
 /// Prevents memory exhaustion attacks from extremely long parameters.
 pub const DEFAULT_MAX_PARAM_LENGTH: usize = 8192;
 
+/// Hard upper bound for the configurable parameter length (1MB).
+/// A misconfigured `DJANGO_BOLT_MAX_PARAM_LENGTH` (e.g. an enormous value) must
+/// not be able to nullify the DoS guardrail, so any configured value is clamped
+/// to this cap.
+pub const MAX_ALLOWED_PARAM_LENGTH: usize = 1024 * 1024;
+
 #[inline]
 fn parse_max_param_length(value: Option<&str>) -> usize {
     value
         .and_then(|raw| raw.parse::<usize>().ok())
         .filter(|parsed| *parsed > 0)
+        .map(|parsed| parsed.min(MAX_ALLOWED_PARAM_LENGTH))
         .unwrap_or(DEFAULT_MAX_PARAM_LENGTH)
 }
 
@@ -639,5 +646,20 @@ mod tests {
     #[test]
     fn test_parse_max_param_length_accepts_valid_positive_value() {
         assert_eq!(parse_max_param_length(Some("16384")), 16384);
+    }
+
+    #[test]
+    fn test_parse_max_param_length_clamps_to_upper_bound() {
+        // A misconfigured oversized value must be clamped to the hard cap so it
+        // cannot nullify the DoS guardrail.
+        assert_eq!(
+            parse_max_param_length(Some("999999999999")),
+            MAX_ALLOWED_PARAM_LENGTH
+        );
+        // The cap itself is accepted as-is.
+        assert_eq!(
+            parse_max_param_length(Some(&MAX_ALLOWED_PARAM_LENGTH.to_string())),
+            MAX_ALLOWED_PARAM_LENGTH
+        );
     }
 }

--- a/src/type_coercion.rs
+++ b/src/type_coercion.rs
@@ -10,7 +10,6 @@ use pyo3::types::{PyAnyMethods, PyDictMethods};
 use pyo3::{IntoPyObject, Py, PyAny, Python};
 use rust_decimal::Decimal;
 use std::str::FromStr;
-use std::sync::OnceLock;
 use uuid::Uuid;
 
 // OPTIMIZATION: Cache Python classes for type construction (avoids repeated imports)
@@ -75,7 +74,6 @@ fn get_time_class(py: Python<'_>) -> &Py<PyAny> {
 /// Default maximum allowed length for parameter values (8KB).
 /// Prevents memory exhaustion attacks from extremely long parameters.
 pub const DEFAULT_MAX_PARAM_LENGTH: usize = 8192;
-static MAX_PARAM_LENGTH_CACHE: OnceLock<usize> = OnceLock::new();
 
 #[inline]
 fn parse_max_param_length(value: Option<&str>) -> usize {
@@ -85,15 +83,15 @@ fn parse_max_param_length(value: Option<&str>) -> usize {
         .unwrap_or(DEFAULT_MAX_PARAM_LENGTH)
 }
 
-/// Maximum allowed length for parameter values.
-/// Can be overridden with DJANGO_BOLT_MAX_PARAM_LENGTH.
-/// Resolved once and cached for the process lifetime.
-#[inline]
-pub fn max_param_length() -> usize {
-    *MAX_PARAM_LENGTH_CACHE.get_or_init(|| {
-        let env_value = std::env::var("DJANGO_BOLT_MAX_PARAM_LENGTH").ok();
-        parse_max_param_length(env_value.as_deref())
-    })
+/// Resolve the configured maximum parameter length from the
+/// `DJANGO_BOLT_MAX_PARAM_LENGTH` environment variable.
+///
+/// Call this exactly ONCE at server startup and store the result in
+/// `AppState.max_param_length`. The per-request hot path then reads that plain
+/// field — no env access, no lock, no atomics. Missing, empty, non-integer, or
+/// `0` values fall back to [`DEFAULT_MAX_PARAM_LENGTH`].
+pub fn resolve_max_param_length() -> usize {
+    parse_max_param_length(std::env::var("DJANGO_BOLT_MAX_PARAM_LENGTH").ok().as_deref())
 }
 
 /// Type hint constants (must match Python's get_type_hint_id() in compiler.py)
@@ -154,8 +152,17 @@ impl CoercedValue {
 /// * `Ok(CoercedValue)` - Successfully coerced value
 /// * `Err(String)` - Error message describing the coercion failure
 pub fn coerce_param(value: &str, type_hint: u8) -> Result<CoercedValue, String> {
+    coerce_param_with_limit(value, type_hint, DEFAULT_MAX_PARAM_LENGTH)
+}
+
+/// Same as [`coerce_param`] but takes the startup-resolved length limit
+/// (`AppState.max_param_length`) so the hot path never re-resolves config.
+pub(crate) fn coerce_param_with_limit(
+    value: &str,
+    type_hint: u8,
+    max_length: usize,
+) -> Result<CoercedValue, String> {
     // Security: Reject excessively long parameters to prevent memory exhaustion
-    let max_length = max_param_length();
     if value.len() > max_length {
         return Err(format!(
             "Parameter too long: {} bytes (max {} bytes)",
@@ -278,14 +285,16 @@ fn parse_time(value: &str) -> Result<CoercedValue, String> {
 /// Convert a string value to Python object based on type hint.
 /// Handles all supported types including datetime, uuid, and decimal.
 /// Returns PyResult to properly handle validation errors.
+/// `max_length` is the startup-resolved limit (`AppState.max_param_length`),
+/// passed in so the `params_to_py_dict` hot loop never re-resolves config.
 #[inline]
 pub fn coerce_to_py(
     py: pyo3::Python<'_>,
     value: &str,
     type_hint: u8,
+    max_length: usize,
 ) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
     // Security: Validate length for ALL types (defense in depth)
-    let max_length = max_param_length();
     if value.len() > max_length {
         return Err(pyo3::exceptions::PyValueError::new_err(format!(
             "Parameter too long: {} bytes (max {} bytes)",
@@ -436,11 +445,12 @@ pub fn params_to_py_dict<'py>(
     py: pyo3::Python<'py>,
     params: &ahash::AHashMap<String, String>,
     param_types: &std::collections::HashMap<String, u8>,
+    max_param_length: usize,
 ) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::types::PyDict>> {
     let dict = pyo3::types::PyDict::new(py);
     for (name, value) in params {
         let type_hint = param_types.get(name).copied().unwrap_or(TYPE_STRING);
-        let py_value = coerce_to_py(py, value, type_hint)?;
+        let py_value = coerce_to_py(py, value, type_hint, max_param_length)?;
         let _ = dict.set_item(name, py_value);
     }
     Ok(dict)
@@ -567,7 +577,7 @@ mod tests {
 
     #[test]
     fn test_param_length_limit() {
-        let max_length = max_param_length();
+        let max_length = DEFAULT_MAX_PARAM_LENGTH;
         // Valid length should work
         let valid = "a".repeat(max_length);
         assert!(coerce_param(&valid, TYPE_STRING).is_ok());

--- a/src/type_coercion.rs
+++ b/src/type_coercion.rs
@@ -10,6 +10,7 @@ use pyo3::types::{PyAnyMethods, PyDictMethods};
 use pyo3::{IntoPyObject, Py, PyAny, Python};
 use rust_decimal::Decimal;
 use std::str::FromStr;
+use std::sync::OnceLock;
 use uuid::Uuid;
 
 // OPTIMIZATION: Cache Python classes for type construction (avoids repeated imports)
@@ -71,9 +72,29 @@ fn get_time_class(py: Python<'_>) -> &Py<PyAny> {
     })
 }
 
-/// Maximum allowed length for parameter values (8KB default)
-/// Prevents memory exhaustion attacks from extremely long parameters
-pub const MAX_PARAM_LENGTH: usize = 8192;
+/// Default maximum allowed length for parameter values (8KB).
+/// Prevents memory exhaustion attacks from extremely long parameters.
+pub const DEFAULT_MAX_PARAM_LENGTH: usize = 8192;
+static MAX_PARAM_LENGTH_CACHE: OnceLock<usize> = OnceLock::new();
+
+#[inline]
+fn parse_max_param_length(value: Option<&str>) -> usize {
+    value
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .filter(|parsed| *parsed > 0)
+        .unwrap_or(DEFAULT_MAX_PARAM_LENGTH)
+}
+
+/// Maximum allowed length for parameter values.
+/// Can be overridden with DJANGO_BOLT_MAX_PARAM_LENGTH.
+/// Resolved once and cached for the process lifetime.
+#[inline]
+pub fn max_param_length() -> usize {
+    *MAX_PARAM_LENGTH_CACHE.get_or_init(|| {
+        let env_value = std::env::var("DJANGO_BOLT_MAX_PARAM_LENGTH").ok();
+        parse_max_param_length(env_value.as_deref())
+    })
+}
 
 /// Type hint constants (must match Python's get_type_hint_id() in compiler.py)
 pub const TYPE_INT: u8 = 1;
@@ -134,11 +155,12 @@ impl CoercedValue {
 /// * `Err(String)` - Error message describing the coercion failure
 pub fn coerce_param(value: &str, type_hint: u8) -> Result<CoercedValue, String> {
     // Security: Reject excessively long parameters to prevent memory exhaustion
-    if value.len() > MAX_PARAM_LENGTH {
+    let max_length = max_param_length();
+    if value.len() > max_length {
         return Err(format!(
             "Parameter too long: {} bytes (max {} bytes)",
             value.len(),
-            MAX_PARAM_LENGTH
+            max_length
         ));
     }
 
@@ -263,11 +285,12 @@ pub fn coerce_to_py(
     type_hint: u8,
 ) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
     // Security: Validate length for ALL types (defense in depth)
-    if value.len() > MAX_PARAM_LENGTH {
+    let max_length = max_param_length();
+    if value.len() > max_length {
         return Err(pyo3::exceptions::PyValueError::new_err(format!(
             "Parameter too long: {} bytes (max {} bytes)",
             value.len(),
-            MAX_PARAM_LENGTH
+            max_length
         )));
     }
 
@@ -544,14 +567,31 @@ mod tests {
 
     #[test]
     fn test_param_length_limit() {
+        let max_length = max_param_length();
         // Valid length should work
-        let valid = "a".repeat(MAX_PARAM_LENGTH);
+        let valid = "a".repeat(max_length);
         assert!(coerce_param(&valid, TYPE_STRING).is_ok());
 
         // Exceeding limit should fail
-        let too_long = "a".repeat(MAX_PARAM_LENGTH + 1);
+        let too_long = "a".repeat(max_length + 1);
         let result = coerce_param(&too_long, TYPE_STRING);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Parameter too long"));
+    }
+
+    #[test]
+    fn test_parse_max_param_length_defaults_for_invalid_values() {
+        assert_eq!(parse_max_param_length(None), DEFAULT_MAX_PARAM_LENGTH);
+        assert_eq!(parse_max_param_length(Some("")), DEFAULT_MAX_PARAM_LENGTH);
+        assert_eq!(parse_max_param_length(Some("0")), DEFAULT_MAX_PARAM_LENGTH);
+        assert_eq!(
+            parse_max_param_length(Some("not-a-number")),
+            DEFAULT_MAX_PARAM_LENGTH
+        );
+    }
+
+    #[test]
+    fn test_parse_max_param_length_accepts_valid_positive_value() {
+        assert_eq!(parse_max_param_length(Some("16384")), 16384);
     }
 }

--- a/src/type_coercion.rs
+++ b/src/type_coercion.rs
@@ -142,6 +142,36 @@ impl CoercedValue {
     }
 }
 
+/// Error returned by [`coerce_param`] / [`coerce_param_with_limit`].
+///
+/// Callers distinguish the two variants structurally:
+/// * [`CoerceError::TooLong`] is a hard security limit — it MUST always be
+///   rejected (422 for HTTP, upgrade rejection for WebSockets). Never fall back
+///   to passing the oversized value through.
+/// * [`CoerceError::Invalid`] is a normal type-coercion failure. Some callers
+///   (WebSocket scope building) intentionally fall back to the raw string here.
+///
+/// `Display` reproduces the exact same messages the old `String` errors used,
+/// so existing `format!("{e}")` / `.to_string()` consumers are unchanged.
+#[derive(Debug, Clone)]
+pub enum CoerceError {
+    /// Value exceeded the configured `max_param_length` (in bytes).
+    TooLong { len: usize, max: usize },
+    /// Value could not be parsed into the requested type.
+    Invalid(String),
+}
+
+impl std::fmt::Display for CoerceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CoerceError::TooLong { len, max } => {
+                write!(f, "Parameter too long: {} bytes (max {} bytes)", len, max)
+            }
+            CoerceError::Invalid(msg) => f.write_str(msg),
+        }
+    }
+}
+
 /// Coerce a string value to the specified type
 ///
 /// # Arguments
@@ -150,8 +180,8 @@ impl CoercedValue {
 ///
 /// # Returns
 /// * `Ok(CoercedValue)` - Successfully coerced value
-/// * `Err(String)` - Error message describing the coercion failure
-pub fn coerce_param(value: &str, type_hint: u8) -> Result<CoercedValue, String> {
+/// * `Err(CoerceError)` - Structured error (`TooLong` vs `Invalid`)
+pub fn coerce_param(value: &str, type_hint: u8) -> Result<CoercedValue, CoerceError> {
     coerce_param_with_limit(value, type_hint, DEFAULT_MAX_PARAM_LENGTH)
 }
 
@@ -161,16 +191,23 @@ pub(crate) fn coerce_param_with_limit(
     value: &str,
     type_hint: u8,
     max_length: usize,
-) -> Result<CoercedValue, String> {
-    // Security: Reject excessively long parameters to prevent memory exhaustion
+) -> Result<CoercedValue, CoerceError> {
+    // Security: Reject excessively long parameters to prevent memory exhaustion.
+    // Surfaced as a distinct variant so callers can enforce it as a hard limit
+    // without inspecting the error message text.
     if value.len() > max_length {
-        return Err(format!(
-            "Parameter too long: {} bytes (max {} bytes)",
-            value.len(),
-            max_length
-        ));
+        return Err(CoerceError::TooLong {
+            len: value.len(),
+            max: max_length,
+        });
     }
 
+    coerce_typed(value, type_hint).map_err(CoerceError::Invalid)
+}
+
+/// Parse `value` into `type_hint` without the length check. Plain-message errors
+/// are wrapped in [`CoerceError::Invalid`] by the public entry points above.
+fn coerce_typed(value: &str, type_hint: u8) -> Result<CoercedValue, String> {
     match type_hint {
         TYPE_INT => value
             .parse::<i64>()
@@ -585,8 +622,7 @@ mod tests {
         // Exceeding limit should fail
         let too_long = "a".repeat(max_length + 1);
         let result = coerce_param(&too_long, TYPE_STRING);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Parameter too long"));
+        assert!(matches!(result, Err(CoerceError::TooLong { .. })));
     }
 
     #[test]

--- a/src/websocket/handler.rs
+++ b/src/websocket/handler.rs
@@ -18,7 +18,7 @@ use crate::handler::coerced_value_to_py;
 use crate::metadata::CorsConfig;
 use crate::middleware::rate_limit::check_rate_limit;
 use crate::state::{AppState, ROUTE_METADATA, TASK_LOCALS};
-use crate::type_coercion::{coerce_param_with_limit, TYPE_STRING};
+use crate::type_coercion::{coerce_param_with_limit, CoerceError, TYPE_STRING};
 use crate::validation::{validate_auth_and_guards, AuthGuardResult};
 
 use super::actor::WebSocketActor;
@@ -109,8 +109,12 @@ fn build_scope(
                         let py_value = coerced_value_to_py(py, &coerced);
                         query_dict.set_item(decoded_key.as_ref(), py_value)?;
                     }
-                    Err(_) => {
-                        // Fall back to string on coercion error
+                    // Oversized values reject the upgrade — never pass a raw string through.
+                    Err(e @ CoerceError::TooLong { .. }) => {
+                        return Err(pyo3::exceptions::PyValueError::new_err(e.to_string()));
+                    }
+                    // Genuine type-coercion failure: fall back to the raw string.
+                    Err(CoerceError::Invalid(_)) => {
                         query_dict.set_item(decoded_key.as_ref(), decoded_value.as_ref())?;
                     }
                 }
@@ -141,8 +145,12 @@ fn build_scope(
                 let py_value = coerced_value_to_py(py, &coerced);
                 params_dict.set_item(k.as_str(), py_value)?;
             }
-            Err(_) => {
-                // Fall back to string on coercion error
+            // Oversized values reject the upgrade — never pass a raw string through.
+            Err(e @ CoerceError::TooLong { .. }) => {
+                return Err(pyo3::exceptions::PyValueError::new_err(e.to_string()));
+            }
+            // Genuine type-coercion failure: fall back to the raw string.
+            Err(CoerceError::Invalid(_)) => {
                 params_dict.set_item(k.as_str(), v.as_str())?;
             }
         }

--- a/src/websocket/handler.rs
+++ b/src/websocket/handler.rs
@@ -18,7 +18,7 @@ use crate::handler::coerced_value_to_py;
 use crate::metadata::CorsConfig;
 use crate::middleware::rate_limit::check_rate_limit;
 use crate::state::{AppState, ROUTE_METADATA, TASK_LOCALS};
-use crate::type_coercion::{coerce_param, TYPE_STRING};
+use crate::type_coercion::{coerce_param_with_limit, TYPE_STRING};
 use crate::validation::{validate_auth_and_guards, AuthGuardResult};
 
 use super::actor::WebSocketActor;
@@ -83,6 +83,7 @@ fn build_scope(
     req: &HttpRequest,
     path_params: &AHashMap<String, String>,
     param_types: &HashMap<String, u8>,
+    max_param_length: usize,
 ) -> PyResult<Py<PyAny>> {
     let scope_dict = PyDict::new(py);
     scope_dict.set_item("type", "websocket")?;
@@ -103,7 +104,7 @@ fn build_scope(
                     .copied()
                     .unwrap_or(TYPE_STRING);
 
-                match coerce_param(&decoded_value, type_hint) {
+                match coerce_param_with_limit(&decoded_value, type_hint, max_param_length) {
                     Ok(coerced) => {
                         let py_value = coerced_value_to_py(py, &coerced);
                         query_dict.set_item(decoded_key.as_ref(), py_value)?;
@@ -135,7 +136,7 @@ fn build_scope(
     let params_dict = PyDict::new(py);
     for (k, v) in path_params.iter() {
         let type_hint = param_types.get(k).copied().unwrap_or(TYPE_STRING);
-        match coerce_param(v, type_hint) {
+        match coerce_param_with_limit(v, type_hint, max_param_length) {
             Ok(coerced) => {
                 let py_value = coerced_value_to_py(py, &coerced);
                 params_dict.set_item(k.as_str(), py_value)?;
@@ -547,7 +548,9 @@ pub async fn handle_websocket_upgrade_with_handler(
         .unwrap_or_default();
 
     // Build scope for Python - if this fails, decrement counter
-    let scope = match Python::attach(|py| build_scope(py, &req, &path_params, &param_types)) {
+    let scope = match Python::attach(|py| {
+        build_scope(py, &req, &path_params, &param_types, state.max_param_length)
+    }) {
         Ok(s) => s,
         Err(e) => {
             // CRITICAL: Decrement counter on error to prevent resource leak


### PR DESCRIPTION
<!-- Describe the change in 2-3 sentences. Link to any related issue. -->

Updated the code to make MAX_PARAM_LENGTH customizable via an environment variable: DJANGO_BOLT_MAX_PARAM_LENGTH.  The default value is unchanged.



## How was this tested?

- [ ] `just lint-lib` and `just test-py` pass
- [ ] If Rust was changed: `just rebuild` succeeds
- [x] If a new feature is added: tested manually in the example project (`python/example/`)


## Performance consideration

I don't expect any impact on performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Hot Request Path Impact

**Yes—this PR touches the hot request path, but the added per-request work is the minimum needed to make parameter-length DoS protection configurable (while keeping env-var parsing startup-only).**

### What changed on the hot path
- **Startup (not per request):** `server.rs` resolves `DJANGO_BOLT_MAX_PARAM_LENGTH` once via `resolve_max_param_length()` and stores it in `AppState.max_param_length`.
- **Per request:** `handler.rs` reads `let max_param_length = state.max_param_length;` and threads it into the places that already enforce the parameter-length guardrail:
  - **Path/query typed validation:** `validate_and_cache_typed_params(..., max_length)` (`request_pipeline.rs`)
  - **Form parsing:**
    - URL-encoded: `parse_urlencoded(..., max_param_length)` (`form_parsing.rs`)
    - Multipart text fields: `parse_multipart(..., max_param_length)` (`form_parsing.rs`)
  - **Python-side construction for headers/cookies:** `params_to_py_dict(..., max_param_length)` → `coerce_to_py(..., max_length)` (`type_coercion.rs`)

### Is it “stupid work” / performance-risky?
- **No env-var overhead in the hot path:** the PR explicitly avoids per-request env parsing/locking by resolving once at startup and only reading a `usize` per request.
- **Required length checks:** the hot-path additions are essentially `value.len() > max_length` checks before accepting/coercing user-controlled parameter values (security/validation behavior that must happen anyway).
- **Some intentional extra checks, but localized:**
  - **Path/query coercion for non-strings:** `validate_and_cache_typed_params` checks length for every param, then `coerce_param_with_limit` checks length again for non-string coercions. That’s at most a second bounds comparison per coerced value.
  - **Multipart text fields:** multipart does an **early reject while buffering**, and then the final coercion path also enforces the limit—so you get an additional check, but it should be redundant only because the early rejection already ensured the value is within bounds.

**Verdict:** The PR’s hot-path changes are targeted and necessary; aside from a couple of extra length comparisons in specific coercion/buffering flows, they don’t introduce env/config parsing or new heavy work in the request pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->