### PR TITLE
fix(serialization): render Serializer response models via from_model+…

### DIFF
--- a/docs/src/topics/class-based-views.md
+++ b/docs/src/topics/class-based-views.md
@@ -163,6 +163,16 @@ class ArticleViewSet(ModelViewSet):
     pagination_class = PageNumberPagination
 ```
 
+### Serializer output
+
+When `serializer_class` is a `Serializer`, generated `list` and `retrieve`
+actions render models through `from_model()` + `dump()`. This preserves computed
+fields, inherited fields, `write_only` exclusions, aliases, `source` mapping,
+and nested serializers.
+
+Plain `msgspec.Struct` response models still use the faster `QuerySet.values()`
+projection path for raw column output.
+
 ### get_queryset
 
 Override to customize the queryset:

--- a/python/django_bolt/_kwargs/extractors.py
+++ b/python/django_bolt/_kwargs/extractors.py
@@ -922,8 +922,9 @@ def coerce_to_response_type(value: Any, annotation: Any, meta: HandlerMetadata |
         if meta and "response_field_names" in meta:
             field_names = meta["response_field_names"]
         else:
-            # Fallback: runtime introspection (slower)
-            field_names = list(getattr(annotation, "__annotations__", {}).keys())
+            field_names = list(
+                getattr(annotation, "__struct_fields__", None) or getattr(annotation, "__annotations__", {}).keys()
+            )
 
         mapped = {name: getattr(value, name, None) for name in field_names}
         try:

--- a/python/django_bolt/_kwargs/model.py
+++ b/python/django_bolt/_kwargs/model.py
@@ -57,12 +57,11 @@ def extract_response_metadata(response_type: Any) -> dict[str, Any]:
         args = get_args(response_type)
         if args:
             elem_type = args[0]
-            if is_msgspec_struct(elem_type):
-                # Extract field names for QuerySet.values() optimization
-                # This allows us to do: queryset.values("id", "username")
-                # instead of loading all fields and converting to dict
-                fields = getattr(elem_type, "__annotations__", {})
-                metadata["response_field_names"] = list(fields.keys())
+            if is_msgspec_struct(elem_type) and not getattr(elem_type, "__is_bolt_serializer__", False):
+                # __struct_fields__ includes inherited msgspec fields.
+                struct_fields = getattr(elem_type, "__struct_fields__", None)
+                if struct_fields:
+                    metadata["response_field_names"] = list(struct_fields)
 
     return metadata
 

--- a/python/django_bolt/exceptions.py
+++ b/python/django_bolt/exceptions.py
@@ -104,6 +104,10 @@ class SerializationError(BoltException, ValueError):
     """Server-side serialization misuse or unsupported serializer state."""
 
 
+class UnloadedRelationError(SerializationError):
+    """A sync serializer path needs an unloaded Django relation."""
+
+
 class RequestValidationError(ValidationException):
     """Request data validation error.
 

--- a/python/django_bolt/pagination.py
+++ b/python/django_bolt/pagination.py
@@ -33,6 +33,7 @@ import msgspec
 from asgiref.sync import sync_to_async
 
 from . import _json
+from .exceptions import UnloadedRelationError
 
 __all__ = [
     "PaginationBase",
@@ -244,6 +245,13 @@ class PaginationBase(ABC):
                     serializer_instances = None
                 else:
                     return serializer_class.dump_many(serializer_instances)
+
+            try:
+                serializer_instances = [serializer_class.from_model(item) for item in items]
+            except UnloadedRelationError:
+                pass
+            else:
+                return serializer_class.dump_many(serializer_instances)
 
             serializer_instances = list(await asyncio.gather(*(serializer_class.afrom_model(item) for item in items)))
             return serializer_class.dump_many(serializer_instances)

--- a/python/django_bolt/serialization.py
+++ b/python/django_bolt/serialization.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import mimetypes
 import types
@@ -35,7 +36,7 @@ from django.http import HttpResponseRedirect as DjangoHttpResponseRedirect
 from . import _json
 from ._kwargs import coerce_to_response_type, coerce_to_response_type_async
 from .cookies import Cookie
-from .exceptions import ResponseValidationError
+from .exceptions import ResponseValidationError, UnloadedRelationError
 from .responses import (
     HTML,
     JSON,
@@ -273,9 +274,149 @@ def _response_validation_is_required(annotation: Any) -> bool:
     return annotation not in _VALIDATION_NOOP_TYPES
 
 
+def _strip_optional(annotation: Any) -> Any:
+    origin = get_origin(annotation)
+    if origin in (Union, types.UnionType):
+        args = [a for a in get_args(annotation) if a is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    return annotation
+
+
+def _response_serializer_info(response_type: Any) -> tuple[Any, bool]:
+    """Return (serializer_class, many) for Serializer or list[Serializer]."""
+    rt = _strip_optional(response_type)
+
+    if _is_bolt_serializer(rt):
+        return rt, False
+
+    if get_origin(rt) is list:
+        args = get_args(rt)
+        if args:
+            item = _strip_optional(args[0])
+            if _is_bolt_serializer(item):
+                return item, True
+
+    return None, False
+
+
+def _dump_dict(serializer_cls: Any, value: dict, validate_dicts: bool) -> Any:
+    """Validate already-serialized dicts only when response validation is on."""
+    if not validate_dicts:
+        return value
+    return msgspec.convert(value, serializer_cls).dump()
+
+
+def _is_serializer_instance(value: Any) -> bool:
+    return getattr(value.__class__, "__is_bolt_serializer__", False)
+
+
+def _dump_one_sync(serializer_cls: Any, value: Any, validate_dicts: bool) -> Any:
+    if value is None:
+        return value
+    if _is_serializer_instance(value):
+        return value.dump()
+    if isinstance(value, dict):
+        return _dump_dict(serializer_cls, value, validate_dicts)
+    return serializer_cls.from_model(value).dump()
+
+
+async def _dump_one_async(serializer_cls: Any, value: Any, sync_safe: bool, validate_dicts: bool) -> Any:
+    if value is None:
+        return value
+    if _is_serializer_instance(value):
+        return value.dump()
+    if isinstance(value, dict):
+        return _dump_dict(serializer_cls, value, validate_dicts)
+    if sync_safe:
+        return serializer_cls.from_model(value).dump()
+    try:
+        return serializer_cls.from_model(value).dump()
+    except UnloadedRelationError:
+        pass
+    return (await serializer_cls.afrom_model(value)).dump()
+
+
+def _dump_many_sync(serializer_cls: Any, items: Any, validate_dicts: bool) -> list[Any]:
+    items = items if isinstance(items, list) else list(items)
+    if not items:
+        return items
+    first = items[0]
+    if isinstance(first, dict):
+        return [_dump_dict(serializer_cls, item, validate_dicts) for item in items]
+    if _is_serializer_instance(first):
+        return [item.dump() for item in items]
+    instances = [serializer_cls.from_model(item) for item in items]
+    return serializer_cls.dump_many(instances)
+
+
+async def _dump_many_async(serializer_cls: Any, items: Any, sync_safe: bool, validate_dicts: bool) -> list[Any]:
+    items = items if isinstance(items, list) else list(items)
+    if not items:
+        return items
+    first = items[0]
+    if isinstance(first, dict):
+        return [_dump_dict(serializer_cls, item, validate_dicts) for item in items]
+    if _is_serializer_instance(first):
+        return [item.dump() for item in items]
+    if sync_safe:
+        instances = [serializer_cls.from_model(item) for item in items]
+    else:
+        try:
+            instances = [serializer_cls.from_model(item) for item in items]
+        except UnloadedRelationError:
+            instances = list(await asyncio.gather(*(serializer_cls.afrom_model(item) for item in items)))
+    return serializer_cls.dump_many(instances)
+
+
+def _serializer_from_model_sync_safe(serializer_cls: Any) -> bool:
+    """True when async relation loading is unnecessary."""
+    serializer_cls._ensure_from_model_ready()
+    return not any(
+        spec.nested is not None or (spec.source is not None and "." in spec.source)
+        for spec in serializer_cls.__model_field_specs__
+    )
+
+
+def _compile_serializer_response_handlers(serializer_cls: Any, many: bool, validate_dicts: bool) -> tuple[Any, Any]:
+    """Compile normalizers that render model/queryset output via the serializer."""
+    sync_safe = _serializer_from_model_sync_safe(serializer_cls)
+
+    if many:
+
+        def normalize_sync(value: Any) -> Any:
+            if not isinstance(value, (list, tuple)):
+                return value
+            return _dump_many_sync(serializer_cls, value, validate_dicts)
+
+        async def normalize_async(value: Any) -> Any:
+            if not isinstance(value, (list, tuple)):
+                return value
+            return await _dump_many_async(serializer_cls, value, sync_safe, validate_dicts)
+
+        return normalize_sync, normalize_async
+
+    def normalize_sync(value: Any) -> Any:
+        return _dump_one_sync(serializer_cls, value, validate_dicts)
+
+    async def normalize_async(value: Any) -> Any:
+        return await _dump_one_async(serializer_cls, value, sync_safe, validate_dicts)
+
+    return normalize_sync, normalize_async
+
+
 def _compile_response_validator(meta: HandlerMetadata | dict[str, Any]) -> tuple[Any, Any]:
     response_type = meta.get("response_type")
-    if not meta.get("validate_response", True) or not _response_validation_is_required(response_type):
+    if not _response_validation_is_required(response_type):
+        return None, None
+
+    serializer_cls, many = _response_serializer_info(response_type)
+    if serializer_cls is not None:
+        return _compile_serializer_response_handlers(
+            serializer_cls, many, validate_dicts=meta.get("validate_response", True)
+        )
+
+    if not meta.get("validate_response", True):
         return None, None
 
     def validate_sync(value: Any) -> Any:
@@ -604,6 +745,22 @@ def compile_response_handlers(meta: HandlerMetadata | dict[str, Any]) -> None:
     stream_info = meta.get("_stream_info", (False, None))
     response_class = meta.get("response_class")
 
+    is_serializer_response = _response_serializer_info(meta.get("response_type"))[0] is not None
+
+    def prepare_list(result: list[Any]) -> Any:
+        if is_serializer_response:
+            return result
+        result = _convert_serializers(result)
+        if model_projector is not None and result and not isinstance(result[0], (dict, msgspec.Struct)):
+            return model_projector(result)
+        return result
+
+    def convert_serializer_result(result: Any) -> tuple[Any, bool]:
+        if is_serializer_response:
+            return result, False
+        converted = _convert_serializers(result)
+        return converted, converted is not result
+
     async def data_handler(result: Any, status_code: int | None = None) -> ResponseWireV1:
         current_status = default_status_code if status_code is None else status_code
 
@@ -613,12 +770,7 @@ def compile_response_handlers(meta: HandlerMetadata | dict[str, Any]) -> None:
         if isinstance(result, dict):
             return await _serialize_json_payload_async(result, current_status, validator_async)
         if isinstance(result, list):
-            result = _convert_serializers(result)
-            # When validate_response=False and list contains model instances (not dicts/Structs),
-            # project them to dicts using pre-compiled field names from the response type annotation.
-            if model_projector is not None and result and not isinstance(result[0], (dict, msgspec.Struct)):
-                result = model_projector(result)
-            return await _serialize_json_payload_async(result, current_status, validator_async)
+            return await _serialize_json_payload_async(prepare_list(result), current_status, validator_async)
         if isinstance(result, (bytes, bytearray)):
             return _wire_bytes(current_status, _RESPONSE_META_OCTETSTREAM, bytes(result))
         if isinstance(result, str):
@@ -628,9 +780,8 @@ def compile_response_handlers(meta: HandlerMetadata | dict[str, Any]) -> None:
         if auto_stream is not None:
             return _to_stream_wire(auto_stream)
 
-        original = result
-        result = _convert_serializers(result)
-        if result is not original:
+        result, was_converted = convert_serializer_result(result)
+        if was_converted:
             return await _serialize_json_payload_async(result, current_status, validator_async)
 
         if isinstance(result, QuerySet):
@@ -657,10 +808,7 @@ def compile_response_handlers(meta: HandlerMetadata | dict[str, Any]) -> None:
         if isinstance(result, dict):
             return _serialize_json_payload_sync(result, current_status, validator_sync)
         if isinstance(result, list):
-            result = _convert_serializers(result)
-            if model_projector is not None and result and not isinstance(result[0], (dict, msgspec.Struct)):
-                result = model_projector(result)
-            return _serialize_json_payload_sync(result, current_status, validator_sync)
+            return _serialize_json_payload_sync(prepare_list(result), current_status, validator_sync)
         if isinstance(result, (bytes, bytearray)):
             return _wire_bytes(current_status, _RESPONSE_META_OCTETSTREAM, bytes(result))
         if isinstance(result, str):
@@ -670,9 +818,8 @@ def compile_response_handlers(meta: HandlerMetadata | dict[str, Any]) -> None:
         if auto_stream is not None:
             return _to_stream_wire(auto_stream)
 
-        original = result
-        result = _convert_serializers(result)
-        if result is not original:
+        result, was_converted = convert_serializer_result(result)
+        if was_converted:
             return _serialize_json_payload_sync(result, current_status, validator_sync)
 
         if isinstance(result, QuerySet):

--- a/python/django_bolt/serialization.py
+++ b/python/django_bolt/serialization.py
@@ -300,6 +300,11 @@ def _response_serializer_info(response_type: Any) -> tuple[Any, bool]:
     return None, False
 
 
+def _annotation_may_need_relation_load(annotation: Any) -> bool:
+    annotation = _strip_optional(annotation)
+    return get_origin(annotation) in {list, tuple, set, frozenset}
+
+
 def _dump_dict(serializer_cls: Any, value: dict, validate_dicts: bool) -> Any:
     """Validate already-serialized dicts only when response validation is on."""
     if not validate_dicts:
@@ -372,8 +377,11 @@ async def _dump_many_async(serializer_cls: Any, items: Any, sync_safe: bool, val
 def _serializer_from_model_sync_safe(serializer_cls: Any) -> bool:
     """True when async relation loading is unnecessary."""
     serializer_cls._ensure_from_model_ready()
+    type_hints = getattr(serializer_cls, "__cached_type_hints__", {})
     return not any(
-        spec.nested is not None or (spec.source is not None and "." in spec.source)
+        spec.nested is not None
+        or spec.source is not None
+        or _annotation_may_need_relation_load(type_hints.get(spec.field_name))
         for spec in serializer_cls.__model_field_specs__
     )
 

--- a/python/django_bolt/serializers/base.py
+++ b/python/django_bolt/serializers/base.py
@@ -38,7 +38,7 @@ from msgspec import ValidationError as MsgspecValidationError
 from msgspec import structs as msgspec_structs
 
 from django_bolt import _json
-from django_bolt.exceptions import RequestValidationError, SerializationError
+from django_bolt.exceptions import RequestValidationError, SerializationError, UnloadedRelationError
 
 from .decorators import (
     ComputedFieldConfig,
@@ -62,6 +62,7 @@ T = TypeVar("T", bound="Serializer")
 _MISSING = object()
 _USE_DEFAULT = object()
 _STRUCT_META = type(msgspec.Struct)
+_MODEL_VALUE_NOOP_TYPES = (str, int, float, bool, bytes, type(None))
 
 
 @dataclass(frozen=True)
@@ -416,6 +417,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
 
     # _FieldMarker default resolution (populated by __init_subclass__)
     __field_marker_defaults__: ClassVar[dict[str, Any]] = {}  # field_name -> actual default value
+    __field_marker_fields__: ClassVar[tuple[str, ...]] = ()
 
     # Fast-path flags: Control which validation runs (set at class definition time)
     __skip_validation__: ClassVar[bool] = True  # Skip all validation
@@ -546,6 +548,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
         # Initialize with Meta values (will be updated by _lazy_collect_field_configs)
         cls.__field_configs__ = {}
         cls.__field_marker_defaults__ = {}
+        cls.__field_marker_fields__ = ()
         cls.__read_only_fields__ = frozenset(read_only)
         cls.__write_only_fields__ = frozenset(write_only)
         cls.__source_mapping__ = {}
@@ -707,7 +710,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
         """
         _setattr = msgspec_structs.force_setattr
 
-        for field_name in self.__struct_fields__:
+        for field_name in self.__class__.__field_marker_fields__:
             current_value = getattr(self, field_name)
 
             # Check if the current value is a _FieldMarker (meaning the user
@@ -731,6 +734,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
         msgspec has already processed the class and set __struct_defaults__.
         """
         field_configs: dict[str, FieldConfig] = {}
+        field_marker_fields: list[str] = []
         read_only: set[str] = set()
         write_only: set[str] = set()
         source_mapping: dict[str, str] = {}
@@ -740,6 +744,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
             if isinstance(default_val, _FieldMarker):
                 config = default_val.config
                 field_configs[field_name] = config
+                field_marker_fields.append(field_name)
 
                 if config.read_only:
                     read_only.add(field_name)
@@ -753,6 +758,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
         cls.__read_only_fields__ = cls.__read_only_fields__ | frozenset(read_only)
         cls.__write_only_fields__ = cls.__write_only_fields__ | frozenset(write_only)
         cls.__source_mapping__.update(source_mapping)
+        cls.__field_marker_fields__ = tuple(field_marker_fields)
 
         default_field_names = {field_name for field_name, _ in _iter_field_defaults(cls)}
         cls.__model_field_specs__ = tuple(
@@ -1213,7 +1219,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
         instance: Any,
     ) -> None:
         """Raise a descriptive error when sync from_model() would need ORM I/O."""
-        raise SerializationError(
+        raise UnloadedRelationError(
             f"{cls.__name__}.{field_name} requires loaded relation '{relation.source}' on "
             f"{instance.__class__.__name__} when using from_model(). Preload it with "
             f"{cls._relation_loading_hint(_DjangoRelationInfo(relation.relation_name, relation.relation_kind, relation.relation_name, None))} "
@@ -1351,6 +1357,10 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
                 return None
 
             is_last = idx == len(parts) - 1
+            if isinstance(current, DjangoModel) and part in current.__dict__:
+                current = current.__dict__[part]
+                continue
+
             relation = _get_django_relation_info(current.__class__, part) if isinstance(current, DjangoModel) else None
 
             if relation is not None:
@@ -1405,6 +1415,10 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
                 return None
 
             is_last = idx == len(parts) - 1
+            if isinstance(current, DjangoModel) and part in current.__dict__:
+                current = current.__dict__[part]
+                continue
+
             relation = _get_django_relation_info(current.__class__, part) if isinstance(current, DjangoModel) else None
 
             if relation is not None:
@@ -1444,6 +1458,8 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
     @classmethod
     def _convert_regular_from_model_value(cls, value: Any, *, field_name: str) -> Any:
         """Convert ORM-ish values into regular serializer output values."""
+        if value.__class__ in _MODEL_VALUE_NOOP_TYPES:
+            return value
         if isinstance(value, Choices):
             # Django keeps create()/acreate() choices as enum members in memory until
             # the instance is reloaded from the database. Normalize them here so
@@ -2329,7 +2345,7 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
             UserSerializer.dump_many(users)
         """
         cls._ensure_dump_ready()
-        instances_list = list(instances)
+        instances_list = instances if isinstance(instances, list) else list(instances)
 
         # FAST PATH: use msgspec native methods (significantly faster than Python iteration)
         if cls.__dump_fast_path__ and not exclude_none and not exclude_defaults and not exclude_unset and not by_alias:
@@ -2343,12 +2359,16 @@ class Serializer(msgspec.Struct, metaclass=_SerializerMeta):
             return [_asdict(instance) for instance in instances_list]
 
         # SLOW PATH: Need special handling (computed fields, write_only, exclude_*, etc.)
+        field_specs = cls._get_dump_field_specs()
+        computed_specs = cls._get_computed_dump_specs()
         return [
-            instance.dump(
+            instance._dump_impl(
                 exclude_none=exclude_none,
                 exclude_unset=exclude_unset,
                 exclude_defaults=exclude_defaults,
                 by_alias=by_alias,
+                field_specs=field_specs,
+                computed_specs=computed_specs,
             )
             for instance in instances_list
         ]
@@ -2550,12 +2570,15 @@ class SerializerView(Iterable[T]):
             List of filtered dictionary representations
         """
         return [
-            self.dump(
-                instance,
+            instance._dump_impl(
                 exclude_none=exclude_none,
                 exclude_unset=exclude_unset,
                 exclude_defaults=exclude_defaults,
                 by_alias=by_alias,
+                include_fields=self._include_fields,
+                exclude_fields=self._exclude_fields,
+                field_specs=self._field_specs,
+                computed_specs=self._computed_specs,
             )
             for instance in instances
         ]

--- a/python/tests/cbv/test_model_viewset_serializer_output.py
+++ b/python/tests/cbv/test_model_viewset_serializer_output.py
@@ -97,9 +97,7 @@ def test_plain_struct_viewset_keeps_values_projection(article):
         serializer_class = PlainArticle
 
     list_meta = next(
-        api._handler_meta[hid]
-        for method, path, hid, _h in api._routes
-        if method == "GET" and path == "/articles"
+        api._handler_meta[hid] for method, path, hid, _h in api._routes if method == "GET" and path == "/articles"
     )
     assert list_meta["response_field_names"] == ["id", "title", "content"]
 

--- a/python/tests/cbv/test_model_viewset_serializer_output.py
+++ b/python/tests/cbv/test_model_viewset_serializer_output.py
@@ -51,6 +51,11 @@ class PostOut(Serializer):
         return len(self.title)
 
 
+class AuthorPostIds(Serializer):
+    id: int
+    posts: list[int]
+
+
 @pytest.fixture
 def article():
     return Article.objects.create(title="hello", content="the body", author="A1")
@@ -91,7 +96,11 @@ def test_plain_struct_viewset_keeps_values_projection(article):
         queryset = Article.objects.all()
         serializer_class = PlainArticle
 
-    list_meta = next(api._handler_meta[hid] for _m, path, hid, _h in api._routes if path == "/articles")
+    list_meta = next(
+        api._handler_meta[hid]
+        for method, path, hid, _h in api._routes
+        if method == "GET" and path == "/articles"
+    )
     assert list_meta["response_field_names"] == ["id", "title", "content"]
 
     with TestClient(api) as client:
@@ -179,6 +188,22 @@ def test_unloaded_nested_serializer_falls_back_to_afrom_model():
                 "title_len": 4,
             }
         ]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_direct_reverse_relation_field_uses_async_fallback():
+    api = BoltAPI()
+    author = Author.objects.create(name="Ada", email="ada@x.io")
+    post = BlogPost.objects.create(title="Post", content="body", author=author)
+
+    @api.get("/authors", response_model=list[AuthorPostIds])
+    async def authors():
+        return Author.objects.all()
+
+    with TestClient(api) as client:
+        r = client.get("/authors")
+        assert r.status_code == 200, r.text
+        assert r.json() == [{"id": author.id, "posts": [post.id]}]
 
 
 @pytest.mark.django_db(transaction=True)

--- a/python/tests/cbv/test_model_viewset_serializer_output.py
+++ b/python/tests/cbv/test_model_viewset_serializer_output.py
@@ -1,0 +1,222 @@
+"""Regression tests for ModelViewSet serializer output."""
+
+from __future__ import annotations
+
+import msgspec
+import pytest
+
+from django_bolt import BoltAPI, ModelViewSet
+from django_bolt.serializers import Serializer, computed_field, field
+from django_bolt.testing import TestClient
+from tests.test_models import Article, Author, BlogPost
+
+
+class BaseArticle(Serializer):
+    id: int
+    title: str
+
+
+class ArticleOut(BaseArticle):
+    content: str
+
+    @computed_field
+    def title_upper(self) -> str:
+        return self.title.upper()
+
+
+class SecretArticle(Serializer):
+    id: int
+    title: str
+    content: str = field(write_only=True)
+
+
+class PlainArticle(msgspec.Struct):
+    id: int
+    title: str
+    content: str
+
+
+class AuthorMini(Serializer):
+    id: int
+    name: str
+
+
+class PostOut(Serializer):
+    id: int
+    title: str
+    author: AuthorMini
+
+    @computed_field
+    def title_len(self) -> int:
+        return len(self.title)
+
+
+@pytest.fixture
+def article():
+    return Article.objects.create(title="hello", content="the body", author="A1")
+
+
+@pytest.mark.django_db(transaction=True)
+def test_default_list_and_retrieve_use_serializer_dump(article):
+    api = BoltAPI()
+
+    @api.viewset("/articles")
+    class VS(ModelViewSet):
+        queryset = Article.objects.all()
+        serializer_class = ArticleOut
+
+    expected = {
+        "id": article.id,
+        "title": "hello",
+        "content": "the body",
+        "title_upper": "HELLO",
+    }
+
+    with TestClient(api) as client:
+        r = client.get("/articles")
+        assert r.status_code == 200, r.text
+        assert r.json() == [expected]
+
+        r = client.get(f"/articles/{article.id}")
+        assert r.status_code == 200, r.text
+        assert r.json() == expected
+
+
+@pytest.mark.django_db(transaction=True)
+def test_plain_struct_viewset_keeps_values_projection(article):
+    api = BoltAPI()
+
+    @api.viewset("/articles")
+    class VS(ModelViewSet):
+        queryset = Article.objects.all()
+        serializer_class = PlainArticle
+
+    list_meta = next(api._handler_meta[hid] for _m, path, hid, _h in api._routes if path == "/articles")
+    assert list_meta["response_field_names"] == ["id", "title", "content"]
+
+    with TestClient(api) as client:
+        r = client.get("/articles")
+        assert r.status_code == 200, r.text
+        assert r.json() == [{"id": article.id, "title": "hello", "content": "the body"}]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_nested_serializer_list_and_retrieve():
+    api = BoltAPI()
+    author = Author.objects.create(name="Ada", email="ada@x.io")
+    post = BlogPost.objects.create(title="Post", content="body", author=author)
+
+    @api.viewset("/posts")
+    class VS(ModelViewSet):
+        queryset = BlogPost.objects.select_related("author").all()
+        serializer_class = PostOut
+
+    expected = {
+        "id": post.id,
+        "title": "Post",
+        "author": {"id": author.id, "name": "Ada"},
+        "title_len": 4,
+    }
+
+    with TestClient(api) as client:
+        r = client.get("/posts")
+        assert r.status_code == 200, r.text
+        assert r.json() == [expected]
+
+        r = client.get(f"/posts/{post.id}")
+        assert r.status_code == 200, r.text
+        assert r.json() == expected
+
+
+@pytest.mark.django_db(transaction=True)
+def test_loaded_nested_serializer_uses_sync_from_model(monkeypatch):
+    api = BoltAPI()
+    author = Author.objects.create(name="Ada", email="ada@x.io")
+    post = BlogPost.objects.create(title="Post", content="body", author=author)
+
+    async def fail_afrom_model(cls, instance, *, _depth=0, max_depth=10):
+        raise AssertionError("select_related nested output should not need afrom_model()")
+
+    monkeypatch.setattr(PostOut, "afrom_model", classmethod(fail_afrom_model))
+
+    @api.viewset("/posts")
+    class VS(ModelViewSet):
+        queryset = BlogPost.objects.select_related("author").all()
+        serializer_class = PostOut
+
+    with TestClient(api) as client:
+        r = client.get("/posts")
+        assert r.status_code == 200, r.text
+        assert r.json() == [
+            {
+                "id": post.id,
+                "title": "Post",
+                "author": {"id": author.id, "name": "Ada"},
+                "title_len": 4,
+            }
+        ]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_unloaded_nested_serializer_falls_back_to_afrom_model():
+    api = BoltAPI()
+    author = Author.objects.create(name="Ada", email="ada@x.io")
+    post = BlogPost.objects.create(title="Post", content="body", author=author)
+
+    @api.viewset("/posts")
+    class VS(ModelViewSet):
+        queryset = BlogPost.objects.all()
+        serializer_class = PostOut
+
+    with TestClient(api) as client:
+        r = client.get("/posts")
+        assert r.status_code == 200, r.text
+        assert r.json() == [
+            {
+                "id": post.id,
+                "title": "Post",
+                "author": {"id": author.id, "name": "Ada"},
+                "title_len": 4,
+            }
+        ]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_serializer_instances_with_write_only_fields_are_dumped(article):
+    api = BoltAPI()
+
+    @api.get("/one/{pk}", response_model=SecretArticle)
+    async def one(pk: int):
+        return SecretArticle.from_model(await Article.objects.aget(id=pk))
+
+    @api.get("/many", response_model=list[SecretArticle])
+    async def many():
+        return [SecretArticle.from_model(a) async for a in Article.objects.all()]
+
+    with TestClient(api) as client:
+        r = client.get(f"/one/{article.id}")
+        assert r.status_code == 200, r.text
+        assert r.json() == {"id": article.id, "title": "hello"}
+
+        r = client.get("/many")
+        assert r.status_code == 200, r.text
+        assert r.json() == [{"id": article.id, "title": "hello"}]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_serializer_response_still_renders_with_validation_disabled(article):
+    api = BoltAPI()
+
+    @api.get("/one/{pk}", response_model=ArticleOut, validate_response=False)
+    async def one(pk: int):
+        return await Article.objects.aget(id=pk)
+
+    with TestClient(api) as client:
+        r = client.get(f"/one/{article.id}")
+        assert r.status_code == 200, r.text
+        assert r.json() == {
+            "id": article.id,
+            "title": "hello",
+            "content": "the body",
+            "title_upper": "HELLO",
+        }

--- a/python/tests/test_response_model_priority.py
+++ b/python/tests/test_response_model_priority.py
@@ -4,7 +4,7 @@ Tests for response_model parameter priority and QuerySet optimization.
 This test suite verifies that:
 1. response_model parameter takes precedence over return annotations
 2. Return annotations work as fallback when response_model not provided
-3. Both syntaxes produce identical metadata (field names for QuerySet optimization)
+3. Both syntaxes produce identical metadata
 4. Works with Serializer subclasses (django-bolt's enhanced msgspec.Struct)
 5. Works with both sync and async handlers
 """
@@ -67,9 +67,7 @@ def test_response_model_overrides_annotation():
     # Verify response_type is UserMini (from response_model), not UserFull (from annotation)
     assert meta["response_type"] == list[UserMini]
 
-    # Verify field names extracted from UserMini
-    assert "response_field_names" in meta
-    assert set(meta["response_field_names"]) == {"id", "username"}
+    assert "response_field_names" not in meta
 
 
 def test_response_model_overrides_annotation_async():
@@ -85,8 +83,7 @@ def test_response_model_overrides_annotation_async():
     meta = api._handler_meta[handler_id]
 
     assert meta["response_type"] == list[UserMini]
-    assert "response_field_names" in meta
-    assert set(meta["response_field_names"]) == {"id", "username"}
+    assert "response_field_names" not in meta
 
 
 # ============================================================================
@@ -109,9 +106,7 @@ def test_return_annotation_fallback():
     # Verify response_type is UserMini (from return annotation)
     assert meta["response_type"] == list[UserMini]
 
-    # Verify field names extracted
-    assert "response_field_names" in meta
-    assert set(meta["response_field_names"]) == {"id", "username"}
+    assert "response_field_names" not in meta
 
 
 def test_return_annotation_fallback_async():
@@ -127,8 +122,7 @@ def test_return_annotation_fallback_async():
     meta = api._handler_meta[handler_id]
 
     assert meta["response_type"] == list[UserMini]
-    assert "response_field_names" in meta
-    assert set(meta["response_field_names"]) == {"id", "username"}
+    assert "response_field_names" not in meta
 
 
 # ============================================================================
@@ -159,9 +153,8 @@ def test_both_syntaxes_produce_same_metadata():
     # Both should have same response_type
     assert meta1["response_type"] == meta2["response_type"]
 
-    # Both should have same field names
-    assert meta1["response_field_names"] == meta2["response_field_names"]
-    assert set(meta1["response_field_names"]) == {"id", "username"}
+    assert "response_field_names" not in meta1
+    assert "response_field_names" not in meta2
 
 
 def test_both_syntaxes_produce_same_metadata_async():
@@ -183,7 +176,8 @@ def test_both_syntaxes_produce_same_metadata_async():
     meta2 = api2._handler_meta[handler_id2]
 
     assert meta1["response_type"] == meta2["response_type"]
-    assert meta1["response_field_names"] == meta2["response_field_names"]
+    assert "response_field_names" not in meta1
+    assert "response_field_names" not in meta2
 
 
 # ============================================================================
@@ -199,8 +193,8 @@ def test_serializer_subclass_recognized():
     assert is_msgspec_struct(PlainStruct)
 
 
-def test_serializer_field_extraction():
-    """Test field extraction from Serializer subclasses."""
+def test_serializer_not_projected_via_values():
+    """Serializer subclasses are routed through from_model+dump, not .values()."""
     api = BoltAPI()
 
     @api.get("/users", response_model=list[UserFull])
@@ -211,10 +205,8 @@ def test_serializer_field_extraction():
     _method, _path, handler_id, _handler = api._routes[0]
     meta = api._handler_meta[handler_id]
 
-    # Verify all UserFull fields extracted
-    assert "response_field_names" in meta
-    expected_fields = {"id", "username", "email", "first_name", "last_name"}
-    assert set(meta["response_field_names"]) == expected_fields
+    assert meta["response_type"] == list[UserFull]
+    assert "response_field_names" not in meta
 
 
 def test_plain_msgspec_struct_field_extraction():
@@ -334,7 +326,7 @@ def test_metadata_extraction_at_registration():
         _method, _path, handler_id, _handler = api._routes[0]
         meta = api._handler_meta[handler_id]
 
-        assert "response_field_names" in meta
+        assert "response_field_names" not in meta
 
         # Still should be 1 (no additional calls)
         assert call_count == 1
@@ -439,8 +431,7 @@ def test_compile_binder_focused_on_parameters():
     # Verify response_type set correctly (response_model, not annotation)
     assert meta["response_type"] == list[UserMini]
 
-    # Verify field names from response_model (UserMini), not annotation (UserFull)
-    assert set(meta["response_field_names"]) == {"id", "username"}
+    assert "response_field_names" not in meta
 
 
 # ============================================================================
@@ -461,8 +452,8 @@ def test_nested_list_extraction():
     meta = api._handler_meta[handler_id]
 
     # Should work with typing.List as well
-    assert "response_field_names" in meta
-    assert set(meta["response_field_names"]) == {"id", "username"}
+    assert meta["response_type"] == list[UserMini]
+    assert "response_field_names" not in meta
 
 
 # ============================================================================


### PR DESCRIPTION
…dump

Serializer response models were projected through QuerySet.values(), which drops computed fields, inherited fields, write_only exclusions, aliases, source mapping, and nested serializers. Route Serializer (and list[Serializer]) responses through from_model() + dump() instead, and reserve the faster .values() projection for plain msgspec.Struct output.

Add UnloadedRelationError so the sync dump path can detect an unloaded Django relation and fall back to async afrom_model() relation loading rather than failing.


<!-- Describe the change in 2-3 sentences. Link to any related issue. -->

Fixes #


## How was this tested?

- [ ] `just lint-lib` and `just test-py` pass
- [ ] If Rust was changed: `just rebuild` succeeds
- [ ] If a new feature is added: tested manually in the example project (`python/example/`)


## Performance consideration

<!-- Django-Bolt is a performance-critical framework. Explain why this change does not regress the hot path, or show benchmark numbers if it touches dispatch/serialization/routing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Yes — this PR touches the hot request path.

It updates the runtime response serialization flow in `serialization.py` (`compile_response_handlers` / `_compile_response_validator`) so that when the handler `response_type` is a Bolt `Serializer` or `list[Serializer]`, list + non-list results are funneled through the serializer pipeline instead of the faster `QuerySet.values()`-style projection. That ensures computed/inherited fields, write-only exclusions, aliases/source mapping, and nested serializers are preserved. The extra work is gated by the `is_serializer_response` checks (e.g., serializer responses skip the additional `_convert_serializers`/projection steps), so non-serializer response types keep their existing fast paths.

For paginated list responses, it also changes the pagination hot path (`pagination.py`): the synchronous serializer path uses `from_model()` + `dump_many()`, but now catches a new `UnloadedRelationError` to safely fall back to the async `afrom_model()` relation loading + `dump_many()` when needed. This is a correctness-driven fallback (avoids sync-path failure when relations aren’t loaded) and only adds the exception/branch cost in those specific unloaded-relation cases.

Overall: it adds targeted branching and serialization conversion only for serializer-typed responses (and only falls back to async when sync relation loading would be invalid), rather than wasting work for plain `msgspec.Struct`/dict/List paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->