### PR TITLE
fix(admin): detect session support via middleware, not INSTALLED_APPS

### DIFF
--- a/python/django_bolt/admin/admin_detection.py
+++ b/python/django_bolt/admin/admin_detection.py
@@ -2,6 +2,8 @@
 Utilities for detecting and configuring Django admin integration.
 """
 
+from __future__ import annotations
+
 import logging
 import sys
 

--- a/python/django_bolt/admin/admin_detection.py
+++ b/python/django_bolt/admin/admin_detection.py
@@ -6,9 +6,39 @@ import logging
 import sys
 
 from django.conf import settings
+from django.contrib.sessions.middleware import SessionMiddleware
 from django.urls import get_resolver
+from django.utils.module_loading import import_string
 
 logger = logging.getLogger(__name__)
+
+
+def _has_session_middleware() -> bool:
+    """Check whether a session middleware is configured in ``settings.MIDDLEWARE``.
+
+    Django admin is auto-mounted through Django's own ASGI application, whose
+    request handling runs ``settings.MIDDLEWARE``. Admin therefore needs a
+    ``SessionMiddleware`` in that chain to maintain login state — it does *not*
+    require the ``django.contrib.sessions`` app to be in ``INSTALLED_APPS``.
+
+    Matching against a subclass (rather than the exact class) mirrors Django's
+    own admin system check (``admin.E410``), so alternative session backends
+    whose middleware subclasses the stock ``SessionMiddleware`` — e.g.
+    django-qsessions' ``qsessions.middleware.SessionMiddleware`` — are recognized.
+
+    Returns:
+        True if a ``SessionMiddleware`` (or subclass) is present, else False.
+    """
+    for middleware_path in getattr(settings, "MIDDLEWARE", None) or ():
+        try:
+            middleware_class = import_string(middleware_path)
+        except ImportError:
+            # Unimportable middleware is reported elsewhere; skip it here.
+            continue
+        if isinstance(middleware_class, type) and issubclass(middleware_class, SessionMiddleware):
+            return True
+
+    return False
 
 
 def is_admin_installed() -> bool:
@@ -147,10 +177,14 @@ def should_enable_admin() -> bool:
 
     # Check if required dependencies are installed
     try:
+        # These apps must be in INSTALLED_APPS for admin to function.
+        # NOTE: django.contrib.sessions is intentionally NOT required here —
+        # admin only needs a SessionMiddleware in the chain (checked below),
+        # which alternative backends like django-qsessions provide via a
+        # subclass while replacing the sessions app in INSTALLED_APPS.
         required_apps = [
             "django.contrib.auth",
             "django.contrib.contenttypes",
-            "django.contrib.sessions",
         ]
 
         for app in required_apps:
@@ -161,6 +195,18 @@ def should_enable_admin() -> bool:
                     file=sys.stderr,
                 )
                 return False
+
+        # Admin needs session support in the middleware chain to track login
+        # state. Mirrors Django's own admin.E410 system check.
+        if not _has_session_middleware():
+            print(
+                "[django-bolt] Warning: Django admin is installed but no SessionMiddleware "
+                "(django.contrib.sessions.middleware.SessionMiddleware or a subclass, e.g. "
+                "qsessions.middleware.SessionMiddleware) was found in settings.MIDDLEWARE. "
+                "Admin integration disabled.",
+                file=sys.stderr,
+            )
+            return False
 
         return True
 

--- a/python/example/test_docs_testing_guide.py
+++ b/python/example/test_docs_testing_guide.py
@@ -17,15 +17,15 @@ import httpx
 import pytest
 from django.contrib.auth import get_user_model
 
-from django_bolt import BoltAPI
-from django_bolt.auth import IsAuthenticated, JWTAuthentication, create_jwt_for_user
-from django_bolt.responses import EventSourceResponse, StreamingResponse
-from django_bolt.testing import TestClient
-
 # The real app modules, imported the way the guide's "real project pattern" shows.
 from testproject.api import api
 from users.api import api as users_api
 from users.models import User
+
+from django_bolt import BoltAPI
+from django_bolt.auth import create_jwt_for_user
+from django_bolt.responses import EventSourceResponse, StreamingResponse
+from django_bolt.testing import TestClient
 
 
 # ── TestClient basics ─────────────────────────────────────────────────────────
@@ -136,9 +136,7 @@ def _free_port() -> int:
 @pytest.fixture(scope="module")
 def bolt_server():
     port = _free_port()
-    process = subprocess.Popen(
-        [sys.executable, "manage.py", "runbolt", "--host", "127.0.0.1", "--port", str(port)]
-    )
+    process = subprocess.Popen([sys.executable, "manage.py", "runbolt", "--host", "127.0.0.1", "--port", str(port)])
     client = httpx.Client(base_url=f"http://127.0.0.1:{port}")
     try:
         deadline = time.time() + 15
@@ -148,9 +146,9 @@ def bolt_server():
             try:
                 client.get("/")  # any route works: a response means it's up
                 break
-            except httpx.TransportError:
+            except httpx.TransportError as err:
                 if time.time() > deadline:
-                    raise TimeoutError("server did not become ready in 15s")
+                    raise TimeoutError("server did not become ready in 15s") from err
                 time.sleep(0.2)
         yield client
     finally:

--- a/python/tests/admin_tests/fake_qsessions.py
+++ b/python/tests/admin_tests/fake_qsessions.py
@@ -1,0 +1,15 @@
+"""Stand-in for django-qsessions used by admin detection tests.
+
+django-qsessions replaces ``django.contrib.sessions`` in ``INSTALLED_APPS`` with
+its own ``qsessions`` app, and swaps ``SessionMiddleware`` for a subclass in
+``MIDDLEWARE``. This module mirrors that middleware subclassing so tests can
+exercise admin detection without installing the real package.
+"""
+
+from __future__ import annotations
+
+from django.contrib.sessions.middleware import SessionMiddleware as DjangoSessionMiddleware
+
+
+class SessionMiddleware(DjangoSessionMiddleware):
+    """A SessionMiddleware subclass, like ``qsessions.middleware.SessionMiddleware``."""

--- a/python/tests/admin_tests/test_admin_detection.py
+++ b/python/tests/admin_tests/test_admin_detection.py
@@ -1,0 +1,59 @@
+"""Tests for admin dependency detection (``should_enable_admin``).
+
+Admin is auto-mounted via Django's own ASGI application, whose request handling
+runs ``settings.MIDDLEWARE``. Admin's real session requirement is therefore a
+``SessionMiddleware`` in that chain (mirroring Django's own ``admin.E410``
+system check) — NOT the ``django.contrib.sessions`` app in ``INSTALLED_APPS``.
+This lets alternative backends such as django-qsessions work.
+"""
+
+from __future__ import annotations
+
+from django.conf import settings
+
+from django_bolt.admin.admin_detection import should_enable_admin
+
+QSESSIONS_MIDDLEWARE = "tests.admin_tests.fake_qsessions.SessionMiddleware"
+DJANGO_SESSION_MIDDLEWARE = "django.contrib.sessions.middleware.SessionMiddleware"
+
+
+def _installed_without_sessions() -> list[str]:
+    return [app for app in settings.INSTALLED_APPS if app != "django.contrib.sessions"]
+
+
+def test_admin_enabled_with_qsessions_style_backend(monkeypatch):
+    """Admin enables when the sessions app is replaced by a subclassed backend.
+
+    Simulates a django-qsessions install: ``django.contrib.sessions`` is dropped
+    from INSTALLED_APPS and its middleware is swapped for a subclass. Admin must
+    still be recognized as usable.
+    """
+    middleware = [
+        QSESSIONS_MIDDLEWARE if m == DJANGO_SESSION_MIDDLEWARE else m for m in settings.MIDDLEWARE
+    ]
+    monkeypatch.setattr(settings, "INSTALLED_APPS", _installed_without_sessions())
+    monkeypatch.setattr(settings, "MIDDLEWARE", middleware)
+
+    assert should_enable_admin() is True
+
+
+def test_admin_enabled_with_stock_sessions_app_removed(monkeypatch):
+    """The stock middleware still counts even when the sessions app is absent."""
+    monkeypatch.setattr(settings, "INSTALLED_APPS", _installed_without_sessions())
+    monkeypatch.setattr(settings, "MIDDLEWARE", list(settings.MIDDLEWARE))
+
+    assert should_enable_admin() is True
+
+
+def test_admin_disabled_without_any_session_middleware(monkeypatch):
+    """Admin stays disabled when no SessionMiddleware (or subclass) is present."""
+    middleware = [m for m in settings.MIDDLEWARE if m != DJANGO_SESSION_MIDDLEWARE]
+    monkeypatch.setattr(settings, "INSTALLED_APPS", _installed_without_sessions())
+    monkeypatch.setattr(settings, "MIDDLEWARE", middleware)
+
+    assert should_enable_admin() is False
+
+
+def test_admin_still_enabled_with_default_settings():
+    """Regression guard: the stock test project (sessions app + middleware) works."""
+    assert should_enable_admin() is True

--- a/python/tests/admin_tests/test_admin_detection.py
+++ b/python/tests/admin_tests/test_admin_detection.py
@@ -28,9 +28,7 @@ def test_admin_enabled_with_qsessions_style_backend(monkeypatch):
     from INSTALLED_APPS and its middleware is swapped for a subclass. Admin must
     still be recognized as usable.
     """
