### PR TITLE
ci: arm linux wheels

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -188,8 +188,8 @@ jobs:
         run: uv run pytest python/tests/integration -m platform_smoke -s -vv
 
   # Build wheels for Linux x86_64 (covers most Linux users including Arch)
-  linux:
-    name: Build wheels on Linux
+  linux-amd64:
+    name: Build wheels on Linux x86_64
     runs-on: ubuntu-latest
 
     steps:
@@ -215,6 +215,36 @@ jobs:
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: wheels-linux-x86_64
+          path: dist
+
+  # Build wheels for Linux arm64
+  linux-arm64:
+    name: Build wheels on Linux ARM
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Free disk space
+        run: |
+          docker system prune -af
+          docker volume prune -f
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          target: aarch64
+          args: --release --out dist --interpreter 3.12 3.13 3.14
+          sccache: "true"
+          manylinux: auto
+          docker-options: --pull always
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: wheels-linux-aarch64
           path: dist
 
   # Build wheels for macOS
@@ -294,7 +324,7 @@ jobs:
   validate:
     name: Validate wheels
     runs-on: ubuntu-latest
-    needs: [linux, macos, windows, sdist]
+    needs: [linux-amd64,linux-arm64, macos, windows, sdist]
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -355,7 +385,7 @@ jobs:
     name: Artifact Smoke ${{ matrix.artifact-kind }}
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [linux, sdist]
+    needs: [linux-amd64, sdist]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fixes #256 

Adds 'linux-arm64' wheels step using ubuntu-24.04-arm runner. Renames old 'linux' wheels step to 'linux-amd64'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The PR does not touch the hot request path. It only changes CI workflow jobs to build and validate Linux AMD64 and ARM64 wheels. No runtime code or request-processing logic is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->