### PR TITLE
ci: drive supported Python versions from pyproject.toml classifiers

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,14 +14,48 @@ permissions:
   contents: read
 
 jobs:
+  # Supported Python versions, parsed from the pyproject.toml classifiers
+  python-versions:
+    name: Read Python versions from pyproject.toml
+    runs-on: ubuntu-latest
+    outputs:
+      versions-json: ${{ steps.extract.outputs.versions-json }}
+      versions: ${{ steps.extract.outputs.versions }}
+      min-max-json: ${{ steps.extract.outputs.min-max-json }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Extract supported versions from classifiers
+        id: extract
+        run: |
+          python3 - <<'EOF' >> "$GITHUB_OUTPUT"
+          import json
+          import tomllib
+
+          with open("pyproject.toml", "rb") as f:
+              classifiers = tomllib.load(f)["project"]["classifiers"]
+          prefix = "Programming Language :: Python :: 3."
+          versions = sorted(
+              (c.removeprefix("Programming Language :: Python :: ") for c in classifiers if c.startswith(prefix)),
+              key=lambda v: tuple(map(int, v.split("."))),
+          )
+          assert versions, "no 'Programming Language :: Python :: 3.X' classifiers in pyproject.toml"
+          print(f"versions-json={json.dumps(versions)}")
+          print(f"versions={' '.join(versions)}")
+          print(f"min-max-json={json.dumps([versions[0], versions[-1]])}")
+          EOF
+
   # Run tests across Python versions
   test:
     name: Test Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    needs: python-versions
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ${{ fromJSON(needs.python-versions.outputs.versions-json) }}
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -101,10 +135,11 @@ jobs:
   server_integration_linux:
     name: Server Integration Linux Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    needs: python-versions
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.14"]
+        python-version: ${{ fromJSON(needs.python-versions.outputs.min-max-json) }}
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -191,6 +226,7 @@ jobs:
   linux-amd64:
     name: Build wheels on Linux x86_64
     runs-on: ubuntu-latest
+    needs: python-versions
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -206,7 +242,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: x86_64
-          args: --release --out dist --interpreter 3.12 3.13 3.14
+          args: --release --out dist --interpreter ${{ needs.python-versions.outputs.versions }}
           sccache: "true"
           manylinux: auto
           docker-options: --pull always
@@ -221,6 +257,7 @@ jobs:
   linux-arm64:
     name: Build wheels on Linux ARM
     runs-on: ubuntu-24.04-arm
+    needs: python-versions
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -236,7 +273,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: aarch64
-          args: --release --out dist --interpreter 3.12 3.13 3.14
+          args: --release --out dist --interpreter ${{ needs.python-versions.outputs.versions }}
           sccache: "true"
           manylinux: auto
           docker-options: --pull always
@@ -251,6 +288,7 @@ jobs:
   macos:
     name: Build wheels on macOS
     runs-on: macos-latest
+    needs: python-versions
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -261,7 +299,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: universal2-apple-darwin
-          args: --release --out dist --interpreter 3.12 3.13 3.14
+          args: --release --out dist --interpreter ${{ needs.python-versions.outputs.versions }}
           sccache: "true"
 
       - name: Upload wheels
@@ -274,6 +312,7 @@ jobs:
   windows:
     name: Build wheels on Windows
     runs-on: windows-latest
+    needs: python-versions
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -284,7 +323,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: x64
-          args: --release --out dist --interpreter 3.12 3.13 3.14
+          args: --release --out dist --interpreter ${{ needs.python-versions.outputs.versions }}
           sccache: "true"
 
       - name: Upload wheels

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,7 +377,7 @@ uv run --with pytest pytest python/tests -s -vv
 
 ## Supported Versions
 
-- **Python**: 3.10, 3.11, 3.12, 3.13
+- **Python**: 3.12, 3.13, 3.14 (source of truth: the `pyproject.toml` classifiers, which CI reads)
 - **Django**: 4.2, 5.0, 5.1
 - **PyPy**: Supported (performance slower than CPython)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,7 +378,7 @@ uv run --with pytest pytest python/tests -s -vv
 ## Supported Versions
 
 - **Python**: 3.12, 3.13, 3.14 (source of truth: the `pyproject.toml` classifiers, which CI reads)
-- **Django**: 4.2, 5.0, 5.1
+- **Django**: 4.2, 5.0, 5.1, 5.2, 6.0
 - **PyPy**: Supported (performance slower than CPython)
 
 ## Project Structure (python/django_bolt)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    # "Programming Language :: Python :: 3.14", coming when msgspec has 3.14 support
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Rust",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ classifiers = [
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
     "Topic :: Software Development :: Libraries :: Application Frameworks",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dev = [
     "pydantic>=2",
     "pyyaml>=5.2",
     "maturin>=1.9.6",
-    "django==6.0.6",
+    "django==6.0.7",
     "ruff>=0.8",
     "vulture>=2.11", #for dead code detection
     "nanodjango>=0.16",

--- a/uv.lock
+++ b/uv.lock
@@ -137,16 +137,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "6.0.6"
+version = "6.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/29/ac41e16097af67066d97a7d5775c5d8e7efc5d0284f6b0a159e07b9adb92/django-6.0.6.tar.gz", hash = "sha256:ad03916ba59523d781ae5c3f631960c23d69a9d9c43cecda52fc23b47e953713", size = 10905525, upload-time = "2026-06-03T13:02:46.503Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/55/664f24ff81c9ea19cb7dfc851afeae1f3c2390c7aee01d4ded68b5c1580d/django-6.0.7.tar.gz", hash = "sha256:2998503fc083124fb58037084bfa00de323c7c743f05f1b4284e77bff0ab8890", size = 10921299, upload-time = "2026-07-07T13:51:26.485Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/50/23f9dc45483419a3cc2085b498b25adfbf10642b2941c73e6d2dfaffc9ab/django-6.0.6-py3-none-any.whl", hash = "sha256:25148b1194c47c2e685e5f5e9c5d59c78b075dfd282cb9618861ba6c1708f4d2", size = 8373354, upload-time = "2026-06-03T13:02:41.72Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ec/1ce5334b6a2c52ce619c23a0be8d366a57a0e080ebb2d88266e5c849157c/django-6.0.7-py3-none-any.whl", hash = "sha256:a037427c2288443a8c02a1b02295a31c239663aa682bc50b1976afb7cf6a769e", size = 8373344, upload-time = "2026-07-07T13:51:20.007Z" },
 ]
 
 [[package]]
