### PR TITLE
feat(server): worker recycling (max-rss/lifetime) with graceful WebSocket drain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,7 @@ just release VERSION=0.2.2 DRY_RUN=1    # Test without changes
      - `middleware.py` - Middleware decorators (@cors, @rate_limit, @skip_middleware)
    - `middleware/compiler.py` - Compiles Python middleware config to Rust metadata
    - `management/commands/runbolt.py` - Django management command with autodiscovery
+   - `workers.py` - Worker supervisor for `runbolt`: RSS/lifetime-based recycling (`--max-rss`, `--workers-lifetime`), crash respawn, graceful spawn-first recycle with WebSocket drain (close code 1012)
 
 3. **Django Integration**
    - `runbolt` management command auto-discovers `api.py` files in:
@@ -432,6 +433,7 @@ uv run --with pytest pytest python/tests -s -vv
 - `bootstrap.py` - Django configuration helper
 - `cli.py` - CLI tool (`django-bolt version` command)
 - `management/commands/runbolt.py` - Django management command with autodiscovery
+- `workers.py` - Worker supervisor (RSS/lifetime recycling, crash respawn, graceful shutdown)
 - `apps.py` - Django app configuration
 
 ## Troubleshooting (Development)

--- a/docs/src/getting-started/deployment.md
+++ b/docs/src/getting-started/deployment.md
@@ -43,13 +43,13 @@ python manage.py runbolt --processes 4 \
 
 Any of these options enables the supervising parent process, even with `--processes 1`.
 
-### How recycling works (zero-downtime, WebSocket-aware)
+### How recycling works (near-zero-downtime, WebSocket-aware)
 
 Recycling is **spawn-first and graceful** — it is safe for long-lived connections:
 
