### PR TITLE
fix project.urls in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ bolt-mcp = ["bolt-mcp>=0.1.0"]
 [project.urls]
 Homepage = "https://github.com/dj-bolt/django-bolt"
 Repository = "https://github.com/dj-bolt/django-bolt"
-Documentation = "https://github.com/dj-bolt/django-bolt#readme"
+Documentation = "https://bolt.farhana.li/"
 "Bug Tracker" = "https://github.com/dj-bolt/django-bolt/issues"
 [project.scripts]
 django-bolt = "django_bolt.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,10 +53,10 @@ mcp = ["bolt-mcp>=0.1.0"]
 bolt-mcp = ["bolt-mcp>=0.1.0"]
 
 [project.urls]
-Homepage = "https://github.com/FarhanAliRaza/django-bolt"
-Repository = "https://github.com/FarhanAliRaza/django-bolt"
-Documentation = "https://github.com/FarhanAliRaza/django-bolt#readme"
-"Bug Tracker" = "https://github.com/FarhanAliRaza/django-bolt/issues"
+Homepage = "https://github.com/dj-bolt/django-bolt"
+Repository = "https://github.com/dj-bolt/django-bolt"
+Documentation = "https://github.com/dj-bolt/django-bolt#readme"
+"Bug Tracker" = "https://github.com/dj-bolt/django-bolt/issues"
 [project.scripts]
 django-bolt = "django_bolt.cli:main"
 


### PR DESCRIPTION
References were from before creation of the dj-bolt org. Updated to current values.

## How was this tested?

- [x] `just lint-lib` and `just test-py` pass
- [x] If Rust was changed: `just rebuild` succeeds
- [x] If a new feature is added: tested manually in the example project (`python/example/`)


## Performance consideration

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR does not touch the hot request path. It only updates `pyproject.toml` package metadata in `[project.urls]`—changing `Homepage`, `Repository`, `Documentation`, and `Bug Tracker` to the current `dj-bolt/django-bolt` GitHub URLs (including the real documentation URL).

Because this is confined to build/distribution metadata and does not affect runtime request handling, it adds no runtime work and has no performance impact on the hot path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->