@@ -217,7 +217,7 @@ provides-extras = ["yaml", "nanodjango", "mcp", "bolt-mcp"]
 [package.metadata.requires-dev]
 dev = [
     { name = "bolt-mcp", editable = "python/bolt-mcp" },
-    { name = "django", specifier = "==6.0.6" },
+    { name = "django", specifier = "==6.0.7" },
     { name = "maturin", specifier = ">=1.9.6" },
     { name = "nanodjango", specifier = ">=0.16" },
     { name = "openapi-spec-validator", specifier = ">=0.8.5" },


### PR DESCRIPTION
The test matrix and the maturin --interpreter list for all wheel jobs previously hardcoded "3.12 3.13 3.14" in six places, which drifted from pyproject.toml (still missing the 3.14 classifier despite CI building and testing 3.14). A new python-versions job parses the "Programming Language :: Python :: 3.X" classifiers and every consumer reads its outputs, so adding or dropping a version is a one-line classifier change. Also enables the 3.14 classifier (msgspec>=0.20 supports it) and corrects the stale version list in CLAUDE.md.


Followup @jameswinegar 
>if possible could you make it so 3.12 3.13 3.14 is emitted from one spot instead of two? I'm wondering if there's a way we could drive this from pyproject.toml so it only lives in one spot, and we'd also fix pyproject.toml so that it represents the support versions correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Hot request path

The PR does **not** touch the hot request path. All changes are confined to CI workflow configuration (`.github/workflows/CI.yml`), packaging metadata (`pyproject.toml`), and documentation (`CLAUDE.md`).

No runtime request-handling or server-side code paths were modified, so there’s no performance impact or unnecessary work introduced on the hot path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->