-    middleware = [
-        QSESSIONS_MIDDLEWARE if m == DJANGO_SESSION_MIDDLEWARE else m for m in settings.MIDDLEWARE
-    ]
+    middleware = [QSESSIONS_MIDDLEWARE if m == DJANGO_SESSION_MIDDLEWARE else m for m in settings.MIDDLEWARE]
     monkeypatch.setattr(settings, "INSTALLED_APPS", _installed_without_sessions())
     monkeypatch.setattr(settings, "MIDDLEWARE", middleware)
 


### PR DESCRIPTION
Admin is auto-mounted through Django's own ASGI application, whose request handling runs settings.MIDDLEWARE. Admin's real requirement is therefore a SessionMiddleware in that chain (mirroring Django's own admin.E410 system check), not the django.contrib.sessions app in INSTALLED_APPS.

Match against a SessionMiddleware subclass so alternative backends like django-qsessions — which replace the sessions app and subclass the middleware — are recognized instead of spuriously disabling admin.


<!-- Describe the change in 2-3 sentences. Link to any related issue. -->

Fixes #https://github.com/dj-bolt/django-bolt/issues/241


## How was this tested?

- x] `just lint-lib` and `just test-py` pass
- [x] If Rust was changed: `just rebuild` succeeds
- [x] If a new feature is added: tested manually in the example project (`python/example/`)


## Performance consideration

<!-- Django-Bolt is a performance-critical framework. Explain why this change does not regress the hot path, or show benchmark numbers if it touches dispatch/serialization/routing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Did not touch the hot request path.

The functional change is in admin auto-detection during app setup/configuration: it now inspects `settings.MIDDLEWARE` and imports middleware classes to verify a `SessionMiddleware` subclass is present. That work is required to correctly decide whether to enable admin, and it happens at initialization rather than per request.

The rest of the PR is test and docs/example cleanup, with no runtime impact on request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->