### PR TITLE
Query http method

### DIFF
--- a/docs/src/ref/api.md
+++ b/docs/src/ref/api.md
@@ -170,6 +170,10 @@ Register a HEAD endpoint.
 
 Register an OPTIONS endpoint.
 
+#### @api.query(path, **options)
+
+Register a QUERY endpoint — a safe, idempotent read that takes a request body. Declare a body parameter as you would for POST. See [The QUERY method](../topics/routing.md#the-query-method).
+
 ### Route options
 
 All route decorators accept these options:

--- a/docs/src/topics/class-based-views.md
+++ b/docs/src/topics/class-based-views.md
@@ -56,6 +56,10 @@ class ResourceView(APIView):
     async def delete(self, request):
         """Handle DELETE requests"""
         return {"method": "DELETE"}
+
+    async def query(self, request):
+        """Handle QUERY requests (a read that takes a request body)"""
+        return {"method": "QUERY"}
 ```
 
 ### Class-level configuration

--- a/docs/src/topics/routing.md
+++ b/docs/src/topics/routing.md
@@ -37,6 +37,7 @@ Django-Bolt supports all common HTTP methods:
 | `@api.delete()` | DELETE | Remove resources |
 | `@api.head()` | HEAD | Get headers only |
 | `@api.options()` | OPTIONS | Get allowed methods |
+| `@api.query()` | QUERY | Read using a request body |
 
 Example with all methods:
 
@@ -70,6 +71,38 @@ async def options_items():
     from django_bolt import Response
     return Response({}, headers={"Allow": "GET, POST, PUT, PATCH, DELETE"})
 ```
+
+### The QUERY method
+
+`QUERY` is a safe, idempotent method that carries a request body. It behaves like `GET` — it reads, it doesn't change server state, and it can be retried — but its parameters travel in the body instead of the query string. Reach for it when a query is too large or too structured for a URL (a nested filter, a long list of IDs, a search document) and a `POST` would wrongly read as a write.
+
+A `QUERY` handler takes a body the same way a `POST` handler does:
+
+```python
+import msgspec
+from django_bolt import BoltAPI
+
+api = BoltAPI()
+
+class Search(msgspec.Struct):
+    term: str
+    limit: int = 20
+
+@api.query("/search")
+async def search(query: Search) -> dict:
+    return {"term": query.term, "limit": query.limit}
+```
+
+```http
+QUERY /search HTTP/1.1
+Content-Type: application/json
+
+{"term": "django", "limit": 5}
+```
+
+`QUERY` works everywhere the other methods do: on routers (`router.query(...)`), on class-based views (an `async def query` handler), and in the test client (`client.query("/search", json=...)`). It's included in the automatic `Allow` header and the default CORS method list.
+
+One caveat for tooling: `query` only becomes a documented operation in the OpenAPI 3.2 draft. Django-Bolt emits 3.1, so the built-in docs UIs render `QUERY` endpoints, but a strict 3.1 validator will reject the operation.
 
 ## Path parameters
 

--- a/docs/src/topics/testing.md
+++ b/docs/src/topics/testing.md
@@ -49,6 +49,7 @@ with TestClient(api) as client:
     client.put("/users/1", json={"name": "Updated", "email": "u@example.com"})
     client.patch("/users/1", json={"name": "Patched"})
     client.delete("/users/1")
+    client.query("/search", json={"term": "django"})
 ```
 
 Responses give you the status code, headers, and body in whatever form you

--- a/justfile
+++ b/justfile
@@ -145,6 +145,10 @@ build-bench: build save-bench
 bench-params host=host port=port c=c n=n p=p workers=workers:
     P={{p}} WORKERS={{workers}} C={{c}} N={{n}} HOST={{host}} PORT={{port}} ./scripts/benchmark_params.sh
 
+# Focused HTTP QUERY method benchmark (QUERY vs POST, identical work)
+bench-query host=host port=port c=c n=n p=p workers=workers:
+    P={{p}} WORKERS={{workers}} C={{c}} N={{n}} HOST={{host}} PORT={{port}} ./scripts/benchmark_query.sh
+
 # Release new version
 # Usage: just release 0.2.2
 # Usage: just release 0.3.0-alpha1 (for pre-releases)

--- a/python/django_bolt/api.py
+++ b/python/django_bolt/api.py
@@ -713,6 +713,36 @@ class BoltAPI:
             response_class=response_class,
         )
 
+    def query(
+        self,
+        path: str,
+        *,
+        name: str | None = None,
+        response_model: Any = _RESPONSE_MODEL_UNSET,
+        status_code: int | None = None,
+        validate_response: bool | None = None,
+        guards: list[Any] | None = None,
+        auth: list[Any] | None = None,
+        tags: list[str] | None = None,
+        summary: str | None = None,
+        description: str | None = None,
+        response_class: type | None = None,
+    ):
+        return self._route_decorator(
+            "QUERY",
+            path,
+            name=name,
+            response_model=response_model,
+            status_code=status_code,
+            validate_response=validate_response,
+            guards=guards,
+            auth=auth,
+            tags=tags,
+            summary=summary,
+            description=description,
+            response_class=response_class,
+        )
+
     def websocket(
         self,
         path: str,
@@ -2995,7 +3025,7 @@ class BoltAPI:
             route_router_middleware = route_meta.pop("_router_middleware", [])
 
             # Register route with merged settings and preserved router middleware.
-            if method.upper() not in {"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}:
+            if method.upper() not in {"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "QUERY"}:
                 continue
 
             decorator = self._route_decorator(

--- a/python/django_bolt/decorators.py
+++ b/python/django_bolt/decorators.py
@@ -171,7 +171,7 @@ def action(
     def decorator(fn: Callable) -> ActionHandler:
         """Wrap the function with ActionHandler metadata."""
         # Validate methods
-        valid_methods = {"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}
+        valid_methods = {"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "QUERY"}
         for method in methods:
             if method.upper() not in valid_methods:
                 raise ValueError(f"Invalid HTTP method '{method}'. Valid methods: {', '.join(sorted(valid_methods))}")

--- a/python/django_bolt/middleware/middleware.py
+++ b/python/django_bolt/middleware/middleware.py
@@ -485,7 +485,7 @@ def cors(
             {
                 "type": "cors",
                 "origins": origin_list,
-                "methods": methods or ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+                "methods": methods or ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "QUERY"],
                 "headers": headers,
                 "credentials": credentials,
                 "max_age": max_age,

--- a/python/django_bolt/nanodjango.py
+++ b/python/django_bolt/nanodjango.py
@@ -43,6 +43,7 @@ _BOLT_DECORATOR_NAMES: tuple[str, ...] = (
     "delete",
     "head",
     "options",
+    "query",
     "websocket",
 )
 _BOLT_MOUNT_NAMES: tuple[str, ...] = ("mount_django", "mount")

--- a/python/django_bolt/openapi/schema_generator.py
+++ b/python/django_bolt/openapi/schema_generator.py
@@ -436,6 +436,14 @@ class SchemaGenerator:
         paths: dict[str, PathItem] = {}
         collected_tags: set[str] = set()
 
+        # The QUERY method is only representable as a Path Item operation in
+        # OpenAPI 3.2.0+. Emitting a `query` operation under the default 3.1.0
+        # declaration produces a document that fails strict 3.1 validation
+        # ("unevaluatedProperties: false"). Bump the declared version only when
+        # a QUERY route is actually present, so non-QUERY APIs keep declaring
+        # 3.1.0 for maximum downstream tooling compatibility.
+        has_query_operation = False
+
         # Process HTTP routes
         for method, path, handler_id, handler in self.api._routes:
             # Skip OpenAPI docs routes (always excluded)
@@ -473,6 +481,8 @@ class SchemaGenerator:
 
             # Add operation to path item
             method_lower = method.lower()
+            if method_lower == "query":
+                has_query_operation = True
             setattr(paths[path], method_lower, operation)
 
         # Process WebSocket routes
@@ -519,6 +529,9 @@ class SchemaGenerator:
             paths[ws_path].extensions["x-websocket"] = True
 
         openapi.paths = paths
+
+        if has_query_operation:
+            openapi.openapi = "3.2.0"
 
         # Auto-register security schemes from auth backends used on routes
         self._register_security_schemes(openapi)

--- a/python/django_bolt/openapi/spec/path_item.py
+++ b/python/django_bolt/openapi/spec/path_item.py
@@ -65,6 +65,9 @@ class PathItem(BaseSchemaObject):
     trace: Operation | None = None
     """A definition of a TRACE operation on this path."""
 
+    query: Operation | None = None
+    """A definition of a QUERY operation on this path."""
+
     servers: list[Server] | None = None
     """An alternative ``server`` array to service all operations in this path."""
 

--- a/python/django_bolt/router.py
+++ b/python/django_bolt/router.py
@@ -173,6 +173,15 @@ class Router:
 
         return dec
 
+    def query(self, path: str, **kwargs: Any):
+        """Register a QUERY route."""
+
+        def dec(fn: Callable):
+            self._add("QUERY", path, fn, **kwargs)
+            return fn
+
+        return dec
+
     def include_router(
         self,
         router: "Router",

--- a/python/django_bolt/testing/client.py
+++ b/python/django_bolt/testing/client.py
@@ -505,6 +505,13 @@ class TestClient(httpx.Client):
             response = self._add_streaming_methods(response)
         return response
 
+    def query(self, url: str | httpx.URL, *, stream: bool = False, **kwargs: Any) -> Response:
+        """QUERY request with optional streaming support."""
+        response = self.request("QUERY", url, **kwargs)
+        if stream:
+            response = self._add_streaming_methods(response)
+        return response
+
     @staticmethod
     def _iter_response_content(
         content: bytes, chunk_size: int = 1024, decode_unicode: bool = False

--- a/python/django_bolt/typing.py
+++ b/python/django_bolt/typing.py
@@ -317,7 +317,7 @@ def infer_param_source(name: str, annotation: Any, path_params: set[str], http_m
     1. If name matches path parameter -> "path"
     2. If special name (request, req) -> "request"
     3. If simple type (str, int, float, bool) -> "query"
-    4. If msgspec.Struct or dataclass -> "body" (if method allows body)
+    4. If msgspec.Struct or dataclass -> "body" (method validation happens later)
     5. Default -> "query"
 
     Args:

--- a/python/django_bolt/typing.py
+++ b/python/django_bolt/typing.py
@@ -352,7 +352,7 @@ def infer_param_source(name: str, annotation: Any, path_params: set[str], http_m
 
     # 5. Complex types (msgspec.Struct, dataclass) -> body (if allowed)
     if is_msgspec_struct(unwrapped) or is_dataclass_type(unwrapped):
-        if http_method in {"POST", "PUT", "PATCH"}:
+        if http_method in {"POST", "PUT", "PATCH", "QUERY"}:
             return "body"
         # For GET/DELETE/HEAD, this will trigger validation error later
         return "body"

--- a/python/django_bolt/typing.py
+++ b/python/django_bolt/typing.py
@@ -350,11 +350,10 @@ def infer_param_source(name: str, annotation: Any, path_params: set[str], http_m
         if args and is_simple_type(args[0]):
             return "query"
 
-    # 5. Complex types (msgspec.Struct, dataclass) -> body (if allowed)
+    # 5. Complex types (msgspec.Struct, dataclass) -> body
+    # Method-appropriateness (rejecting bodies on GET/DELETE/HEAD) is enforced
+    # later in the validation path, not here.
     if is_msgspec_struct(unwrapped) or is_dataclass_type(unwrapped):
-        if http_method in {"POST", "PUT", "PATCH", "QUERY"}:
-            return "body"
-        # For GET/DELETE/HEAD, this will trigger validation error later
         return "body"
 
     # 6. Default to query

--- a/python/django_bolt/views.py
+++ b/python/django_bolt/views.py
@@ -35,13 +35,13 @@ class APIView:
     Base class for class-based views in Django-Bolt.
 
     Attributes:
-        http_method_names: List of supported HTTP methods (lowercase)
+        http_method_names: Tuple of supported HTTP methods (lowercase)
         guards: List of guard/permission classes to apply to all methods
         auth: List of authentication backends to apply to all methods
         status_code: Default status code for responses (can be overridden per-method)
     """
 
-    http_method_names = ["get", "post", "put", "patch", "delete", "head", "options", "query"]
+    http_method_names = ("get", "post", "put", "patch", "delete", "head", "options", "query")
 
     # Class-level defaults (can be overridden by subclasses)
     guards: list[Any] | None = None

--- a/python/django_bolt/views.py
+++ b/python/django_bolt/views.py
@@ -41,7 +41,7 @@ class APIView:
         status_code: Default status code for responses (can be overridden per-method)
     """
 
-    http_method_names = ["get", "post", "put", "patch", "delete", "head", "options"]
+    http_method_names = ["get", "post", "put", "patch", "delete", "head", "options", "query"]
 
     # Class-level defaults (can be overridden by subclasses)
     guards: list[Any] | None = None

--- a/python/example/test_docs_testing_guide.py
+++ b/python/example/test_docs_testing_guide.py
@@ -17,15 +17,15 @@ import httpx
 import pytest
 from django.contrib.auth import get_user_model
 
-from django_bolt import BoltAPI
-from django_bolt.auth import IsAuthenticated, JWTAuthentication, create_jwt_for_user
-from django_bolt.responses import EventSourceResponse, StreamingResponse
-from django_bolt.testing import TestClient
-
 # The real app modules, imported the way the guide's "real project pattern" shows.
 from testproject.api import api
 from users.api import api as users_api
 from users.models import User
+
+from django_bolt import BoltAPI
+from django_bolt.auth import create_jwt_for_user
+from django_bolt.responses import EventSourceResponse, StreamingResponse
+from django_bolt.testing import TestClient
 
 
 # ── TestClient basics ─────────────────────────────────────────────────────────
@@ -146,9 +146,9 @@ def bolt_server():
             try:
                 client.get("/")  # any route works: a response means it's up
                 break
-            except httpx.TransportError:
+            except httpx.TransportError as err:
                 if time.time() > deadline:
-                    raise TimeoutError("server did not become ready in 15s")
+                    raise TimeoutError("server did not become ready in 15s") from err
                 time.sleep(0.2)
         yield client
     finally:

--- a/python/example/test_docs_testing_guide.py
+++ b/python/example/test_docs_testing_guide.py
@@ -136,9 +136,7 @@ def _free_port() -> int:
 @pytest.fixture(scope="module")
 def bolt_server():
     port = _free_port()
-    process = subprocess.Popen(
-        [sys.executable, "manage.py", "runbolt", "--host", "127.0.0.1", "--port", str(port)]
-    )
+    process = subprocess.Popen([sys.executable, "manage.py", "runbolt", "--host", "127.0.0.1", "--port", str(port)])
     client = httpx.Client(base_url=f"http://127.0.0.1:{port}")
     try:
         deadline = time.time() + 15

--- a/python/example/testproject/api.py
+++ b/python/example/testproject/api.py
@@ -659,6 +659,13 @@ async def bench_parse(req: Request, payload: BenchPayload):
     return {"ok": True, "n": len(payload.items), "count": payload.count}
 
 
+@api.query("/bench/query")
+async def bench_query(req: Request, payload: BenchPayload):
+    # Byte-identical work to /bench/parse (POST). The only difference is the
+    # HTTP QUERY method, so diffing RPS isolates the method's routing cost.
+    return {"ok": True, "n": len(payload.items), "count": payload.count}
+
+
 @api.get("/bench/slow")
 async def bench_slow(ms: int | None = 100):
     # Simulate slow I/O (network) with asyncio.sleep

--- a/python/tests/integration/apps/query.py
+++ b/python/tests/integration/apps/query.py
@@ -1,0 +1,19 @@
+"""App under test for the HTTP QUERY method."""
+
+from __future__ import annotations
+
+import msgspec
+
+from django_bolt import BoltAPI
+
+api = BoltAPI()
+
+
+class SearchQuery(msgspec.Struct):
+    term: str
+    limit: int = 10
+
+
+@api.query("/search")
+async def search(query: SearchQuery) -> dict:
+    return {"term": query.term, "limit": query.limit}

--- a/python/tests/integration/apps/query.py
+++ b/python/tests/integration/apps/query.py
@@ -9,6 +9,11 @@ from django_bolt import BoltAPI
 api = BoltAPI()
 
 
+@api.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
 class SearchQuery(msgspec.Struct):
     term: str
     limit: int = 10

--- a/python/tests/integration/test_query_method_server_integration.py
+++ b/python/tests/integration/test_query_method_server_integration.py
@@ -1,4 +1,12 @@
-"""Real-server tests for the HTTP QUERY method."""
+"""Real-server tests for the HTTP QUERY method.
+
+These run against an actual ``runbolt`` process over TCP, which is the only way
+to prove actix-web accepts and routes the non-standard ``QUERY`` method off the
+wire. The in-process ``TestClient`` builds the method a different way
+(``Method::from_bytes`` in ``src/testing.rs``), so it can't stand in for the
+real socket path here. In-process behavior (validation, coexistence with GET,
+OpenAPI, CBV) is covered in ``python/tests/test_query_method.py``.
+"""
 
 from __future__ import annotations
 
@@ -21,3 +29,14 @@ def test_query_with_body_over_real_tcp(make_server_project):
 
     assert response.status_code == 200, response.text
     assert response.json() == {"term": "django", "limit": 7}
+
+
+def test_query_body_is_validated_over_real_tcp(make_server_project):
+    """A bad QUERY body must be read and rejected by the real server, not routed
+    blindly. Missing the required ``term`` field returns 422."""
+    project = make_server_project(api_module=app_module("query"))
+
+    with project.start() as server:
+        response = server.request("QUERY", "/search", json={"limit": 7})
+
+    assert response.status_code == 422, response.text

--- a/python/tests/integration/test_query_method_server_integration.py
+++ b/python/tests/integration/test_query_method_server_integration.py
@@ -1,0 +1,23 @@
+"""Real-server tests for the HTTP QUERY method."""
+
+from __future__ import annotations
+
+import pytest
+
+from .apps import app_module
+
+pytestmark = pytest.mark.server_integration
+
+
+def test_query_with_body_over_real_tcp(make_server_project):
+    project = make_server_project(api_module=app_module("query"))
+
+    with project.start() as server:
+        response = server.request(
+            "QUERY",
+            "/search",
+            json={"term": "django", "limit": 7},
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"term": "django", "limit": 7}

--- a/python/tests/test_nanodjango_plugin.py
+++ b/python/tests/test_nanodjango_plugin.py
@@ -379,7 +379,7 @@ def create_item(request):
         assert len(extra_src) == 2
 
     def test_detects_all_http_methods(self):
-        methods = ["get", "post", "put", "patch", "delete", "head", "options", "websocket"]
+        methods = ["get", "post", "put", "patch", "delete", "head", "options", "query", "websocket"]
         for method in methods:
             source = f"""\
 bolt = BoltAPI()

--- a/python/tests/test_openapi_spec_validity.py
+++ b/python/tests/test_openapi_spec_validity.py
@@ -147,6 +147,33 @@ def test_generated_spec_declares_openapi_3_1(full_spec: dict) -> None:
     assert full_spec.get("openapi", "").startswith("3.1.")
 
 
+def test_query_operation_declares_openapi_3_2_and_validates() -> None:
+    """A QUERY route is only representable as a Path Item operation in
+    OpenAPI 3.2.0+. Under the default 3.1.0 declaration the generated
+    `query` operation fails strict 3.1 validation ("unevaluatedProperties:
+    false"), so the generator must bump the declared version to 3.2.0
+    whenever a QUERY route is present — and the result must still validate."""
+    api = BoltAPI(openapi_config=OpenAPIConfig(title="Query API", version="1.0.0"))
+
+    @api.query("/search")
+    async def search(request, data: ItemMutationIn) -> ItemBase:
+        pass
+
+    api._register_openapi_routes()
+    with TestClient(api) as client:
+        spec = client.get("/docs/openapi.json").json()
+
+    assert spec.get("openapi") == "3.2.0"
+    assert "query" in spec["paths"]["/search"]
+    validate(spec)
+
+
+def test_query_free_spec_keeps_openapi_3_1(full_spec: dict) -> None:
+    """The 3.2.0 bump is conditional: APIs without a QUERY route must keep
+    declaring 3.1.0 for maximum downstream tooling compatibility."""
+    assert full_spec.get("openapi", "").startswith("3.1.")
+
+
 def test_no_dangling_refs_in_components(full_spec: dict) -> None:
     """Every `$ref` in the spec must resolve to a `components.schemas`
     entry. Catches the bug class where a Struct is referenced inside

--- a/python/tests/test_query_method.py
+++ b/python/tests/test_query_method.py
@@ -1,0 +1,121 @@
+"""Tests for the HTTP QUERY method."""
+
+from __future__ import annotations
+
+import msgspec
+
+from django_bolt import BoltAPI, Router
+from django_bolt.openapi.config import OpenAPIConfig
+from django_bolt.testing import TestClient
+from django_bolt.views import APIView
+
+
+class SearchQuery(msgspec.Struct):
+    term: str
+    limit: int = 10
+
+
+def test_query_with_json_body():
+    api = BoltAPI()
+
+    @api.query("/search")
+    async def search(query: SearchQuery) -> dict:
+        return {"term": query.term, "limit": query.limit}
+
+    with TestClient(api) as client:
+        response = client.query("/search", json={"term": "django", "limit": 5})
+        assert response.status_code == 200, response.text
+        assert response.json() == {"term": "django", "limit": 5}
+
+        defaulted = client.query("/search", json={"term": "only"})
+        assert defaulted.status_code == 200, defaulted.text
+        assert defaulted.json() == {"term": "only", "limit": 10}
+
+
+def test_query_and_get_coexist_on_same_path():
+    api = BoltAPI()
+
+    @api.get("/resource")
+    async def read() -> dict:
+        return {"method": "GET"}
+
+    @api.query("/resource")
+    async def find(query: SearchQuery) -> dict:
+        return {"method": "QUERY", "term": query.term}
+
+    with TestClient(api) as client:
+        get_resp = client.get("/resource")
+        assert get_resp.status_code == 200
+        assert get_resp.json() == {"method": "GET"}
+
+        query_resp = client.query("/resource", json={"term": "x"})
+        assert query_resp.status_code == 200
+        assert query_resp.json() == {"method": "QUERY", "term": "x"}
+
+        response = client.options("/resource")
+        assert response.status_code == 204
+        allow = response.headers.get("allow", "")
+        assert "QUERY" in allow, f"Allow header missing QUERY: {allow!r}"
+
+
+def test_query_via_router():
+    api = BoltAPI()
+    router = Router(prefix="/v1")
+
+    @router.query("/find")
+    async def find(query: SearchQuery) -> dict:
+        return {"term": query.term, "limit": query.limit}
+
+    api.include_router(router)
+
+    with TestClient(api) as client:
+        response = client.query("/v1/find", json={"term": "routed", "limit": 3})
+        assert response.status_code == 200, response.text
+        assert response.json() == {"term": "routed", "limit": 3}
+
+
+def test_query_openapi_operation():
+    api = BoltAPI(openapi_config=OpenAPIConfig(title="Q", version="1.0.0"))
+
+    @api.query("/search")
+    async def search(query: SearchQuery) -> dict:
+        return {"term": query.term}
+
+    api._register_openapi_routes()
+
+    with TestClient(api) as client:
+        response = client.get("/docs/openapi.json")
+        assert response.status_code == 200, response.text
+        schema = response.json()
+
+    path_item = schema["paths"]["/search"]
+    assert "query" in path_item, f"query operation missing: {list(path_item)}"
+    operation = path_item["query"]
+    assert "requestBody" in operation, "QUERY operation should document a request body"
+    assert operation["operationId"] == "query_search"
+
+
+def test_query_class_based_view():
+    api = BoltAPI()
+
+    @api.view("/cbv-search")
+    class SearchView(APIView):
+        async def query(self, query: SearchQuery) -> dict:
+            return {"term": query.term, "limit": query.limit}
+
+    with TestClient(api) as client:
+        response = client.query("/cbv-search", json={"term": "cbv", "limit": 2})
+        assert response.status_code == 200, response.text
+        assert response.json() == {"term": "cbv", "limit": 2}
+
+
+def test_query_missing_required_body_field_is_422():
+    api = BoltAPI()
+
+    @api.query("/search")
+    async def search(query: SearchQuery) -> dict:
+        return {"term": query.term}
+
+    with TestClient(api) as client:
+        response = client.query("/search", json={"limit": 5})
+        assert response.status_code == 422, response.text

--- a/scripts/benchmark_query.py
+++ b/scripts/benchmark_query.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""HTTP QUERY method load generator.
+
+bombardier (the tool the other benchmarks use) rejects non-standard methods
+with "Unknown HTTP method: QUERY", so QUERY throughput is measured here with
+httpx instead — which is already a django-bolt dependency and sends arbitrary
+methods. The same generator drives POST for an apples-to-apples comparison
+against the byte-identical /bench/parse endpoint.
+
+Output mirrors the "Reqs/sec / Latency / NN%" lines the shell benchmarks emit
+so it can be grepped the same way.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import time
+
+import httpx
+
+DEFAULT_BODY = '{"title":"bench","count":100,"items":[{"name":"a","price":1.0,"is_offer":true}]}'
+
+
+def _percentile(sorted_us: list[float], pct: float) -> float:
+    """Nearest-rank percentile over already-sorted microsecond latencies."""
+    if not sorted_us:
+        return 0.0
+    rank = max(0, min(len(sorted_us) - 1, round(pct / 100.0 * len(sorted_us)) - 1))
+    return sorted_us[rank]
+
+
+async def _worker(
+    client: httpx.AsyncClient,
+    method: str,
+    url: str,
+    body: bytes,
+    count: int,
+    latencies: list[float],
+    errors: list[int],
+) -> None:
+    headers = {"Content-Type": "application/json"}
+    for _ in range(count):
+        start = time.perf_counter()
+        try:
+            resp = await client.request(method, url, content=body, headers=headers)
+            elapsed_us = (time.perf_counter() - start) * 1_000_000
+            if resp.status_code == 200:
+                latencies.append(elapsed_us)
+            else:
+                errors[0] += 1
+        except Exception:
+            errors[0] += 1
+
+
+async def run(method: str, url: str, body: bytes, concurrency: int, total: int, warmup: int) -> None:
+    limits = httpx.Limits(max_connections=concurrency, max_keepalive_connections=concurrency)
+    async with httpx.AsyncClient(limits=limits, timeout=30.0) as client:
+        # Warmup (not measured): primes connections and the JIT-y first-call paths.
+        if warmup > 0:
+            warm_lat: list[float] = []
+            warm_err = [0]
+            await _worker(client, method, url, body, warmup, warm_lat, warm_err)
+
+        latencies: list[float] = []
+        errors = [0]
+        per_worker = [total // concurrency] * concurrency
+        for i in range(total % concurrency):  # spread the remainder
+            per_worker[i] += 1
+
+        wall_start = time.perf_counter()
+        await asyncio.gather(*(_worker(client, method, url, body, n, latencies, errors) for n in per_worker if n > 0))
+        wall = time.perf_counter() - wall_start
+
+    done = len(latencies)
+    rps = done / wall if wall > 0 else 0.0
+    latencies.sort()
+    avg_us = sum(latencies) / done if done else 0.0
+
+    print(f"  Reqs/sec  {rps:12.2f}")
+    print(f"  Latency   {avg_us / 1000:8.2f}ms  (avg)")
+    print(f"    50%     {_percentile(latencies, 50) / 1000:8.2f}ms")
+    print(f"    75%     {_percentile(latencies, 75) / 1000:8.2f}ms")
+    print(f"    90%     {_percentile(latencies, 90) / 1000:8.2f}ms")
+    print(f"    99%     {_percentile(latencies, 99) / 1000:8.2f}ms")
+    print(f"  Completed {done}/{total}  Errors {errors[0]}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="HTTP QUERY/POST load generator (httpx)")
+    parser.add_argument("url", help="Target URL, e.g. http://127.0.0.1:8001/bench/query")
+    parser.add_argument("-m", "--method", default="QUERY", help="HTTP method (default: QUERY)")
+    parser.add_argument("-c", "--concurrency", type=int, default=50, help="Concurrent connections (default: 50)")
+    parser.add_argument("-n", "--requests", type=int, default=10000, help="Total requests (default: 10000)")
+    parser.add_argument("--warmup", type=int, default=200, help="Unmeasured warmup requests (default: 200)")
+    parser.add_argument("--body", default=DEFAULT_BODY, help="JSON request body")
+    args = parser.parse_args()
+
+    asyncio.run(
+        run(
+            method=args.method.upper(),
+            url=args.url,
+            body=args.body.encode(),
+            concurrency=args.concurrency,
+            total=args.requests,
+            warmup=args.warmup,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_query.sh
+++ b/scripts/benchmark_query.sh
@@ -66,6 +66,12 @@ if [ "$QCODE" != "200" ]; then
     exit 1
 fi
 
+PCODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: application/json' --data-binary "$BODY" "http://$HOST:$PORT/bench/parse")
+if [ "$PCODE" != "200" ]; then
+    echo "Expected 200 from POST /bench/parse but got $PCODE; aborting." >&2
+    exit 1
+fi
+
 run_bench() {
     local name="$1" method="$2" path="$3"
     printf "### %s\n" "$name"

--- a/scripts/benchmark_query.sh
+++ b/scripts/benchmark_query.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Focused benchmark for the HTTP QUERY method.
+#
+# QUERY is a safe, body-bearing request method. /bench/query does byte-identical
+# work to /bench/parse (POST), so running both through the same httpx generator
+# isolates the method's routing cost from everything else.
+#
+# bombardier can't send QUERY ("Unknown HTTP method"), so this uses the httpx
+# generator in scripts/benchmark_query.py for both methods.
+
+set -e
+
+P=${P:-1}
+WORKERS=${WORKERS:-1}
+C=${C:-50}
+N=${N:-10000}
+HOST=${HOST:-127.0.0.1}
+PORT=${PORT:-8001}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SETSID_BIN=""
+if command -v setsid &> /dev/null; then
+    SETSID_BIN="setsid"
+elif [ -f "/opt/homebrew/opt/util-linux/bin/setsid" ]; then
+    SETSID_BIN="/opt/homebrew/opt/util-linux/bin/setsid"
+fi
+if [ -z "$SETSID_BIN" ]; then
+    echo "ERROR: setsid not installed. Install with: apt install util-linux (Linux) or brew install util-linux (macOS)" >&2
+    exit 1
+fi
+
+echo "# Django-Bolt HTTP QUERY Method Benchmark"
+echo "Generated: $(date)"
+echo "Config: $P processes x $WORKERS workers | C=$C N=$N"
+echo ""
+
+cd "$REPO_ROOT/python/example"
+DJANGO_BOLT_WORKERS=$WORKERS $SETSID_BIN uv run python manage.py runbolt --host "$HOST" --port "$PORT" --processes "$P" >/dev/null 2>&1 &
+SERVER_PID=$!
+
+cleanup() {
+    kill -TERM -"$SERVER_PID" 2>/dev/null || true
+    pkill -TERM -f "manage.py runbolt --host $HOST --port $PORT" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Wait for the server to answer 200 on /.
+elapsed=0
+until [ "$(curl -s -o /dev/null -w '%{http_code}' "http://$HOST:$PORT/")" = "200" ]; do
+    sleep 1
+    elapsed=$((elapsed + 1))
+    if [ "$elapsed" -ge 15 ]; then
+        echo "Server not ready after 15s; aborting." >&2
+        exit 1
+    fi
+done
+
+BODY='{"title":"bench","count":100,"items":[{"name":"a","price":1.0,"is_offer":true}]}'
+
+# Sanity check both endpoints return 200 before benchmarking.
+QCODE=$(curl -s -o /dev/null -w '%{http_code}' -X QUERY -H 'Content-Type: application/json' --data-binary "$BODY" "http://$HOST:$PORT/bench/query")
+if [ "$QCODE" != "200" ]; then
+    echo "Expected 200 from QUERY /bench/query but got $QCODE; aborting." >&2
+    exit 1
+fi
+
+run_bench() {
+    local name="$1" method="$2" path="$3"
+    printf "### %s\n" "$name"
+    uv run --with httpx python "$SCRIPT_DIR/benchmark_query.py" \
+        "http://$HOST:$PORT$path" -m "$method" -c "$C" -n "$N" --body "$BODY"
+    echo ""
+}
+
+echo "## Body-bearing request throughput (identical work, different method)"
+echo ""
+run_bench "QUERY /bench/query" "QUERY" "/bench/query"
+run_bench "POST /bench/parse (comparison)" "POST" "/bench/parse"
+
+echo "## Summary"
+echo ""
+echo "Diff Reqs/sec between the two to isolate the QUERY method's routing cost."
+echo "Key metrics: Reqs/sec (higher=better), p50/p90/p99 latency (lower=better)"

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -65,6 +65,7 @@ impl Default for CorsConfig {
             "PATCH".to_string(),
             "DELETE".to_string(),
             "OPTIONS".to_string(),
+            "QUERY".to_string(),
         ];
         let headers = vec!["Content-Type".to_string(), "Authorization".to_string()];
         let expose_headers = vec![];

--- a/src/middleware/cors.rs
+++ b/src/middleware/cors.rs
@@ -178,7 +178,7 @@ fn find_cors_config<'a>(
 
     // For OPTIONS, try multiple methods to find route config
     let methods_to_try: &[&str] = if method == &Method::OPTIONS {
-        &["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]
+        &["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "QUERY"]
     } else {
         // Use a slice pointing to the method string
         // This avoids allocation for the common case

--- a/src/router.rs
+++ b/src/router.rs
@@ -139,6 +139,7 @@ pub struct Router {
     delete: MethodRouter,
     head: MethodRouter,
     options: MethodRouter,
+    query: MethodRouter,
 }
 
 impl Router {
@@ -151,6 +152,7 @@ impl Router {
             delete: MethodRouter::new(),
             head: MethodRouter::new(),
             options: MethodRouter::new(),
+            query: MethodRouter::new(),
         }
     }
 
@@ -169,6 +171,7 @@ impl Router {
             "DELETE" => &mut self.delete,
             "HEAD" => &mut self.head,
             "OPTIONS" => &mut self.options,
+            "QUERY" => &mut self.query,
             _ => {
                 return Err(pyo3::exceptions::PyValueError::new_err(format!(
                     "Unsupported method: {}",
@@ -230,6 +233,7 @@ impl Router {
             "DELETE" => &self.delete,
             "HEAD" => &self.head,
             "OPTIONS" => &self.options,
+            "QUERY" => &self.query,
             _ => return None,
         };
 
@@ -272,6 +276,7 @@ impl Router {
             ("DELETE", &self.delete),
             ("HEAD", &self.head),
             ("OPTIONS", &self.options),
+            ("QUERY", &self.query),
         ];
 
         for (method_name, method_router) in method_routers.iter() {

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -170,6 +170,7 @@ fn parse_cors_config_from_dict(dict: &Bound<'_, PyDict>) -> PyResult<CorsConfig>
                 "PATCH".to_string(),
                 "DELETE".to_string(),
                 "OPTIONS".to_string(),
+                "QUERY".to_string(),
             ]
         });
 
@@ -617,7 +618,8 @@ pub fn test_request(
             let mut req = test::TestRequest::with_uri(&uri);
 
             // Set method
-            req = match method.to_uppercase().as_str() {
+            let method_upper = method.to_uppercase();
+            req = match method_upper.as_str() {
                 "GET" => req.method(actix_web::http::Method::GET),
                 "POST" => req.method(actix_web::http::Method::POST),
                 "PUT" => req.method(actix_web::http::Method::PUT),
@@ -625,7 +627,10 @@ pub fn test_request(
                 "DELETE" => req.method(actix_web::http::Method::DELETE),
                 "OPTIONS" => req.method(actix_web::http::Method::OPTIONS),
                 "HEAD" => req.method(actix_web::http::Method::HEAD),
-                _ => req.method(actix_web::http::Method::GET),
+                other => req.method(
+                    actix_web::http::Method::from_bytes(other.as_bytes())
+                        .unwrap_or(actix_web::http::Method::GET),
+                ),
             };
 
             // Set headers

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -627,10 +627,18 @@ pub fn test_request(
                 "DELETE" => req.method(actix_web::http::Method::DELETE),
                 "OPTIONS" => req.method(actix_web::http::Method::OPTIONS),
                 "HEAD" => req.method(actix_web::http::Method::HEAD),
-                other => req.method(
-                    actix_web::http::Method::from_bytes(other.as_bytes())
-                        .unwrap_or(actix_web::http::Method::GET),
+                // QUERY is a supported method but has no actix constant.
+                "QUERY" => req.method(
+                    actix_web::http::Method::from_bytes(b"QUERY")
+                        .expect("QUERY is a valid HTTP method token"),
                 ),
+                // Reject anything that isn't a supported method instead of
+                // silently defaulting to GET, which would hide typos in tests.
+                other => {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "Unsupported HTTP method {other:?}"
+                    )));
+                }
             };
 
             // Set headers


### PR DESCRIPTION
<!-- Describe the change in 2-3 sentences. Link to any related issue. -->

Fixes #


## How was this tested?

- [ ] `just lint-lib` and `just test-py` pass
- [ ] If Rust was changed: `just rebuild` succeeds
- [ ] If a new feature is added: tested manually in the example project (`python/example/`)


## Performance consideration

<!-- Django-Bolt is a performance-critical framework. Explain why this change does not regress the hot path, or show benchmark numbers if it touches dispatch/serialization/routing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Yes — it touches the production hot request path, but the added work is limited to routing/method plumbing needed to support a new HTTP method.

- **Core routing hot path:** `src/router.rs` adds a `query` method router and extends `register()`/`find()` dispatch so `"QUERY"` selects that router (one extra method dispatch/field in the existing per-request routing flow; it doesn’t introduce a new full-path scan or new unconditional parsing).
- **Per-request handler hot path:** `src/handler.rs` continues to rely on the existing execution-plan bitfields. `QUERY` handling only parses query parameters and/or request body when the plan indicates it (`needs_query` / `needs_body`). There’s no new unconditional body/query parsing added for all requests—only for routes whose handler signature requires it.
- **OPTIONS/CORS hot path (preflight only):** `src/middleware/cors.rs` and related routing (`src/router.rs` automatic OPTIONS/Allow support) expand method probing to include `"QUERY"`, which adds extra lookup attempts only for `OPTIONS` requests (not normal GET/POST/etc. traffic).
- **Request validation/testing harness:** changes in `src/testing.rs` affect the in-process test harness rather than production request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->