-1. The supervisor forks a **replacement worker first**; `SO_REUSEPORT` lets old and new workers share the port, so there is never a moment without an accepting process.
+1. The supervisor forks a **replacement worker first**; `SO_REUSEPORT` lets old and new workers share the port, so an accepting process is always up. (Closing the old worker's socket can reset the handful of connections already queued on it — negligible with keep-alive clients, which simply retry.)
 2. The old worker receives SIGTERM and stops accepting new connections — the kernel routes new traffic to healthy workers.
-3. Active **WebSocket connections receive a proper close frame with code `1012` (Service Restart)** instead of an abrupt reset. Clients should treat 1012 as "reconnect now"; the reconnect lands on a healthy worker. New upgrade attempts on the draining worker get `503`.
+3. Active **WebSocket connections receive a proper close frame with code `1012` (Service Restart)** instead of an abrupt reset. Clients should treat 1012 as "reconnect now"; the reconnect lands on a healthy worker. New connections to the draining worker are refused, so they retry onto a healthy one.
 4. In-flight HTTP requests finish (up to `--workers-kill-timeout`, which also sets the server's internal graceful-shutdown window).
 5. If the worker still hasn't exited after the timeout, it is SIGKILLed.
 

--- a/docs/src/getting-started/deployment.md
+++ b/docs/src/getting-started/deployment.md
@@ -19,6 +19,47 @@ Under the hood, Django-Bolt uses `SO_REUSEPORT` so the kernel load-balances inco
 
 **Rule of thumb:** Set `--processes` to the number of CPU cores available.
 
+## Worker recycling (memory leaks)
+
+Long-running Python processes slowly accumulate resident memory — leaky C extensions, allocator fragmentation, unbounded caches. Traditional servers like Gunicorn work around this with `max_requests` restarts; request count is only a proxy for memory, so Django-Bolt (like Granian) recycles workers on the actual symptoms instead:
+
+```bash
+# Recycle any worker whose resident memory exceeds 512 MiB
+python manage.py runbolt --processes 4 --max-rss 512
+
+# Also recycle each worker every 6 hours, and replace crashed workers
+python manage.py runbolt --processes 4 \
+    --max-rss 512 \
+    --workers-lifetime 21600 \
+    --respawn-failed-workers
+```
+
+| Option | Meaning |
+| --- | --- |
+| `--max-rss <MiB>` | Recycle a worker once its resident set size exceeds this many MiB (checked about once per second). Set it well above your baseline per-worker RSS. `0` disables (default). |
+| `--workers-lifetime <seconds>` | Recycle each worker after this much uptime. `0` disables (default). |
+| `--respawn-failed-workers` | Fork a replacement when a worker exits unexpectedly (crash, OOM kill) instead of letting the fleet shrink. |
+| `--workers-kill-timeout <seconds>` | How long a worker gets to shut down gracefully before it is SIGKILLed (default: 30). |
+
+Any of these options enables the supervising parent process, even with `--processes 1`.
+
+### How recycling works (zero-downtime, WebSocket-aware)
+
+Recycling is **spawn-first and graceful** — it is safe for long-lived connections:
+
+1. The supervisor forks a **replacement worker first**; `SO_REUSEPORT` lets old and new workers share the port, so there is never a moment without an accepting process.
+2. The old worker receives SIGTERM and stops accepting new connections — the kernel routes new traffic to healthy workers.
+3. Active **WebSocket connections receive a proper close frame with code `1012` (Service Restart)** instead of an abrupt reset. Clients should treat 1012 as "reconnect now"; the reconnect lands on a healthy worker. New upgrade attempts on the draining worker get `503`.
+4. In-flight HTTP requests finish (up to `--workers-kill-timeout`, which also sets the server's internal graceful-shutdown window).
+5. If the worker still hasn't exited after the timeout, it is SIGKILLed.
+
+The same drain sequence runs on plain `SIGTERM` (systemd stop, `kubectl delete pod`), so deploys and scale-downs also close WebSockets cleanly. `SIGINT` (Ctrl-C) stops immediately without draining; pressing Ctrl-C twice force-kills workers.
+
+!!! note "WebSocket clients must reconnect"
+    No server can migrate a live TCP connection between processes. Recycling closes WebSockets *cleanly* (close code 1012) rather than avoiding the disconnect. Build reconnect logic into your WebSocket clients and keep per-connection session state in Redis/the database so a reconnect is transparent.
+
+The graceful-shutdown window can also be set directly via the `DJANGO_BOLT_SHUTDOWN_TIMEOUT` environment variable (seconds, default 30) when running without the supervisor.
+
 ## Production deployment
 
 For production, run Django-Bolt as a managed service behind a reverse proxy.

--- a/python/django_bolt/management/commands/runbolt.py
+++ b/python/django_bolt/management/commands/runbolt.py
@@ -9,6 +9,7 @@ import importlib.util
 import os
 import signal
 import sys
+import traceback
 import warnings
 from pathlib import Path
 
@@ -20,6 +21,7 @@ from django.utils.autoreload import iter_all_python_module_files
 
 from django_bolt import _core
 from django_bolt.api import BoltAPI, _validate_asgi_mount_conflicts, serve_with_lifespan
+from django_bolt.workers import MIB, WorkerSupervisor
 
 try:
     from django_bolt.logging.config import setup_django_logging
@@ -386,6 +388,42 @@ class Command(BaseCommand):
         parser.add_argument(
             "--keep-alive", type=int, default=None, help="HTTP keep-alive timeout in seconds (default: OS setting)"
         )
+        parser.add_argument(
+            "--max-rss",
+            type=int,
+            default=0,
+            help=(
+                "Recycle a worker once its resident memory exceeds this many MiB "
+                "(0 = disabled). Guards long-running servers against slow Python "
+                "memory leaks; recycling is graceful (spawn-first, WebSockets "
+                "closed with 1012 Service Restart)."
+            ),
+        )
+        parser.add_argument(
+            "--workers-lifetime",
+            type=int,
+            default=0,
+            help="Recycle each worker after this many seconds of uptime (0 = disabled)",
+        )
+        parser.add_argument(
+            "--respawn-failed-workers",
+            action="store_true",
+            help="Respawn workers that exit unexpectedly instead of letting the fleet shrink",
+        )
+        parser.add_argument(
+            "--workers-kill-timeout",
+            type=int,
+            default=30,
+            help=(
+                "Seconds a worker gets to shut down gracefully (finish in-flight "
+                "requests, close WebSockets) before it is SIGKILLed (default: 30)"
+            ),
+        )
+
+    @staticmethod
+    def _supervision_requested(options) -> bool:
+        """True when any worker-recycling option is enabled."""
+        return bool(options["max_rss"] or options["workers_lifetime"] or options["respawn_failed_workers"])
 
     def handle(self, *args, **options):
         processes = options["processes"]
@@ -398,11 +436,14 @@ class Command(BaseCommand):
             if processes > 1:
                 self.stdout.write(self.style.WARNING("  Warning: dev mode forces --processes=1 for auto-reload"))
                 options["processes"] = 1
+            if self._supervision_requested(options):
+                self.stdout.write(self.style.WARNING("  Warning: worker recycling options are ignored in dev mode"))
 
             self.run_with_autoreload(options)
         else:
-            # Production mode (current logic)
-            if processes > 1:
+            # Production mode. Worker recycling needs the supervising parent
+            # even for a single worker, so route through start_multiprocess.
+            if processes > 1 or (self._supervision_requested(options) and not dev_worker_mode):
                 self.start_multiprocess(options)
             else:
                 self.start_single_process(options, dev_mode=effective_dev_mode)
@@ -427,63 +468,72 @@ class Command(BaseCommand):
             sys.exit(exit_code)
 
     def start_multiprocess(self, options):
-        """Start multiple processes with SO_REUSEPORT.
+        """Start worker processes with SO_REUSEPORT under a supervisor.
 
         Prints the startup banner once from the parent process, then forks
         children that each run start_single_process (which skips the banner
-        when process_id is set).
+        when process_id is set). The parent supervises the workers: it
+        recycles them on --max-rss / --workers-lifetime limits (spawn-first,
+        graceful drain), respawns crashed workers when
+        --respawn-failed-workers is set, and coordinates graceful shutdown
+        on SIGTERM/SIGINT.
         """
+        if not hasattr(os, "fork"):
+            raise CommandError(
+                "--processes > 1 and worker recycling require os.fork(), which is unavailable on this platform"
+            )
+
         processes = options["processes"]
+        kill_timeout = options["workers_kill_timeout"]
 
         # Run autodiscovery + banner once in the parent before forking so the
         # user sees a single clean banner instead of N copies.
         self._print_multiprocess_banner(options)
 
-        # Store child PIDs for cleanup
-        child_pids = []
+        # Give Actix the same graceful-shutdown window the supervisor allows
+        # before escalating to SIGKILL (user-set env takes precedence).
+        os.environ.setdefault("DJANGO_BOLT_SHUTDOWN_TIMEOUT", str(kill_timeout))
+
+        def spawn_worker(slot: int) -> int:
+            pid = os.fork()
+            if pid != 0:
+                return pid
+            # Child: reset inherited handlers so only the supervising parent
+            # reacts to terminal signals; the Rust server installs its own
+            # SIGTERM/SIGINT handling for graceful drain.
+            signal.signal(signal.SIGINT, signal.SIG_DFL)
+            signal.signal(signal.SIGTERM, signal.SIG_DFL)
+            # Always enable SO_REUSEPORT: during recycling the replacement
+            # worker binds the port while the old worker is still draining.
+            os.environ["DJANGO_BOLT_REUSE_PORT"] = "1"
+            os.environ["DJANGO_BOLT_PROCESS_ID"] = str(slot)
+            exit_code = 0
+            try:
+                self.start_single_process(options, process_id=slot)
+            except BaseException:
+                traceback.print_exc()
+                exit_code = 1
+            finally:
+                os._exit(exit_code)
+            return 0  # unreachable: os._exit never returns
+
+        supervisor = WorkerSupervisor(
+            processes=processes,
+            spawn=spawn_worker,
+            max_rss_bytes=options["max_rss"] * MIB if options["max_rss"] else None,
+            lifetime_seconds=float(options["workers_lifetime"]) if options["workers_lifetime"] else None,
+            respawn_failed=options["respawn_failed_workers"],
+            kill_timeout=float(kill_timeout),
+            log=lambda message: self.stdout.write(f"  {message}"),
+        )
 
         def signal_handler(signum, frame):
-            self.stdout.write("\n  Shutting down...")
-            for pid in child_pids:
-                with contextlib.suppress(ProcessLookupError):
-                    os.kill(pid, signal.SIGTERM)
-            # Wait for children to exit before the parent exits
-            for pid in list(child_pids):
-                with contextlib.suppress(ChildProcessError):
-                    os.waitpid(pid, 0)
-            sys.exit(0)
+            supervisor.request_shutdown()
 
         signal.signal(signal.SIGINT, signal_handler)
         signal.signal(signal.SIGTERM, signal_handler)
 
-        # Fork processes
-        for i in range(processes):
-            pid = os.fork()
-            if pid == 0:
-                # Child: reset signals to default so only the parent prints
-                # shutdown messages and manages the process group.
-                signal.signal(signal.SIGINT, signal.SIG_DFL)
-                signal.signal(signal.SIGTERM, signal.SIG_DFL)
-                os.environ["DJANGO_BOLT_REUSE_PORT"] = "1"
-                os.environ["DJANGO_BOLT_PROCESS_ID"] = str(i)
-                self.start_single_process(options, process_id=i)
-                os._exit(0)
-            else:
-                # Parent process
-                child_pids.append(pid)
-
-        # Parent waits for children
-        try:
-            while True:
-                pid, status = os.wait()
-                if pid in child_pids:
-                    child_pids.remove(pid)
-                if not child_pids:
-                    break
-        except ChildProcessError:
-            pass
-        except KeyboardInterrupt:
-            pass
+        supervisor.run()
 
     def _print_multiprocess_banner(self, options):
         """Perform a dry-run of autodiscovery to collect route/feature info,
@@ -550,6 +600,16 @@ class Command(BaseCommand):
             features.append(("Compression", "enabled"))
         if middleware_count:
             features.append(("Middleware", f"{middleware_count} handlers"))
+
+        recycling_bits = []
+        if options["max_rss"]:
+            recycling_bits.append(f"max-rss {options['max_rss']}MiB")
+        if options["workers_lifetime"]:
+            recycling_bits.append(f"lifetime {options['workers_lifetime']}s")
+        if options["respawn_failed_workers"]:
+            recycling_bits.append("respawn-on-failure")
+        if recycling_bits:
+            features.append(("Recycling", ", ".join(recycling_bits)))
 
         self._print_startup_banner(
             options=options,

--- a/python/django_bolt/workers.py
+++ b/python/django_bolt/workers.py
@@ -1,0 +1,272 @@
+"""Worker process supervision for ``runbolt``.
+
+Long-running Python servers accumulate resident memory (leaky C extensions,
+allocator fragmentation, unbounded caches). Traditional servers work around
+this with ``max_requests``-style restarts; request count is only a proxy for
+memory, so — like Granian — django-bolt recycles workers on the actual
+symptoms instead:
+
+- ``max_rss_bytes``: recycle a worker once its resident set size exceeds a
+  threshold (the primary defense against slow memory leaks).
+- ``lifetime_seconds``: recycle workers after a wall-clock lifetime.
+- ``respawn_failed``: replace workers that exit unexpectedly.
+
+Recycling is *graceful and spawn-first*: a replacement worker is forked and
+binds the same port via SO_REUSEPORT *before* the old worker receives
+SIGTERM, so the port is never left without an accepting process. On SIGTERM
+the worker stops accepting connections, closes WebSocket connections with
+code 1012 (Service Restart) so clients reconnect to a healthy worker,
+finishes in-flight requests, and exits. A worker that has not exited after
+``kill_timeout`` seconds is SIGKILLed.
+
+All OS interactions (spawn, kill, waitpid, RSS reading, clock, sleep) are
+injectable for deterministic unit testing.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import os
+import signal
+import subprocess
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+MIB = 1024 * 1024
+
+DEFAULT_KILL_TIMEOUT = 30.0
+DEFAULT_CHECK_INTERVAL = 1.0
+
+
+def get_rss_bytes(pid: int) -> int | None:
+    """Return the resident set size of *pid* in bytes, or None if unreadable.
+
+    Reads ``/proc/<pid>/status`` (Linux) and falls back to ``ps -o rss=``
+    (macOS/BSD). Returns None for dead PIDs or unsupported platforms.
+    """
+    try:
+        with open(f"/proc/{pid}/status", "rb") as status_file:
+            for line in status_file:
+                if line.startswith(b"VmRSS:"):
+                    return int(line.split()[1]) * 1024  # VmRSS is in KiB
+    except (OSError, ValueError, IndexError):
+        pass
+
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "rss=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        value = result.stdout.strip()
+        if result.returncode == 0 and value:
+            return int(value) * 1024  # ps reports RSS in KiB
+    except (OSError, ValueError, subprocess.SubprocessError):
+        pass
+
+    return None
+
+
+@dataclass
+class _Worker:
+    slot: int
+    pid: int
+    started_at: float
+
+
+class WorkerSupervisor:
+    """Supervises forked worker processes: recycling, respawn, shutdown.
+
+    The supervisor owns the parent process main loop. ``spawn(slot)`` must
+    fork a worker for the given slot and return its PID (in the parent).
+    Call :meth:`request_shutdown` from a signal handler to begin graceful
+    shutdown; a second call escalates to SIGKILL.
+    """
+
+    def __init__(
+        self,
+        *,
+        processes: int,
+        spawn: Callable[[int], int],
+        max_rss_bytes: int | None = None,
+        lifetime_seconds: float | None = None,
+        respawn_failed: bool = False,
+        kill_timeout: float = DEFAULT_KILL_TIMEOUT,
+        check_interval: float = DEFAULT_CHECK_INTERVAL,
+        kill: Callable[[int, int], None] = os.kill,
+        waitpid: Callable[[int, int], tuple[int, int]] = os.waitpid,
+        rss_reader: Callable[[int], int | None] = get_rss_bytes,
+        clock: Callable[[], float] = time.monotonic,
+        log: Callable[[str], None] = print,
+    ) -> None:
+        self.processes = processes
+        self.max_rss_bytes = max_rss_bytes
+        self.lifetime_seconds = lifetime_seconds
+        self.respawn_failed = respawn_failed
+        self.kill_timeout = kill_timeout
+        self.check_interval = check_interval
+
+        self._spawn = spawn
+        self._kill = kill
+        self._waitpid = waitpid
+        self._rss_reader = rss_reader
+        self._clock = clock
+        self._log = log
+
+        self._workers: dict[int, _Worker] = {}  # pid -> worker
+        self._draining: dict[int, float] = {}  # pid -> SIGKILL deadline
+        self._shutdown_requested = False
+        self._shutdown_signaled = False
+        self._force_kill = False
+        # Interruptible sleep: request_shutdown() wakes the loop immediately
+        # instead of waiting out the current check interval.
+        self._wakeup = threading.Event()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Fork the initial set of workers, one per slot."""
+        for slot in range(self.processes):
+            self._spawn_slot(slot)
+
+    def run(self) -> None:
+        """Supervise until all workers have exited.
+
+        Without ``respawn_failed`` the loop also ends when every worker has
+        died on its own (matching the historical runbolt behavior of the
+        parent exiting once all children are gone).
+        """
+        self.start()
+        while self._workers or self._draining:
+            self._wakeup.wait(self.check_interval)
+            self._wakeup.clear()
+            self.tick()
+
+    def tick(self) -> None:
+        """One supervision pass: reap, then recycle/terminate as needed."""
+        self._reap()
+        now = self._clock()
+        if self._shutdown_requested:
+            self._begin_shutdown()
+        else:
+            self._check_limits(now)
+        self._enforce_deadlines(now)
+
+    def request_shutdown(self) -> None:
+        """Begin graceful shutdown; a second call escalates to SIGKILL."""
+        if self._shutdown_requested:
+            self._force_kill = True
+        self._shutdown_requested = True
+        self._wakeup.set()
+
+    def active_worker_count(self) -> int:
+        return len(self._workers)
+
+    def has_draining_workers(self) -> bool:
+        return bool(self._draining)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _spawn_slot(self, slot: int) -> None:
+        pid = self._spawn(slot)
+        self._workers[pid] = _Worker(slot=slot, pid=pid, started_at=self._clock())
+
+    def _reap(self) -> None:
+        """Collect exited children without blocking."""
+        while True:
+            try:
+                pid, status = self._waitpid(-1, os.WNOHANG)
+            except ChildProcessError:
+                return
+            except OSError as exc:
+                if exc.errno == errno.ECHILD:
+                    return
+                raise
+            if pid == 0:
+                return
+            self._on_worker_exit(pid, status)
+
+    def _on_worker_exit(self, pid: int, status: int) -> None:
+        if pid in self._draining:
+            del self._draining[pid]
+            return
+
+        worker = self._workers.pop(pid, None)
+        if worker is None:
+            return
+
+        if self._shutdown_requested:
+            return
+
+        exit_code = os.waitstatus_to_exitcode(status)
+        if self.respawn_failed:
+            self._log(f"Worker {pid} (slot {worker.slot}) exited unexpectedly (code {exit_code}); respawning")
+            self._spawn_slot(worker.slot)
+        else:
+            self._log(
+                f"Worker {pid} (slot {worker.slot}) exited unexpectedly (code {exit_code}); "
+                f"not respawning (enable with --respawn-failed-workers)"
+            )
+
+    def _check_limits(self, now: float) -> None:
+        for worker in list(self._workers.values()):
+            reason = self._limit_violation(worker, now)
+            if reason is not None:
+                self._recycle(worker, reason)
+                # At most one recycle per tick: staggers respawns when every
+                # worker crosses a limit at once (common with a shared leak),
+                # so capacity never drops to all-cold workers simultaneously.
+                return
+
+    def _limit_violation(self, worker: _Worker, now: float) -> str | None:
+        if self.lifetime_seconds is not None and now - worker.started_at >= self.lifetime_seconds:
+            return f"lifetime {self.lifetime_seconds:.0f}s reached"
+        if self.max_rss_bytes is not None:
+            rss = self._rss_reader(worker.pid)
+            if rss is not None and rss > self.max_rss_bytes:
+                return f"rss {rss / MIB:.0f}MiB exceeds limit {self.max_rss_bytes / MIB:.0f}MiB"
+        return None
+
+    def _recycle(self, worker: _Worker, reason: str) -> None:
+        self._log(f"Recycling worker {worker.pid} (slot {worker.slot}): {reason}")
+        del self._workers[worker.pid]
+        # Spawn the replacement BEFORE stopping the old worker so the port
+        # always has an accepting process (SO_REUSEPORT allows the overlap).
+        self._spawn_slot(worker.slot)
+        self._terminate(worker.pid)
+
+    def _terminate(self, pid: int) -> None:
+        self._draining[pid] = self._clock() + self.kill_timeout
+        # ProcessLookupError: already dead; the next reap pass clears it.
+        with contextlib.suppress(ProcessLookupError):
+            self._kill(pid, signal.SIGTERM)
+
+    def _begin_shutdown(self) -> None:
+        if not self._shutdown_signaled:
+            self._shutdown_signaled = True
+            worker_count = len(self._workers)
+            if worker_count:
+                self._log(f"Shutting down {worker_count} worker{'s' if worker_count != 1 else ''}...")
+            for pid in list(self._workers):
+                del self._workers[pid]
+                self._terminate(pid)
+        if self._force_kill:
+            for pid in self._draining:
+                self._draining[pid] = 0.0
+
+    def _enforce_deadlines(self, now: float) -> None:
+        for pid, deadline in list(self._draining.items()):
+            if now >= deadline:
+                self._log(f"Worker {pid} did not exit within kill timeout; sending SIGKILL")
+                with contextlib.suppress(ProcessLookupError):
+                    self._kill(pid, signal.SIGKILL)
+                # Push the deadline out so a slow reap doesn't re-SIGKILL.
+                self._draining[pid] = now + self.kill_timeout

--- a/python/tests/integration/apps/recycling_leak.py
+++ b/python/tests/integration/apps/recycling_leak.py
@@ -1,0 +1,29 @@
+"""A deliberately leaky app under test for ``--max-rss`` recycling.
+
+Each ``/leak`` request retains memory forever, so a worker's RSS climbs without
+bound until ``--max-rss`` recycles it. 16 KiB/request makes RSS climb fast
+enough that, without recycling, workers would blow far past the limit within the
+load window — so a worker seen back near baseline is unambiguous proof that
+recycling reset it.
+"""
+
+from __future__ import annotations
+
+import os
+
+from django_bolt import BoltAPI
+
+api = BoltAPI()
+
+_LEAK: list[bytearray] = []
+
+
+@api.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@api.get("/leak")
+async def leak():
+    _LEAK.append(bytearray(16384))  # retain 16 KiB per request == a memory leak
+    return {"pid": os.getpid(), "chunks": len(_LEAK)}

--- a/python/tests/integration/apps/recycling_pid.py
+++ b/python/tests/integration/apps/recycling_pid.py
@@ -1,0 +1,29 @@
+"""App under test for worker recycling (lifetime/max-rss/respawn).
+
+Exposes the worker PID so a test can confirm a recycle happened (the PID
+changes) and a ``/die`` route that crashes the worker mid-request so the
+respawn path can be exercised.
+"""
+
+from __future__ import annotations
+
+import os
+
+from django_bolt import BoltAPI
+
+api = BoltAPI()
+
+
+@api.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@api.get("/pid")
+async def pid():
+    return {"pid": os.getpid()}
+
+
+@api.get("/die")
+async def die():
+    os._exit(1)

--- a/python/tests/integration/apps/recycling_ws_echo.py
+++ b/python/tests/integration/apps/recycling_ws_echo.py
@@ -1,0 +1,23 @@
+"""App under test for graceful WebSocket drain on shutdown.
+
+A plain echo socket: the test opens it, triggers SIGTERM, and asserts the server
+closes the connection with 1012 (Service Restart) instead of dropping it.
+"""
+
+from __future__ import annotations
+
+from django_bolt import BoltAPI, WebSocket
+
+api = BoltAPI()
+
+
+@api.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@api.websocket("/ws/echo")
+async def echo(websocket: WebSocket):
+    await websocket.accept()
+    async for message in websocket.iter_text():
+        await websocket.send_text(f"echo:{message}")

--- a/python/tests/integration/helpers.py
+++ b/python/tests/integration/helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import collections
 import contextlib
 import hashlib
 import os
@@ -12,6 +13,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -22,6 +24,141 @@ import httpx
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_TIMEOUT = 20.0
+
+
+def child_pids(parent_pid: int) -> set[int]:
+    """Return the PIDs of a process's direct children (POSIX only).
+
+    Used to observe worker recycling: the ``runbolt`` supervisor forks one
+    worker per slot, so a changing child-PID set is proof of recycles.
+    """
+    result = subprocess.run(
+        ["ps", "--ppid", str(parent_pid), "-o", "pid="],
+        capture_output=True,
+        text=True,
+    )
+    return {int(token) for token in result.stdout.split()}
+
+
+@dataclass
+class LoadResult:
+    """Aggregate outcome of a :func:`generate_load` run.
+
+    ``ok``       requests that eventually got a <400 response.
+    ``failed``   requests that stayed failed after exhausting retries — genuine
+                 downtime (no worker could serve the request).
+    ``retried``  requests that hit a transient transport error / 5xx but
+                 succeeded on a retry — the expected, benign consequence of a
+                 keep-alive connection being closed by a graceful drain. A real
+                 client (browser, load balancer, bombardier) reconnects and
+                 retries idempotent GETs transparently, so this is *not*
+                 downtime; it is tracked separately for observability.
+    """
+
+    ok: int
+    failed: int
+    retried: int
+    errors: dict[str, int]
+
+    @property
+    def total(self) -> int:
+        return self.ok + self.failed
+
+    @property
+    def failure_rate(self) -> float:
+        return self.failed / self.total if self.total else 1.0
+
+
+def generate_load(
+    url: str,
+    *,
+    duration_s: float,
+    concurrency: int = 16,
+    timeout_s: float = 3.0,
+    max_attempts: int = 4,
+    on_tick: Callable[[], None] | None = None,
+    tick_interval: float = 0.25,
+) -> LoadResult:
+    """Bombard *url* with concurrent keep-alive requests for *duration_s*.
+
+    A dependency-free stand-in for an external load tool (bombardier/wrk): each
+    worker thread drives its own connection-pooled ``httpx.Client`` so requests
+    reuse connections the way a real client does.
+
+    Only idempotent GETs are issued, so — like any real HTTP client or load
+    balancer — a transient transport error or 5xx is retried on a fresh
+    connection up to ``max_attempts`` times. A request counts as ``failed`` only
+    if every attempt fails, which is the true "server dropped the request /
+    there was no accepting process" signal. Transient errors that a retry
+    recovers from are counted in ``retried`` (see :class:`LoadResult`).
+
+    ``on_tick`` is invoked from a side thread every ``tick_interval`` seconds
+    (e.g. to sample worker PIDs) for the duration of the run.
+    """
+    deadline = time.monotonic() + duration_s
+    stop = threading.Event()
+    lock = threading.Lock()
+    counters = {"ok": 0, "failed": 0, "retried": 0}
+    errors: collections.Counter[str] = collections.Counter()
+
+    def worker() -> None:
+        ok = 0
+        failed = 0
+        retried = 0
+        local_errors: collections.Counter[str] = collections.Counter()
+        with httpx.Client(timeout=timeout_s) as client:
+            while not stop.is_set() and time.monotonic() < deadline:
+                succeeded = False
+                had_retry = False
+                for attempt in range(max_attempts):
+                    try:
+                        response = client.get(url)
+                        if response.status_code < 500:
+                            succeeded = True
+                            break
+                        local_errors[f"status={response.status_code}"] += 1
+                    except httpx.HTTPError as exc:
+                        local_errors[type(exc).__name__] += 1
+                    had_retry = True
+                    time.sleep(0.02 * (attempt + 1))
+                if succeeded:
+                    ok += 1
+                    if had_retry:
+                        retried += 1
+                else:
+                    failed += 1
+        with lock:
+            counters["ok"] += ok
+            counters["failed"] += failed
+            counters["retried"] += retried
+            errors.update(local_errors)
+
+    def ticker() -> None:
+        while not stop.is_set() and time.monotonic() < deadline:
+            if on_tick is not None:
+                on_tick()
+            time.sleep(tick_interval)
+
+    threads = [threading.Thread(target=worker, name=f"load-{i}") for i in range(concurrency)]
+    tick_thread = threading.Thread(target=ticker, name="load-ticker") if on_tick is not None else None
+    for thread in threads:
+        thread.start()
+    if tick_thread is not None:
+        tick_thread.start()
+    try:
+        for thread in threads:
+            thread.join()
+    finally:
+        stop.set()
+        if tick_thread is not None:
+            tick_thread.join()
+
+    return LoadResult(
+        ok=counters["ok"],
+        failed=counters["failed"],
+        retried=counters["retried"],
+        errors=dict(errors),
+    )
 
 
 def get_free_port(host: str = DEFAULT_HOST) -> int:

--- a/python/tests/integration/test_worker_recycling_integration.py
+++ b/python/tests/integration/test_worker_recycling_integration.py
@@ -30,6 +30,7 @@ import pytest
 
 from django_bolt.workers import MIB, get_rss_bytes
 
+from .apps import app_module
 from .helpers import SimpleWebSocketClient, child_pids, generate_load
 
 pytestmark = pytest.mark.server_integration
@@ -41,55 +42,6 @@ _requires_posix = pytest.mark.skipif(
     platform.system() == "Windows",
     reason="worker recycling under load requires POSIX fork + /proc RSS reading",
 )
-
-PID_API_BODY = """
-import os
-
-
-@api.get("/pid")
-async def pid():
-    return {"pid": os.getpid()}
-
-
-@api.get("/die")
-async def die():
-    os._exit(1)
-"""
-
-# A deliberately leaky app: each /leak request retains memory forever, so a
-# worker's RSS climbs without bound until --max-rss recycles it. 16 KiB/request
-# makes RSS climb fast enough that, without recycling, workers would blow far
-# past the limit within the load window — so a worker seen back near baseline
-# is unambiguous proof that recycling reset it.
-LEAK_API_BODY = """
-import os
-
-_LEAK = []
-
-
-@api.get("/leak")
-async def leak():
-    _LEAK.append(bytearray(16384))  # retain 16 KiB per request == a memory leak
-    return {"pid": os.getpid(), "chunks": len(_LEAK)}
-"""
-
-WS_ECHO_API_BODY = """
-@api.websocket("/ws/echo")
-async def echo(websocket: WebSocket):
-    await websocket.accept()
-    async for message in websocket.iter_text():
-        await websocket.send_text(f"echo:{message}")
-"""
-
-
-def _peak_worker_rss_mib(supervisor_pid: int) -> float:
-    """Largest current RSS (MiB) across the supervisor's worker children."""
-    peak = 0.0
-    for pid in child_pids(supervisor_pid):
-        rss = get_rss_bytes(pid)
-        if rss is not None:
-            peak = max(peak, rss / MIB)
-    return peak
 
 
 def _receive_close_skipping_pings(websocket: SimpleWebSocketClient) -> tuple[int, str]:
@@ -110,7 +62,7 @@ def _wait_for_pid_change(server, first_pid: int, timeout: float = RECYCLE_TIMEOU
 
 
 def test_sigterm_closes_websockets_with_service_restart_code(make_server_project):
-    project = make_server_project(project_api_body=WS_ECHO_API_BODY)
+    project = make_server_project(api_module=app_module("recycling_ws_echo"))
 
     with (
         project.start() as server,
@@ -134,7 +86,7 @@ def test_sigterm_closes_websockets_with_service_restart_code(make_server_project
 
 
 def test_workers_lifetime_recycles_worker_without_downtime(make_server_project):
-    project = make_server_project(project_api_body=PID_API_BODY)
+    project = make_server_project(api_module=app_module("recycling_pid"))
 
     with project.start(
         extra_args=["--workers-lifetime", "2", "--workers-kill-timeout", "5"],
@@ -159,7 +111,7 @@ def test_workers_lifetime_recycles_under_load_without_dropping_requests(make_ser
     dropped connection or a gap with no accepting process would show up as a
     non-zero failure count.
     """
-    project = make_server_project(project_api_body=PID_API_BODY)
+    project = make_server_project(api_module=app_module("recycling_pid"))
 
     with project.start(
         processes=2,
@@ -204,7 +156,7 @@ def test_max_rss_recycles_leaking_app_under_load_with_bounded_memory(make_server
       (verified via a no-recycle control), and
     - not a single request is dropped despite the constant churn.
     """
-    project = make_server_project(project_api_body=LEAK_API_BODY)
+    project = make_server_project(api_module=app_module("recycling_leak"))
 
     # Measure a fresh worker's baseline RSS so the limit is above idle memory —
     # this exercises the *leak-driven* recycle path, not an immediate trip.
@@ -268,7 +220,7 @@ def test_max_rss_recycles_leaking_app_under_load_with_bounded_memory(make_server
 
 
 def test_max_rss_recycles_worker(make_server_project):
-    project = make_server_project(project_api_body=PID_API_BODY)
+    project = make_server_project(api_module=app_module("recycling_pid"))
 
     # 1 MiB is far below any real worker's baseline RSS, so the very first
     # RSS check trips the limit — exercising the full CLI → supervisor →
@@ -282,7 +234,7 @@ def test_max_rss_recycles_worker(make_server_project):
 
 
 def test_respawn_failed_workers_replaces_crashed_worker(make_server_project):
-    project = make_server_project(project_api_body=PID_API_BODY)
+    project = make_server_project(api_module=app_module("recycling_pid"))
 
     with project.start(extra_args=["--respawn-failed-workers"]) as server:
         first_pid = server.get("/pid").json()["pid"]

--- a/python/tests/integration/test_worker_recycling_integration.py
+++ b/python/tests/integration/test_worker_recycling_integration.py
@@ -4,26 +4,43 @@ Covers the real ``runbolt`` server:
 
 - SIGTERM closes active WebSocket connections with 1012 (Service Restart)
   instead of dropping them abruptly.
-- ``--workers-lifetime`` recycles workers (new PID) while the server keeps
-  serving throughout (spawn-first via SO_REUSEPORT).
+- ``--workers-lifetime`` recycles workers (new PID) *while the server is under
+  concurrent HTTP load*, without dropping requests (spawn-first via
+  SO_REUSEPORT).
+- ``--max-rss`` recycles a real memory-leaking app under sustained load,
+  keeping resident memory bounded while still serving every request.
 - ``--respawn-failed-workers`` replaces a crashed worker.
+
+The load-based tests are the teeth behind the "no downtime" claim: a recycle
+that silently reset the fleet or dropped in-flight requests would surface here
+as non-zero failures. Load is generated in-process with ``httpx`` (see
+``helpers.generate_load``) so the suite has no external load-tool dependency.
 """
 
 from __future__ import annotations
 
 import contextlib
 import os
+import platform
 import signal
 import time
 
 import httpx
 import pytest
 
-from .helpers import SimpleWebSocketClient
+from django_bolt.workers import MIB, get_rss_bytes
+
+from .helpers import SimpleWebSocketClient, child_pids, generate_load
 
 pytestmark = pytest.mark.server_integration
 
 RECYCLE_TIMEOUT = 30.0
+
+# child_pids()/get_rss_bytes() rely on POSIX /proc + ps and fork-based workers.
+_requires_posix = pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="worker recycling under load requires POSIX fork + /proc RSS reading",
+)
 
 PID_API_BODY = """
 import os
@@ -39,6 +56,23 @@ async def die():
     os._exit(1)
 """
 
+# A deliberately leaky app: each /leak request retains memory forever, so a
+# worker's RSS climbs without bound until --max-rss recycles it. 16 KiB/request
+# makes RSS climb fast enough that, without recycling, workers would blow far
+# past the limit within the load window — so a worker seen back near baseline
+# is unambiguous proof that recycling reset it.
+LEAK_API_BODY = """
+import os
+
+_LEAK = []
+
+
+@api.get("/leak")
+async def leak():
+    _LEAK.append(bytearray(16384))  # retain 16 KiB per request == a memory leak
+    return {"pid": os.getpid(), "chunks": len(_LEAK)}
+"""
+
 WS_ECHO_API_BODY = """
 @api.websocket("/ws/echo")
 async def echo(websocket: WebSocket):
@@ -46,6 +80,16 @@ async def echo(websocket: WebSocket):
     async for message in websocket.iter_text():
         await websocket.send_text(f"echo:{message}")
 """
+
+
+def _peak_worker_rss_mib(supervisor_pid: int) -> float:
+    """Largest current RSS (MiB) across the supervisor's worker children."""
+    peak = 0.0
+    for pid in child_pids(supervisor_pid):
+        rss = get_rss_bytes(pid)
+        if rss is not None:
+            peak = max(peak, rss / MIB)
+    return peak
 
 
 def _receive_close_skipping_pings(websocket: SimpleWebSocketClient) -> tuple[int, str]:
@@ -104,6 +148,125 @@ def test_workers_lifetime_recycles_worker_without_downtime(make_server_project):
 
         # Server keeps serving after the recycle.
         assert server.get("/health").json() == {"status": "ok"}
+
+
+@_requires_posix
+def test_workers_lifetime_recycles_under_load_without_dropping_requests(make_server_project):
+    """Recycle repeatedly *while under concurrent load* and drop nothing.
+
+    A short lifetime against a two-worker fleet forces several spawn-first
+    recycles during the load window. Every request must still succeed — a
+    dropped connection or a gap with no accepting process would show up as a
+    non-zero failure count.
+    """
+    project = make_server_project(project_api_body=PID_API_BODY)
+
+    with project.start(
+        processes=2,
+        extra_args=["--workers-lifetime", "2", "--workers-kill-timeout", "5"],
+    ) as server:
+        seen_workers: set[int] = set()
+        seen_workers.update(child_pids(server.process.pid))
+
+        result = generate_load(
+            server.url("/health"),
+            duration_s=10.0,
+            concurrency=16,
+            on_tick=lambda: seen_workers.update(child_pids(server.process.pid)),
+        )
+
+        recycles = len(seen_workers) - 2  # started with 2 workers
+        assert recycles >= 1, f"expected at least one recycle under load, saw {seen_workers}"
+        assert result.ok > 1000, f"load generator barely ran: {result.ok} ok requests"
+        # failed == request unserved after retries (true downtime). retried > 0 is
+        # expected and fine: graceful drain closes idle keep-alive connections and
+        # the client reconnects to a live worker.
+        assert result.failed == 0, (
+            f"requests were dropped during recycling: {result.failed}/{result.total} "
+            f"failed after retries (retried={result.retried}, errors={result.errors})"
+        )
+
+
+@_requires_posix
+def test_max_rss_recycles_leaking_app_under_load_with_bounded_memory(make_server_project):
+    """A real leaking app under load: --max-rss recycles it, memory stays bounded.
+
+    Bombard a two-worker fleet whose ``/leak`` endpoint retains memory on every
+    request. Without recycling, worker RSS climbs monotonically; with ``--max-rss``
+    the supervisor recycles each worker as it crosses the limit, so a fresh
+    replacement (RSS back near baseline) takes over. The test asserts:
+
+    - recycling actually happens under load (worker PIDs rotate),
+    - recycling *bounds* memory: a worker is observed back near baseline RSS in
+      the second half of the run. This can only happen if a grown worker was
+      replaced by a fresh one — without recycling every worker would be far above
+      baseline by then, so this assertion fails if recycling is disabled/broken
+      (verified via a no-recycle control), and
+    - not a single request is dropped despite the constant churn.
+    """
+    project = make_server_project(project_api_body=LEAK_API_BODY)
+
+    # Measure a fresh worker's baseline RSS so the limit is above idle memory —
+    # this exercises the *leak-driven* recycle path, not an immediate trip.
+    # Single-process mode runs the server in-process (no forked children), so
+    # read that process's own RSS.
+    with project.start(processes=1) as probe:
+        probe.get("/health")
+        time.sleep(0.5)
+        baseline_bytes = get_rss_bytes(probe.process.pid)
+    assert baseline_bytes, "could not read baseline worker RSS"
+    baseline_mib = baseline_bytes / MIB
+
+    limit_mib = int(baseline_mib + 40)
+    duration = 14.0
+
+    with project.start(
+        processes=2,
+        extra_args=["--max-rss", str(limit_mib), "--workers-kill-timeout", "3"],
+    ) as server:
+        start = time.monotonic()
+        seen_workers: set[int] = set()
+        peak_rss = 0.0
+        # Smallest worker RSS seen in the *second half* of the run. A recycle
+        # resets a worker to ~baseline; without recycling this stays high.
+        min_rss_late = float("inf")
+
+        def sample() -> None:
+            nonlocal peak_rss, min_rss_late
+            seen_workers.update(child_pids(server.process.pid))
+            current = [
+                get_rss_bytes(pid) for pid in child_pids(server.process.pid)
+            ]
+            live = [rss / MIB for rss in current if rss]
+            if live:
+                peak_rss = max(peak_rss, max(live))
+                if time.monotonic() - start > duration / 2:
+                    min_rss_late = min(min_rss_late, min(live))
+
+        result = generate_load(
+            server.url("/leak"),
+            duration_s=duration,
+            concurrency=16,
+            on_tick=sample,
+        )
+
+        recycles = len(seen_workers) - 2
+        assert recycles >= 2, (
+            f"leak did not drive recycles under load (limit={limit_mib}MiB, "
+            f"baseline={baseline_mib:.0f}MiB, workers seen={seen_workers})"
+        )
+        # A worker was reset to ~baseline after growing => recycling caps memory.
+        assert min_rss_late < baseline_mib + 25, (
+            f"no worker returned near baseline in the second half "
+            f"(min late RSS {min_rss_late:.0f}MiB, baseline {baseline_mib:.0f}MiB, "
+            f"peak {peak_rss:.0f}MiB) — recycling is not bounding memory"
+        )
+        assert result.ok > 1000, f"load generator barely ran: {result.ok} ok requests"
+        assert result.failed == 0, (
+            f"requests were dropped while recycling a leaking app: "
+            f"{result.failed}/{result.total} failed after retries "
+            f"(retried={result.retried}, errors={result.errors})"
+        )
 
 
 def test_max_rss_recycles_worker(make_server_project):

--- a/python/tests/integration/test_worker_recycling_integration.py
+++ b/python/tests/integration/test_worker_recycling_integration.py
@@ -1,0 +1,135 @@
+"""Integration tests for worker recycling and graceful shutdown.
+
+Covers the real ``runbolt`` server:
+
+- SIGTERM closes active WebSocket connections with 1012 (Service Restart)
+  instead of dropping them abruptly.
+- ``--workers-lifetime`` recycles workers (new PID) while the server keeps
+  serving throughout (spawn-first via SO_REUSEPORT).
+- ``--respawn-failed-workers`` replaces a crashed worker.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import signal
+import time
+
+import httpx
+import pytest
+
+from .helpers import SimpleWebSocketClient
+
+pytestmark = pytest.mark.server_integration
+
+RECYCLE_TIMEOUT = 30.0
+
+PID_API_BODY = """
+import os
+
+
+@api.get("/pid")
+async def pid():
+    return {"pid": os.getpid()}
+
+
+@api.get("/die")
+async def die():
+    os._exit(1)
+"""
+
+WS_ECHO_API_BODY = """
+@api.websocket("/ws/echo")
+async def echo(websocket: WebSocket):
+    await websocket.accept()
+    async for message in websocket.iter_text():
+        await websocket.send_text(f"echo:{message}")
+"""
+
+
+def _receive_close_skipping_pings(websocket: SimpleWebSocketClient) -> tuple[int, str]:
+    """Receive frames until a close frame arrives (heartbeat pings may interleave)."""
+    for _ in range(10):
+        opcode, payload = websocket._receive_frame()
+        if opcode == 0x8:
+            if len(payload) >= 2:
+                return int.from_bytes(payload[:2], "big"), payload[2:].decode("utf-8")
+            return 1005, ""
+        assert opcode in (0x9, 0xA), f"Unexpected frame opcode {opcode} while waiting for close"
+    raise AssertionError("No close frame received")
+
+
+def _wait_for_pid_change(server, first_pid: int, timeout: float = RECYCLE_TIMEOUT) -> int:
+    payload = server.wait_for_json("/pid", lambda data: data["pid"] != first_pid, timeout=timeout)
+    return payload["pid"]
+
+
+def test_sigterm_closes_websockets_with_service_restart_code(make_server_project):
+    project = make_server_project(project_api_body=WS_ECHO_API_BODY)
+
+    with (
+        project.start() as server,
+        SimpleWebSocketClient(server.host, server.port, "/ws/echo") as websocket,
+    ):
+        websocket.send_text("hello")
+        assert websocket.receive_text() == "echo:hello"
+
+        # Signal the server directly (single process == the server itself).
+        os.kill(server.process.pid, signal.SIGTERM)
+
+        code, reason = _receive_close_skipping_pings(websocket)
+
+    assert code == 1012, f"Expected 1012 Service Restart close, got {code} ({reason!r})"
+
+    # The server must also actually exit (graceful stop, not a hang).
+    deadline = time.time() + 15.0
+    while server.process.poll() is None and time.time() < deadline:
+        time.sleep(0.1)
+    assert server.process.poll() is not None, "Server did not exit after SIGTERM"
+
+
+def test_workers_lifetime_recycles_worker_without_downtime(make_server_project):
+    project = make_server_project(project_api_body=PID_API_BODY)
+
+    with project.start(
+        extra_args=["--workers-lifetime", "2", "--workers-kill-timeout", "5"],
+    ) as server:
+        first_pid = server.get("/pid").json()["pid"]
+        # The supervisor forks workers, so the worker is not the manage.py process.
+        assert first_pid != server.process.pid
+
+        new_pid = _wait_for_pid_change(server, first_pid)
+        assert new_pid != first_pid
+
+        # Server keeps serving after the recycle.
+        assert server.get("/health").json() == {"status": "ok"}
+
+
+def test_max_rss_recycles_worker(make_server_project):
+    project = make_server_project(project_api_body=PID_API_BODY)
+
+    # 1 MiB is far below any real worker's baseline RSS, so the very first
+    # RSS check trips the limit — exercising the full CLI → supervisor →
+    # /proc RSS read → graceful recycle path against a real worker.
+    with project.start(
+        extra_args=["--max-rss", "1", "--workers-kill-timeout", "5"],
+    ) as server:
+        first_pid = server.get("/pid").json()["pid"]
+        new_pid = _wait_for_pid_change(server, first_pid)
+        assert new_pid != first_pid
+
+
+def test_respawn_failed_workers_replaces_crashed_worker(make_server_project):
+    project = make_server_project(project_api_body=PID_API_BODY)
+
+    with project.start(extra_args=["--respawn-failed-workers"]) as server:
+        first_pid = server.get("/pid").json()["pid"]
+
+        # os._exit(1) kills the worker mid-request; the connection drops.
+        with contextlib.suppress(httpx.HTTPError):
+            server.get("/die")
+
+        new_pid = _wait_for_pid_change(server, first_pid)
+        assert new_pid != first_pid
+        assert server.get("/health").json() == {"status": "ok"}

--- a/python/tests/integration/test_worker_recycling_integration.py
+++ b/python/tests/integration/test_worker_recycling_integration.py
@@ -234,9 +234,7 @@ def test_max_rss_recycles_leaking_app_under_load_with_bounded_memory(make_server
         def sample() -> None:
             nonlocal peak_rss, min_rss_late
             seen_workers.update(child_pids(server.process.pid))
-            current = [
-                get_rss_bytes(pid) for pid in child_pids(server.process.pid)
-            ]
+            current = [get_rss_bytes(pid) for pid in child_pids(server.process.pid)]
             live = [rss / MIB for rss in current if rss]
             if live:
                 peak_rss = max(peak_rss, max(live))

--- a/python/tests/test_worker_supervisor.py
+++ b/python/tests/test_worker_supervisor.py
@@ -1,0 +1,273 @@
+"""Unit tests for the runbolt worker supervisor (RSS/lifetime recycling).
+
+These tests drive :class:`django_bolt.workers.WorkerSupervisor` deterministically
+through injected fakes (clock, spawn, kill, waitpid, RSS reader) — no real
+processes are forked. Real-server behavior is covered by
+``integration/test_worker_recycling_integration.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+
+import pytest
+
+from django_bolt.workers import WorkerSupervisor, get_rss_bytes
+
+MIB = 1024 * 1024
+
+
+class FakeWorkerEnv:
+    """Deterministic stand-in for the OS process APIs the supervisor uses.
+
+    Records every spawn and signal into a single ``events`` list so tests can
+    assert ordering (e.g. replacement spawned *before* the old worker is
+    terminated).
+    """
+
+    def __init__(self):
+        self.now = 0.0
+        self.next_pid = 100
+        self.alive: set[int] = set()
+        self.exited: list[tuple[int, int]] = []
+        self.rss: dict[int, int | None] = {}
+        self.events: list[tuple] = []
+
+    def spawn(self, slot: int) -> int:
+        pid = self.next_pid
+        self.next_pid += 1
+        self.alive.add(pid)
+        self.events.append(("spawn", slot, pid))
+        return pid
+
+    def kill(self, pid: int, signum: int) -> None:
+        if pid not in self.alive:
+            raise ProcessLookupError(pid)
+        self.events.append(("signal", pid, signum))
+        if signum == signal.SIGKILL:
+            self.exit(pid, -signal.SIGKILL)
+
+    def exit(self, pid: int, status: int = 0) -> None:
+        if pid in self.alive:
+            self.alive.remove(pid)
+            self.exited.append((pid, status))
+
+    def waitpid(self, pid: int, flags: int) -> tuple[int, int]:
+        if self.exited:
+            return self.exited.pop(0)
+        if not self.alive:
+            raise ChildProcessError
+        return (0, 0)
+
+    def clock(self) -> float:
+        return self.now
+
+    def rss_reader(self, pid: int) -> int | None:
+        return self.rss.get(pid)
+
+    def signals(self) -> list[tuple[int, int]]:
+        return [(pid, signum) for kind, pid, signum in self.events if kind == "signal"]
+
+    def spawns(self) -> list[tuple[int, int]]:
+        return [(slot, pid) for kind, slot, pid in self.events if kind == "spawn"]
+
+
+def make_supervisor(env: FakeWorkerEnv, **kwargs) -> WorkerSupervisor:
+    defaults = {
+        "processes": 1,
+        "spawn": env.spawn,
+        "kill": env.kill,
+        "waitpid": env.waitpid,
+        "rss_reader": env.rss_reader,
+        "clock": env.clock,
+        "kill_timeout": 10.0,
+        "log": lambda _message: None,
+    }
+    defaults.update(kwargs)
+    return WorkerSupervisor(**defaults)
+
+
+def test_start_spawns_one_worker_per_slot():
+    env = FakeWorkerEnv()
+    supervisor = make_supervisor(env, processes=3)
+    supervisor.start()
+    assert env.spawns() == [(0, 100), (1, 101), (2, 102)]
+    assert supervisor.active_worker_count() == 3
+
+
+def test_rss_over_limit_spawns_replacement_before_terminating_old_worker():
+    env = FakeWorkerEnv()
+    supervisor = make_supervisor(env, max_rss_bytes=100 * MIB)
+    supervisor.start()
+    old_pid = env.spawns()[0][1]
+
+    env.rss[old_pid] = 200 * MIB
+    supervisor.tick()
+
+    # Replacement forked first (port stays covered via SO_REUSEPORT),
+    # SIGTERM to the old worker second.
+    assert env.events == [
+        ("spawn", 0, old_pid),
+        ("spawn", 0, old_pid + 1),
+        ("signal", old_pid, signal.SIGTERM),
+    ]
+
+
+def test_rss_under_limit_does_not_recycle():
+    env = FakeWorkerEnv()
+    supervisor = make_supervisor(env, max_rss_bytes=100 * MIB)
+    supervisor.start()
+    env.rss[100] = 50 * MIB
+    supervisor.tick()
+    assert env.signals() == []
+    assert len(env.spawns()) == 1
+
+
+def test_recycled_worker_exit_is_reaped_without_respawn():
+    env = FakeWorkerEnv()
+    supervisor = make_supervisor(env, max_rss_bytes=100 * MIB, respawn_failed=True)
+    supervisor.start()
+    env.rss[100] = 200 * MIB
+    supervisor.tick()
+
+    # Old worker exits gracefully: reaped, no extra spawn beyond the replacement.
+    env.exit(100, 0)
+    supervisor.tick()
+    assert len(env.spawns()) == 2
+    assert supervisor.active_worker_count() == 1
+    assert not supervisor.has_draining_workers()
+
+
+def test_draining_worker_gets_sigkill_after_kill_timeout():
+    env = FakeWorkerEnv()
+    supervisor = make_supervisor(env, max_rss_bytes=100 * MIB, kill_timeout=10.0)
+    supervisor.start()
+    env.rss[100] = 200 * MIB
+    supervisor.tick()
+    assert (100, signal.SIGTERM) in env.signals()
+
+    # Worker refuses to exit: after the kill timeout it is SIGKILLed.
+    env.now = 9.0
+    supervisor.tick()
+    assert (100, signal.SIGKILL) not in env.signals()
+    env.now = 11.0
+    supervisor.tick()
+    assert (100, signal.SIGKILL) in env.signals()
+
+
+def test_lifetime_exceeded_recycles_worker():
+    env = FakeWorkerEnv()
+    supervisor = make_supervisor(env, lifetime_seconds=60.0)
+    supervisor.start()
+
+    env.now = 59.0
+    supervisor.tick()
+    assert env.signals() == []
+
+    env.now = 61.0
+    supervisor.tick()
+    assert env.spawns() == [(0, 100), (0, 101)]
+    assert env.signals() == [(100, signal.SIGTERM)]
+
+
+def test_at_most_one_recycle_per_tick():
+    env = FakeWorkerEnv()
+    supervisor = make_supervisor(env, processes=2, max_rss_bytes=100 * MIB)
+    supervisor.start()
+    env.rss[100] = 200 * MIB
+    env.rss[101] = 200 * MIB
+
+    supervisor.tick()
+    assert len(env.signals()) == 1
+
+    supervisor.tick()
+    assert len(env.signals()) == 2
+
+
+def test_unexpected_exit_respawns_when_enabled():
+    env = FakeWorkerEnv()
+    supervisor = make_supervisor(env, respawn_failed=True)
+    supervisor.start()
+
+    env.exit(100, 1)
+    supervisor.tick()
+    assert env.spawns() == [(0, 100), (0, 101)]
+    assert supervisor.active_worker_count() == 1
+
+
+def test_unexpected_exit_not_respawned_when_disabled():
+    env = FakeWorkerEnv()
+    supervisor = make_supervisor(env, respawn_failed=False)
+    supervisor.start()
+
+    env.exit(100, 1)
+    supervisor.tick()
+    assert env.spawns() == [(0, 100)]
+    assert supervisor.active_worker_count() == 0
+
+
+def test_shutdown_terminates_all_workers_and_reaps():
+    env = FakeWorkerEnv()
+    supervisor = make_supervisor(env, processes=2)
+    supervisor.start()
+
+    supervisor.request_shutdown()
+    supervisor.tick()
+    assert sorted(env.signals()) == [(100, signal.SIGTERM), (101, signal.SIGTERM)]
+
+    env.exit(100, 0)
+    env.exit(101, 0)
+    supervisor.tick()
+    assert supervisor.active_worker_count() == 0
+    assert not supervisor.has_draining_workers()
+
+
+def test_shutdown_does_not_respawn_exiting_workers():
+    env = FakeWorkerEnv()
+    supervisor = make_supervisor(env, respawn_failed=True)
+    supervisor.start()
+
+    supervisor.request_shutdown()
+    env.exit(100, 0)
+    supervisor.tick()
+    assert env.spawns() == [(0, 100)]
+
+
+def test_second_shutdown_request_forces_sigkill():
+    env = FakeWorkerEnv()
+    supervisor = make_supervisor(env, kill_timeout=30.0)
+    supervisor.start()
+
+    supervisor.request_shutdown()
+    supervisor.tick()
+    assert env.signals() == [(100, signal.SIGTERM)]
+
+    supervisor.request_shutdown()  # e.g. second Ctrl-C
+    supervisor.tick()
+    assert (100, signal.SIGKILL) in env.signals()
+
+
+def test_rss_reader_failure_is_not_a_recycle():
+    env = FakeWorkerEnv()
+    supervisor = make_supervisor(env, max_rss_bytes=100 * MIB)
+    supervisor.start()
+    env.rss[100] = None  # e.g. /proc read failed
+    supervisor.tick()
+    assert env.signals() == []
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="RSS reading is POSIX-only")
+def test_get_rss_bytes_reads_own_process():
+    rss = get_rss_bytes(os.getpid())
+    assert rss is not None
+    assert rss > MIB  # a running CPython interpreter is always > 1 MiB resident
+
+
+def test_get_rss_bytes_returns_none_for_dead_pid():
+    # Spawn a child that exits immediately; after wait() reaps it, the PID is gone.
+    child = subprocess.Popen([sys.executable, "-c", "pass"])
+    child.wait()
+    assert get_rss_bytes(child.pid) is None

--- a/src/server.rs
+++ b/src/server.rs
@@ -812,6 +812,14 @@ pub fn start_server(
                     .map(|seconds| KeepAlive::Timeout(std::time::Duration::from_secs(seconds)))
                     .unwrap_or(KeepAlive::Os);
 
+                // Graceful-shutdown window: how long in-flight connections get
+                // to finish after a shutdown signal before being force-closed.
+                // The runbolt supervisor sets this to --workers-kill-timeout.
+                let shutdown_timeout: u64 = std::env::var("DJANGO_BOLT_SHUTDOWN_TIMEOUT")
+                    .ok()
+                    .and_then(|s| s.parse::<u64>().ok())
+                    .unwrap_or(30);
+
                 {
                     let server = HttpServer::new(move || {
                         let mut app = App::new()
@@ -880,6 +888,10 @@ pub fn start_server(
                     })
                     .keep_alive(keep_alive)
                     .client_request_timeout(std::time::Duration::from_secs(0))
+                    // Signals are handled by our own task below (WebSocket
+                    // drain must run before the Actix graceful stop).
+                    .disable_signals()
+                    .shutdown_timeout(shutdown_timeout)
                     .workers(workers);
 
                     let use_reuse_port = std::env::var("DJANGO_BOLT_REUSE_PORT")
@@ -923,11 +935,26 @@ pub fn start_server(
                     listener
                         .set_nonblocking(true)
                         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
-                    server
+                    let server = server
                         .listen(listener)
                         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
-                        .run()
-                        .await
+                        .run();
+
+                    // Custom shutdown sequencing (Actix signals disabled above):
+                    // 1. close WebSocket connections with 1012 Service Restart so
+                    //    clients reconnect to a healthy worker,
+                    // 2. graceful Actix stop (drain in-flight HTTP up to
+                    //    shutdown_timeout). SIGTERM drains gracefully;
+                    //    SIGINT/SIGQUIT stop immediately (Actix's default
+                    //    per-signal semantics).
+                    let handle = server.handle();
+                    aw::rt::spawn(async move {
+                        let graceful = wait_for_shutdown_signal().await;
+                        crate::websocket::begin_drain();
+                        handle.stop(graceful).await;
+                    });
+
+                    server.await
                 }
             })
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("{:?}", e)))
@@ -935,6 +962,50 @@ pub fn start_server(
     .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("Server error: {}", e)))?;
 
     Ok(())
+}
+
+/// Wait for a shutdown signal. Returns `true` for graceful shutdown (SIGTERM)
+/// and `false` for immediate shutdown (SIGINT/SIGQUIT), mirroring
+/// actix-server's default per-signal semantics.
+#[cfg(unix)]
+async fn wait_for_shutdown_signal() -> bool {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    // If a handler cannot be installed, log it and never resolve that arm:
+    // the remaining signals still work, and the OS default disposition was
+    // already replaced only for successfully-installed handlers.
+    async fn recv_or_pending(sig: std::io::Result<tokio::signal::unix::Signal>, name: &str) {
+        match sig {
+            Ok(mut s) => {
+                s.recv().await;
+            }
+            Err(e) => {
+                eprintln!(
+                    "[django-bolt] Failed to install {} handler: {}; graceful shutdown for this signal is disabled",
+                    name, e
+                );
+                std::future::pending::<()>().await;
+            }
+        }
+    }
+
+    tokio::select! {
+        _ = recv_or_pending(signal(SignalKind::terminate()), "SIGTERM") => true,
+        _ = recv_or_pending(signal(SignalKind::interrupt()), "SIGINT") => false,
+        _ = recv_or_pending(signal(SignalKind::quit()), "SIGQUIT") => false,
+    }
+}
+
+#[cfg(not(unix))]
+async fn wait_for_shutdown_signal() -> bool {
+    if let Err(e) = tokio::signal::ctrl_c().await {
+        eprintln!(
+            "[django-bolt] Failed to install Ctrl-C handler: {}; graceful shutdown is disabled",
+            e
+        );
+        std::future::pending::<()>().await;
+    }
+    false
 }
 
 /// Guard function to detect WebSocket upgrade requests

--- a/src/websocket/actor.rs
+++ b/src/websocket/actor.rs
@@ -12,6 +12,9 @@ use super::config::WS_CONFIG;
 use super::messages::{SendToClient, WsMessage};
 use super::ACTIVE_WS_CONNECTIONS;
 
+/// How often each connection polls the process-wide drain flag.
+const DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
 /// WebSocket actor that bridges Actix and Python
 pub struct WebSocketActor {
     /// Client heartbeat tracking
@@ -61,6 +64,23 @@ impl WebSocketActor {
         });
     }
 
+    /// Poll the process-wide drain flag; when the server begins shutting
+    /// down (stop or recycle), close the connection with 1012 (Service
+    /// Restart) so clients know to reconnect — they'll land on a healthy
+    /// worker via SO_REUSEPORT.
+    fn start_drain_watch(&self, ctx: &mut ws::WebsocketContext<Self>) {
+        ctx.run_interval(DRAIN_POLL_INTERVAL, |act, ctx| {
+            if super::is_draining() && act.close_code.is_none() {
+                act.close_code = Some(1012);
+                ctx.close(Some(ws::CloseReason {
+                    code: ws::CloseCode::Restart,
+                    description: Some("server restarting".to_string()),
+                }));
+                ctx.stop();
+            }
+        });
+    }
+
     /// Close connection with error code when Python channel fails
     fn close_on_channel_error(&mut self, ctx: &mut ws::WebsocketContext<Self>, error: &str) {
         eprintln!("[django-bolt] {}", error);
@@ -78,6 +98,7 @@ impl Actor for WebSocketActor {
 
     fn started(&mut self, ctx: &mut Self::Context) {
         self.start_heartbeat(ctx);
+        self.start_drain_watch(ctx);
     }
 
     fn stopped(&mut self, _ctx: &mut Self::Context) {

--- a/src/websocket/handler.rs
+++ b/src/websocket/handler.rs
@@ -469,6 +469,14 @@ pub async fn handle_websocket_upgrade_with_handler(
         return Ok(HttpResponse::BadRequest().body("Expected WebSocket upgrade request"));
     }
 
+    // Refuse new connections while draining for shutdown/recycle; clients
+    // that retry will land on a healthy worker via SO_REUSEPORT.
+    if super::is_draining() {
+        return Ok(HttpResponse::ServiceUnavailable()
+            .content_type("application/json")
+            .body(r#"{"detail":"Server is shutting down"}"#));
+    }
+
     // Check connection limit FIRST (before any processing)
     let current_connections = ACTIVE_WS_CONNECTIONS.load(Ordering::Relaxed);
     if current_connections >= config.max_connections {

--- a/src/websocket/handler.rs
+++ b/src/websocket/handler.rs
@@ -471,6 +471,10 @@ pub async fn handle_websocket_upgrade_with_handler(
 
     // Refuse new connections while draining for shutdown/recycle; clients
     // that retry will land on a healthy worker via SO_REUSEPORT.
+    // Best-effort: the acceptor is usually torn down (handle.stop) right after
+    // draining begins, so most new upgrades are refused at the TCP layer before
+    // reaching here. This mainly covers an upgrade racing in on an already-open
+    // keep-alive connection during the drain window.
     if super::is_draining() {
         return Ok(HttpResponse::ServiceUnavailable()
             .content_type("application/json")

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -18,7 +18,7 @@ mod handler;
 mod messages;
 mod router;
 
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 // Re-export public API
 #[allow(unused_imports)] // Re-exported for external use
@@ -34,3 +34,20 @@ pub use router::WebSocketRouter;
 
 /// Global counter for active WebSocket connections
 pub static ACTIVE_WS_CONNECTIONS: AtomicUsize = AtomicUsize::new(0);
+
+/// Process-wide flag: the server is shutting down or being recycled.
+///
+/// While draining, new WebSocket upgrades are refused with 503 and existing
+/// connections are closed with 1012 (Service Restart) so clients reconnect
+/// and land on a healthy worker (SO_REUSEPORT routes them there).
+static DRAINING: AtomicBool = AtomicBool::new(false);
+
+/// Begin draining WebSocket connections (called once on shutdown signal).
+pub fn begin_drain() {
+    DRAINING.store(true, Ordering::Release);
+}
+
+/// Whether the server is currently draining for shutdown/recycle.
+pub fn is_draining() -> bool {
+    DRAINING.load(Ordering::Acquire)
+}


### PR DESCRIPTION
Long-running servers accumulate resident memory from Python-level leaks
(C extensions, allocator fragmentation, unbounded caches). Gunicorn-style
servers work around this with max_requests restarts; request count is only
a proxy for memory, so recycle workers on the actual symptoms instead
(Granian's model):

- --max-rss <MiB>: recycle a worker once its RSS exceeds the threshold
  (read from /proc, ps fallback)
- --workers-lifetime <s>: recycle workers after a wall-clock lifetime
- --respawn-failed-workers: replace crashed workers (previously the fleet
  silently shrank; the parent only reaped)
- --workers-kill-timeout <s>: graceful window before SIGKILL (also sets
  the in-server Actix shutdown timeout via DJANGO_BOLT_SHUTDOWN_TIMEOUT)

Recycling is spawn-first: the replacement worker binds the port through
SO_REUSEPORT before the old worker gets SIGTERM, so the port always has
an accepting process. The supervisor (new django_bolt/workers.py, fully
dependency-injected for unit testing) recycles at most one worker per
tick to stagger fleet-wide limit breaches.

WebSocket connections can't be migrated across processes, so make the
disconnect clean instead of abrupt: the Rust server now installs its own
signal handling (Actix signals disabled), and on SIGTERM closes every
WebSocket with code 1012 (Service Restart) so clients know to reconnect
to a healthy worker, refuses new upgrades with 503 while draining, then
performs the graceful Actix stop for in-flight HTTP. SIGINT/SIGQUIT keep
their immediate-stop semantics. This same drain runs for plain SIGTERM
(systemd stop, kubectl delete pod), not just recycling.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CHDRhBqnEAykcM7nD9GPv9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Yes—the PR touches the hot path for **WebSocket upgrade/connection lifecycle**, not the normal HTTP request-handling path.

What’s on the hot path:
- **WebSocket upgrade requests:** `handle_websocket_upgrade_with_handler` adds an early draining guard. If `is_draining()` is true, it immediately returns **503** with `{"detail":"Server is shutting down"}` before the connection-limit check and before the rest of the upgrade/auth/rate-limit/origin/actor setup work.
- **Established WebSocket connections:** each `WebSocketActor` starts a per-connection drain watcher (`start_drain_watch`) that runs every **250ms** and, once draining begins, closes the connection with close code **1012** (“Service Restart”) and stops the actor.

Why this isn’t “stupid work” affecting regular HTTP traffic:
- The new logic is scoped to **WebSocket upgrade attempts** and **existing WebSocket connections** only; standard HTTP request handling does not pass through these draining checks.
- For upgrade requests, the overhead is just one cheap atomic flag check (`is_draining()`) plus an early return during draining.
- For existing WebSockets, the periodic work scales with the number of open WebSockets (not HTTP RPS) and is limited to an atomic load + conditional close/stop once draining is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->