### PR TITLE
feat(auth): cookie-based JWT tokens and per-route custom get_user

### DIFF
--- a/bench/BENCHMARK_BASELINE.md
+++ b/bench/BENCHMARK_BASELINE.md
@@ -1,513 +1,529 @@
 # Django-Bolt Benchmark
-Generated: Sat 30 May 2026 08:57:55 PM PKT
+Generated: Thu 02 Jul 2026 02:30:40 AM PKT
 Config: 8 processes × 1 workers | C=100 N=10000
 
 ## Root Endpoint Performance
-  Reqs/sec    172699.32   27577.98  196308.64
-  Latency      554.77us   357.65us     6.34ms
+  Reqs/sec    185702.47   23573.92  199741.37
+  Latency      534.73us   317.58us     4.47ms
   Latency Distribution
-     50%   466.00us
-     75%   665.00us
-     90%     0.87ms
-     99%     2.18ms
+     50%   464.00us
+     75%   609.00us
+     90%   805.00us
+     99%     2.09ms
 
 ## 10kb JSON Response Performance
 ### 10kb JSON (Async) (/10k-json)
-  Reqs/sec    115793.77    8867.72  125174.08
-  Latency      842.22us   298.58us     4.45ms
+  Reqs/sec    119561.64   13058.99  128884.58
+  Latency      829.31us   395.81us     6.47ms
   Latency Distribution
-     50%   776.00us
-     75%     1.04ms
-     90%     1.29ms
-     99%     2.25ms
+     50%   749.00us
+     75%     0.99ms
+     90%     1.27ms
+     99%     2.88ms
 ### 10kb JSON (Sync) (/sync-10k-json)
-  Reqs/sec    115003.36   12109.06  127872.30
-  Latency      817.15us   344.51us     5.29ms
+  Reqs/sec    124424.75   12717.67  134418.62
+  Latency      788.82us   364.30us     4.89ms
   Latency Distribution
-     50%   724.00us
-     75%     0.98ms
-     90%     1.28ms
-     99%     2.40ms
+     50%   720.00us
+     75%     0.90ms
+     90%     1.27ms
+     99%     2.67ms
 
 ## Response Type Endpoints
 ### Header Endpoint (/header)
-  Reqs/sec     94010.76    6937.25   99901.51
-  Latency        1.05ms   377.50us     4.61ms
+  Reqs/sec    108563.12    9519.99  118053.94
+  Latency        0.91ms   352.72us     5.41ms
   Latency Distribution
-     50%     0.97ms
-     75%     1.30ms
-     90%     1.66ms
-     99%     2.68ms
+     50%   815.00us
+     75%     1.11ms
+     90%     1.44ms
+     99%     2.44ms
 ### Cookie Endpoint (/cookie)
-  Reqs/sec    101560.72    8190.18  107796.73
-  Latency        0.97ms   307.28us     5.46ms
+  Reqs/sec    113082.65   11480.29  125597.58
+  Latency        0.88ms   266.15us     3.43ms
   Latency Distribution
-     50%     0.91ms
-     75%     1.18ms
-     90%     1.46ms
-     99%     2.17ms
+     50%   816.00us
+     75%     1.08ms
+     90%     1.39ms
+     99%     2.11ms
 ### Exception Endpoint (/exc)
-  Reqs/sec    137735.69   14141.74  147362.85
-  Latency      709.03us   360.21us     6.28ms
+  Reqs/sec    153272.92    7150.44  157782.49
+  Latency      639.36us   226.62us     5.04ms
   Latency Distribution
-     50%   611.00us
-     75%     0.86ms
-     90%     1.13ms
-     99%     1.91ms
+     50%   601.00us
+     75%   759.00us
+     90%     0.89ms
+     99%     1.55ms
 ### HTML Response (/html)
-  Reqs/sec    143465.70   30586.94  175371.28
-  Latency      610.29us   324.90us     4.73ms
+  Reqs/sec    168048.22   15979.16  177986.43
+  Latency      583.34us   236.81us     3.83ms
   Latency Distribution
      50%   526.00us
-     75%   712.00us
-     90%     1.00ms
-     99%     2.34ms
+     75%   696.00us
+     90%     0.87ms
+     99%     1.64ms
 ### Redirect Response (/redirect)
 ### File Static via FileResponse (/file-static)
-  Reqs/sec     35138.34    5614.74   39011.81
-  Latency        2.83ms     1.27ms    17.35ms
+  Reqs/sec     36734.39    7439.58   41337.29
+  Latency        2.72ms     1.42ms    16.35ms
   Latency Distribution
-     50%     2.59ms
-     75%     3.40ms
-     90%     4.35ms
-     99%     7.79ms
+     50%     2.42ms
+     75%     3.14ms
+     90%     4.24ms
+     99%     8.61ms
 
 ## Native Static & Media File Serving
 ### Static 1KB CSS (GET /static/bench/asset_1k.css)
-  Reqs/sec    106574.41   23840.17  132126.42
-  Latency      826.37us   434.63us     5.79ms
+  Reqs/sec    130014.88   16975.36  147961.89
+  Latency      761.80us   508.60us     7.11ms
   Latency Distribution
-     50%   713.00us
-     75%     1.00ms
-     90%     1.41ms
-     99%     2.93ms
-### Static 1KB CSS (HEAD /static/bench/asset_1k.css)
-  Reqs/sec    121927.57   12477.49  134743.96
-  Latency      788.89us   381.03us     6.09ms
-  Latency Distribution
-     50%   713.00us
-     75%     0.93ms
-     90%     1.24ms
-     99%     2.65ms
-### Static 100KB JS (GET /static/bench/asset_100k.js)
-  Reqs/sec     55299.05   30853.60   79817.23
-  Latency        1.45ms     2.64ms    44.33ms
-  Latency Distribution
-     50%     1.07ms
-     75%     1.49ms
-     90%     1.96ms
-     99%     9.45ms
-### Static 404 miss (GET /static/bench/missing.css)
-  Reqs/sec    137746.80   46259.34  172411.06
-  Latency      604.23us   314.38us     5.09ms
-  Latency Distribution
-     50%   512.00us
-     75%   764.00us
-     90%     0.95ms
-     99%     1.82ms
-### Media 1KB (GET /media/bench/upload_1k.bin)
-  Reqs/sec    134933.77   17010.01  148095.69
-  Latency      712.95us   357.45us     7.92ms
-  Latency Distribution
-     50%   748.00us
-     75%     0.88ms
+     50%   677.00us
+     75%   817.00us
      90%     1.03ms
-     99%     2.10ms
-### Media 100KB (GET /media/bench/upload_100k.bin)
-  Reqs/sec     74661.66   11370.82   86656.51
-  Latency        1.30ms     2.27ms    44.33ms
+     99%     3.55ms
+### Static 1KB CSS (HEAD /static/bench/asset_1k.css)
+  Reqs/sec    140456.10   11901.62  148249.95
+  Latency      690.96us   333.90us     7.38ms
   Latency Distribution
-     50%     1.06ms
+     50%   627.00us
+     75%   802.00us
+     90%     1.00ms
+     99%     2.20ms
+### Static 100KB JS (GET /static/bench/asset_100k.js)
+  Reqs/sec     60166.49   30648.52   84113.11
+  Latency        1.31ms     2.58ms    42.78ms
+  Latency Distribution
+     50%     0.97ms
      75%     1.30ms
-     90%     1.70ms
-     99%     4.50ms
+     90%     1.87ms
+     99%     6.57ms
+### Static 404 miss (GET /static/bench/missing.css)
+  Reqs/sec    173621.30   20949.33  186126.47
+  Latency      563.32us   277.45us     4.59ms
+  Latency Distribution
+     50%   522.00us
+     75%   656.00us
+     90%   846.00us
+     99%     1.97ms
+### Media 1KB (GET /media/bench/upload_1k.bin)
+  Reqs/sec    146834.15   14578.21  155843.45
+  Latency      671.03us   312.52us     5.20ms
+  Latency Distribution
+     50%   615.00us
+     75%   762.00us
+     90%   843.00us
+     99%     1.84ms
+### Media 100KB (GET /media/bench/upload_100k.bin)
+  Reqs/sec     55607.56   40233.39   92919.16
+  Latency        1.26ms     3.32ms    44.31ms
+  Latency Distribution
+     50%   847.00us
+     75%     1.05ms
+     90%     1.43ms
+     99%    12.55ms
 
 ## Union Response Overhead
 ### Single struct, no union (/bench/single)
-  Reqs/sec    157026.34    8938.73  165942.76
-  Latency      616.31us   400.13us     8.88ms
+  Reqs/sec    183180.21   19162.50  195673.23
+  Latency      535.21us   234.90us     5.69ms
   Latency Distribution
-     50%   529.00us
-     75%   704.00us
-     90%     0.95ms
-     99%     2.44ms
+     50%   568.00us
+     75%   675.00us
+     90%   756.00us
+     99%     1.43ms
 ### Single struct via tagged union (/bench/union-single)
-  Reqs/sec    158782.00   10055.88  166854.09
-  Latency      618.70us   386.96us     5.54ms
+  Reqs/sec    163224.75   18354.19  178199.99
+  Latency      596.34us   389.04us     4.60ms
   Latency Distribution
-     50%   543.00us
-     75%   714.00us
-     90%     0.90ms
-     99%     2.69ms
+     50%   509.00us
+     75%   681.00us
+     90%     0.96ms
+     99%     3.20ms
 ### List of 100 structs, no union (/bench/list)
-  Reqs/sec     70859.47    4105.08   73599.80
-  Latency        1.39ms   487.40us     6.84ms
-  Latency Distribution
-     50%     1.32ms
-     75%     1.73ms
-     90%     2.13ms
-     99%     3.12ms
-### List of 100 structs via tagged union (/bench/union-list)
-  Reqs/sec     68246.93    2968.98   71028.02
-  Latency        1.44ms   408.69us     5.75ms
+  Reqs/sec     72646.59    4270.69   77506.33
+  Latency        1.36ms   326.29us     5.19ms
   Latency Distribution
      50%     1.34ms
-     75%     1.82ms
-     90%     2.18ms
-     99%     3.05ms
+     75%     1.63ms
+     90%     1.80ms
+     99%     2.69ms
+### List of 100 structs via tagged union (/bench/union-list)
+  Reqs/sec     69465.02    4729.83   74631.81
+  Latency        1.40ms   327.95us     4.75ms
+  Latency Distribution
+     50%     1.33ms
+     75%     1.70ms
+     90%     1.87ms
+     99%     2.71ms
 
 ## Authentication & Authorization Performance
 ### Auth NO User Access (/auth/no-user-access) - lazy loading, no DB query
-  Reqs/sec     79319.75    6930.14   86599.80
-  Latency        1.23ms   389.50us     4.96ms
+  Reqs/sec     82861.99    5982.94   86940.10
+  Latency        1.19ms   367.73us     4.74ms
   Latency Distribution
-     50%     1.14ms
-     75%     1.51ms
-     90%     1.91ms
+     50%     1.11ms
+     75%     1.46ms
+     90%     1.82ms
      99%     2.85ms
 ### Get Authenticated User (/auth/me) - accesses request.user, triggers DB query
-  Reqs/sec     16621.26    1294.01   17668.49
-  Latency        5.97ms     1.69ms    15.53ms
+  Reqs/sec     18867.28    1808.99   22705.12
+  Latency        5.30ms     1.29ms    12.83ms
+  Latency Distribution
+     50%     5.17ms
+     75%     6.07ms
+     90%     7.14ms
+     99%    10.16ms
+### Get User via Dependency (/auth/me-dependency)
+  Reqs/sec     15586.21    3033.07   17466.81
+  Latency        6.16ms     4.17ms    68.59ms
   Latency Distribution
      50%     5.55ms
-     75%     6.47ms
-     90%     9.15ms
-     99%    12.22ms
-### Get User via Dependency (/auth/me-dependency)
-  Reqs/sec     14765.04     724.46   15507.46
-  Latency        6.72ms     2.17ms    15.38ms
-  Latency Distribution
-     50%     6.55ms
-     75%     8.35ms
-     90%    10.04ms
-     99%    12.80ms
+     75%     7.21ms
+     90%     8.94ms
+     99%    13.82ms
 ### Get Auth Context (/auth/context) validated jwt no db
-  Reqs/sec     84790.15   10879.25  105757.31
-  Latency        1.20ms   371.38us     5.53ms
+  Reqs/sec     89098.83    5395.12   92670.21
+  Latency        1.11ms   347.68us     4.80ms
   Latency Distribution
-     50%     1.13ms
-     75%     1.47ms
-     90%     1.83ms
-     99%     2.64ms
+     50%     1.03ms
+     75%     1.38ms
+     90%     1.76ms
+     99%     2.53ms
 
 ## Items GET Performance (/items/1?q=hello)
-  Reqs/sec    138911.22   13961.88  147725.31
-  Latency      698.39us   338.37us     6.09ms
+  Reqs/sec    165037.45   17829.75  176193.08
+  Latency      586.25us   235.42us     5.71ms
   Latency Distribution
-     50%   606.00us
-     75%   839.00us
-     90%     1.13ms
-     99%     2.34ms
+     50%   524.00us
+     75%   615.00us
+     90%     0.92ms
+     99%     1.66ms
 
 ## Items PUT JSON Performance (/items/1)
-  Reqs/sec    140814.75   15519.13  155714.28
-  Latency      684.56us   358.80us     7.69ms
+  Reqs/sec    152146.75   14122.17  160626.40
+  Latency      644.55us   267.78us     5.02ms
   Latency Distribution
-     50%   591.00us
-     75%   783.00us
-     90%     0.98ms
-     99%     2.57ms
+     50%   607.00us
+     75%   683.00us
+     90%     0.90ms
+     99%     1.92ms
 
 ## ORM Performance
 Seeding 1000 users for benchmark...
 Successfully seeded users
 Validated: 10 users exist in database
 ### Users Full10 (Async) (/users/full10)
-  Reqs/sec     14425.12    1381.96   16513.88
-  Latency        6.92ms     1.73ms    20.35ms
+  Reqs/sec     16142.98    1694.70   21581.38
+  Latency        6.21ms     3.48ms    71.67ms
   Latency Distribution
-     50%     6.87ms
-     75%     8.06ms
-     90%     9.29ms
-     99%    12.24ms
+     50%     6.01ms
+     75%     7.16ms
+     90%     9.47ms
+     99%    12.49ms
 ### Users Full10 (Sync) (/users/sync-full10)
-  Reqs/sec     10596.00    1262.12   15333.74
-  Latency        9.45ms     4.21ms    31.32ms
+  Reqs/sec     12271.88    2159.46   15102.70
+  Latency        8.13ms     7.08ms    81.93ms
   Latency Distribution
-     50%     9.06ms
-     75%    12.07ms
-     90%    15.30ms
-     99%    23.30ms
+     50%     6.82ms
+     75%     9.38ms
+     90%    13.07ms
+     99%    27.97ms
 ### Users Mini10 (Async) (/users/mini10)
-  Reqs/sec     17247.78    1215.40   18853.02
-  Latency        5.77ms     1.65ms    16.29ms
+  Reqs/sec     19468.96    1436.38   21461.99
+  Latency        5.10ms     2.10ms    59.60ms
   Latency Distribution
-     50%     5.47ms
-     75%     6.80ms
-     90%     8.46ms
-     99%    11.11ms
+     50%     4.94ms
+     75%     6.07ms
+     90%     7.26ms
+     99%     9.23ms
 ### Users Mini10 (Sync) (/users/sync-mini10)
-  Reqs/sec     12461.27    4083.41   38193.11
-  Latency        8.38ms     3.11ms    27.02ms
+  Reqs/sec     15244.13     931.62   16641.20
+  Latency        6.50ms     2.05ms    18.08ms
   Latency Distribution
-     50%     7.84ms
-     75%    10.48ms
-     90%    13.09ms
-     99%    18.33ms
+     50%     6.16ms
+     75%     7.79ms
+     90%     9.61ms
+     99%    13.32ms
 Cleaning up test users...
 
 ## Class-Based Views (CBV) Performance
 ### Simple APIView GET (/cbv-simple)
-  Reqs/sec    104426.92    7905.53  108915.33
-  Latency        0.94ms   326.34us     4.47ms
+  Reqs/sec    110903.51    6984.54  116356.25
+  Latency        0.89ms   268.97us     3.24ms
   Latency Distribution
-     50%     0.85ms
-     75%     1.17ms
-     90%     1.52ms
-     99%     2.40ms
-### Simple APIView POST (/cbv-simple)
-  Reqs/sec    104556.02    7796.36  110011.60
-  Latency        0.94ms   309.87us     5.23ms
-  Latency Distribution
-     50%     0.89ms
-     75%     1.15ms
+     50%   822.00us
+     75%     1.09ms
      90%     1.41ms
-     99%     2.12ms
-### Items100 ViewSet GET (/cbv-items100)
-  Reqs/sec     65167.73    4353.79   68700.45
-  Latency        1.52ms   442.33us     4.66ms
+     99%     2.11ms
+### Simple APIView POST (/cbv-simple)
+  Reqs/sec    110779.96    7833.22  115444.17
+  Latency        0.89ms   293.96us     4.07ms
   Latency Distribution
-     50%     1.39ms
-     75%     1.81ms
-     90%     2.34ms
-     99%     3.37ms
+     50%   832.00us
+     75%     1.11ms
+     90%     1.39ms
+     99%     2.20ms
+### Items100 ViewSet GET (/cbv-items100)
+  Reqs/sec     68771.59    4768.04   73810.74
+  Latency        1.44ms   472.13us     4.80ms
+  Latency Distribution
+     50%     1.29ms
+     75%     1.78ms
+     90%     2.28ms
+     99%     3.49ms
 
 ## CBV Items - Basic Operations
 ### CBV Items GET (Retrieve) (/cbv-items/1)
-  Reqs/sec     98747.61   10347.91  105914.08
-  Latency        0.99ms   320.55us     4.00ms
+  Reqs/sec    110670.63    6939.29  117088.61
+  Latency        0.89ms   293.63us     4.15ms
   Latency Distribution
-     50%     0.92ms
-     75%     1.25ms
-     90%     1.57ms
-     99%     2.42ms
+     50%   814.00us
+     75%     1.08ms
+     90%     1.41ms
+     99%     2.24ms
 ### CBV Items PUT (Update) (/cbv-items/1)
-  Reqs/sec     98528.97    7017.60  103153.58
-  Latency        0.99ms   307.76us     4.72ms
+  Reqs/sec    106700.03    6390.22  111063.10
+  Latency        0.92ms   280.63us     3.13ms
   Latency Distribution
-     50%     0.93ms
-     75%     1.23ms
-     90%     1.53ms
-     99%     2.18ms
+     50%   846.00us
+     75%     1.15ms
+     90%     1.48ms
+     99%     2.25ms
 
 ## CBV Additional Benchmarks
 ### CBV Bench Parse (POST /cbv-bench-parse)
-  Reqs/sec     99944.06    7551.58  104204.64
-  Latency        0.98ms   334.49us     4.94ms
+  Reqs/sec    108893.20    6700.57  114598.68
+  Latency        0.90ms   280.00us     4.88ms
   Latency Distribution
-     50%     0.92ms
-     75%     1.21ms
-     90%     1.55ms
-     99%     2.40ms
+     50%   836.00us
+     75%     1.11ms
+     90%     1.41ms
+     99%     2.15ms
 ### CBV Response Types (/cbv-response)
-  Reqs/sec    103752.87    8891.57  110609.20
-  Latency        0.95ms   319.25us     4.59ms
+  Reqs/sec    111622.40    6094.53  119199.85
+  Latency        0.87ms   274.35us     3.18ms
   Latency Distribution
-     50%     0.88ms
-     75%     1.17ms
-     90%     1.49ms
-     99%     2.26ms
+     50%   792.00us
+     75%     1.07ms
+     90%     1.41ms
+     99%     2.20ms
 
 ## ORM Performance with CBV
 Seeding 1000 users for CBV benchmark...
 Successfully seeded users
 Validated: 10 users exist in database
 ### Users CBV Mini10 (List) (/users/cbv-mini10)
-  Reqs/sec     15844.43    1275.34   17596.41
-  Latency        6.29ms     1.95ms    18.36ms
+  Reqs/sec     17700.93    1363.77   18921.09
+  Latency        5.61ms     2.56ms    62.88ms
   Latency Distribution
-     50%     5.94ms
-     75%     7.90ms
-     90%     9.43ms
-     99%    12.12ms
+     50%     5.39ms
+     75%     6.61ms
+     90%     7.60ms
+     99%     9.59ms
 Cleaning up test users...
 
 
 ## Form and File Upload Performance
 ### Form Data (POST /form)
-  Reqs/sec    113586.83   11090.40  124793.97
-  Latency      837.65us   399.53us     5.86ms
+  Reqs/sec    137854.40   12023.63  148563.57
+  Latency      709.94us   293.45us     4.81ms
   Latency Distribution
-     50%   732.00us
-     75%     1.03ms
-     90%     1.45ms
-     99%     2.54ms
+     50%   642.00us
+     75%   846.00us
+     90%     1.04ms
+     99%     1.85ms
 ### File Upload (POST /upload)
-  Reqs/sec    102478.95    5831.30  108388.89
-  Latency        0.95ms   424.67us     6.11ms
+  Reqs/sec    119336.10   10885.62  128706.23
+  Latency      836.13us   359.81us     6.62ms
   Latency Distribution
-     50%     0.86ms
-     75%     1.14ms
-     90%     1.57ms
-     99%     2.92ms
+     50%   769.00us
+     75%     1.00ms
+     90%     1.26ms
+     99%     1.96ms
 ### Mixed Form with Files (POST /mixed-form)
-  Reqs/sec     86038.58   32640.53  108247.67
-  Latency        0.98ms   488.85us     7.18ms
+  Reqs/sec    112318.27   10225.94  121279.65
+  Latency        0.88ms   314.96us     5.32ms
   Latency Distribution
-     50%     0.86ms
-     75%     1.21ms
-     90%     1.68ms
-     99%     2.99ms
+     50%   820.00us
+     75%     1.02ms
+     90%     1.29ms
+     99%     2.12ms
+### Form Repeated Keys urlencoded (POST /form-list)
+  Reqs/sec    130222.81   13334.06  139272.44
+  Latency      752.75us   344.07us     5.70ms
+  Latency Distribution
+     50%   724.00us
+     75%     0.92ms
+     90%     1.06ms
+     99%     1.91ms
+### Form Repeated Keys multipart (POST /form-list)
+  Reqs/sec    105184.20    5307.44  107903.76
+  Latency        0.93ms   279.32us     4.42ms
+  Latency Distribution
+     50%     0.91ms
+     75%     1.20ms
+     90%     1.51ms
+     99%     2.13ms
 
 ## Django Middleware Performance
 ### Django Middleware + Messages Framework (/middleware/demo)
 Tests: SessionMiddleware, AuthenticationMiddleware, MessageMiddleware, custom middleware, template rendering
-  Reqs/sec     10058.00    6091.40   54006.37
-  Latency       10.78ms     2.66ms    24.14ms
+  Reqs/sec      8396.97    1479.84   15083.28
+  Latency       11.99ms     7.03ms    84.03ms
   Latency Distribution
-     50%    10.19ms
-     75%    12.24ms
-     90%    15.05ms
-     99%    19.82ms
+     50%    11.51ms
+     75%    13.00ms
+     90%    16.37ms
+     99%    25.20ms
 
 ## Django Ninja-style Benchmarks
 ### JSON Parse/Validate (POST /bench/parse)
-  Reqs/sec    151741.31   13000.54  160035.95
-  Latency      648.92us   303.36us     6.17ms
+  Reqs/sec    145891.37   14133.89  156525.31
+  Latency      666.69us   266.62us     4.35ms
   Latency Distribution
-     50%   609.00us
-     75%   733.00us
-     90%     0.91ms
-     99%     1.85ms
+     50%   596.00us
+     75%   830.00us
+     90%     1.07ms
+     99%     1.90ms
 
 ## Serializer Performance Benchmarks
 ### Raw msgspec Serializer (POST /bench/serializer-raw)
-  Reqs/sec    140966.35   13647.12  156634.37
-  Latency      681.20us   319.30us     5.56ms
+  Reqs/sec    153182.45   10006.13  159822.23
+  Latency      644.42us   293.50us     4.89ms
   Latency Distribution
-     50%   606.00us
-     75%   839.00us
-     90%     1.09ms
-     99%     2.08ms
+     50%   580.00us
+     75%   745.00us
+     90%     0.93ms
+     99%     2.06ms
 ### Django-Bolt Serializer with Validators (POST /bench/serializer-validated)
-  Reqs/sec     84087.25   10388.10   92168.60
-  Latency        1.17ms   541.43us     8.96ms
+  Reqs/sec     90606.15    9475.14  101804.31
+  Latency        1.09ms   428.89us     6.82ms
   Latency Distribution
-     50%     1.08ms
-     75%     1.46ms
-     90%     1.85ms
+     50%     0.99ms
+     75%     1.32ms
+     90%     1.71ms
      99%     3.19ms
 ### Users msgspec Serializer (POST /users/bench/msgspec)
-  Reqs/sec    136717.68   11750.46  145299.04
-  Latency      711.89us   358.20us     6.72ms
+  Reqs/sec    146583.21   12371.29  160101.14
+  Latency      663.51us   264.61us     4.59ms
   Latency Distribution
-     50%   611.00us
-     75%     0.87ms
-     90%     1.20ms
-     99%     2.28ms
+     50%   627.00us
+     75%   786.00us
+     90%     1.01ms
+     99%     1.85ms
 
 ## Multi-Response Performance
 
 ### Multi-response tuple return (/bench/multi/tuple)
-  Reqs/sec    100901.62    6888.74  105792.04
-  Latency        0.97ms   315.17us     4.75ms
+  Reqs/sec    114514.32    9004.46  120252.69
+  Latency        0.87ms   250.16us     2.83ms
   Latency Distribution
-     50%     0.91ms
-     75%     1.19ms
-     90%     1.48ms
-     99%     2.30ms
+     50%   805.00us
+     75%     1.05ms
+     90%     1.32ms
+     99%     2.12ms
 
 ### Multi-response bare dict (/bench/multi/dict)
-  Reqs/sec    102167.95    8802.03  108399.49
-  Latency        0.96ms   297.76us     4.42ms
+  Reqs/sec    112771.14    8357.32  119383.34
+  Latency        0.87ms   215.54us     2.56ms
   Latency Distribution
-     50%     0.90ms
-     75%     1.19ms
-     90%     1.50ms
-     99%     2.24ms
+     50%   821.00us
+     75%     1.08ms
+     90%     1.33ms
+     99%     1.91ms
 
 ## Union Response Performance
 Polymorphic feed with tagged msgspec Struct union (PostActivity | CommentActivity | LikeActivity)
 
 ### Single union item — Post branch (/feed/0)
-  Reqs/sec     89909.21    5784.94   93857.43
-  Latency        1.09ms   388.06us     6.13ms
+  Reqs/sec    108086.12    7911.05  112200.09
+  Latency        0.91ms   255.66us     3.70ms
   Latency Distribution
-     50%     1.00ms
-     75%     1.36ms
-     90%     1.77ms
-     99%     2.75ms
+     50%   846.00us
+     75%     1.11ms
+     90%     1.42ms
+     99%     2.04ms
 
 ### Single union item — Comment branch (/feed/1)
-  Reqs/sec     92992.99    6252.81   98501.63
-  Latency        1.06ms   324.11us     4.91ms
+  Reqs/sec    107282.18    6251.17  112143.29
+  Latency        0.92ms   238.08us     3.21ms
   Latency Distribution
-     50%     1.00ms
-     75%     1.33ms
-     90%     1.66ms
-     99%     2.37ms
+     50%     0.85ms
+     75%     1.12ms
+     90%     1.41ms
+     99%     2.04ms
 
 ### Single union item — Like branch (/feed/2)
-  Reqs/sec     90600.07    7296.65  100155.22
-  Latency        1.10ms   351.65us     5.03ms
+  Reqs/sec    105836.84    7794.18  111491.91
+  Latency        0.93ms   264.69us     3.47ms
   Latency Distribution
-     50%     1.03ms
-     75%     1.38ms
-     90%     1.73ms
-     99%     2.62ms
+     50%     0.87ms
+     75%     1.15ms
+     90%     1.47ms
+     99%     2.18ms
 
 ### Feed of 100 mixed union items (/feed)
-  Reqs/sec     63082.43    4099.69   69878.20
-  Latency        1.56ms   552.89us     5.90ms
+  Reqs/sec     72953.78    3701.70   75073.40
+  Latency        1.35ms   357.74us     5.55ms
   Latency Distribution
-     50%     1.47ms
-     75%     1.95ms
-     90%     2.43ms
-     99%     3.87ms
+     50%     1.31ms
+     75%     1.63ms
+     90%     1.88ms
+     99%     2.80ms
 
 ## Latency Percentile Benchmarks
 Measures p50/p75/p90/p99 latency for type coercion overhead analysis
 
 ### Baseline - No Parameters (/)
-  Reqs/sec    177286.27   16797.40  189907.39
-  Latency      546.89us   262.91us     5.16ms
+  Reqs/sec    178947.48   17245.25  194591.58
+  Latency      553.68us   301.43us     4.22ms
   Latency Distribution
-     50%   512.00us
-     75%   667.00us
-     90%   831.00us
-     99%     1.66ms
+     50%   505.00us
+     75%   608.00us
+     90%   818.00us
+     99%     2.59ms
 
 ### Path Parameter - int (/items/12345)
-  Reqs/sec    150638.43    9780.16  162928.32
-  Latency      632.60us   277.76us     5.47ms
+  Reqs/sec    155036.89   17077.03  170270.58
+  Latency      606.35us   259.37us     5.10ms
   Latency Distribution
-     50%   559.00us
-     75%   761.00us
-     90%     0.98ms
-     99%     1.78ms
+     50%   566.00us
+     75%   707.00us
+     90%     0.89ms
+     99%     1.69ms
 
 ### Path + Query Parameters (/items/12345?q=hello)
-  Reqs/sec    138722.40   10774.28  152540.36
-  Latency      710.65us   317.23us     4.85ms
+  Reqs/sec    148434.15   15836.83  161392.78
+  Latency      629.19us   327.58us     5.92ms
   Latency Distribution
-     50%   621.00us
-     75%   843.00us
-     90%     1.20ms
-     99%     2.18ms
+     50%   556.00us
+     75%   753.00us
+     90%     1.02ms
+     99%     1.87ms
 
 ### Header Parameter (/header)
-  Reqs/sec     97492.11    8989.11  103037.79
-  Latency        1.01ms   406.62us     5.77ms
+  Reqs/sec    111853.19   11179.85  120281.03
+  Latency        0.88ms   277.95us     3.87ms
   Latency Distribution
-     50%     0.92ms
-     75%     1.24ms
-     90%     1.64ms
-     99%     2.60ms
+     50%   804.00us
+     75%     1.06ms
+     90%     1.39ms
+     99%     2.22ms
 
 ### Cookie Parameter (/cookie)
-  Reqs/sec     88635.21    6522.55   97529.60
-  Latency        1.10ms   381.89us     4.19ms
+  Reqs/sec    112569.93    8362.68  118358.41
+  Latency        0.88ms   267.84us     3.67ms
   Latency Distribution
-     50%     1.02ms
-     75%     1.35ms
-     90%     1.75ms
-     99%     2.87ms
+     50%   816.00us
+     75%     1.09ms
+     90%     1.41ms
+     99%     2.17ms
 
 ### Auth Context - JWT validated, no DB (/auth/context)
-  Reqs/sec     77074.47    4813.92   81026.23
-  Latency        1.29ms   441.94us     6.34ms
+  Reqs/sec     92626.61    4573.47   96216.48
+  Latency        1.06ms   319.66us     4.90ms
   Latency Distribution
-     50%     1.21ms
-     75%     1.58ms
-     90%     1.97ms
-     99%     3.23ms
+     50%     1.00ms
+     75%     1.30ms
+     90%     1.60ms
+     99%     2.40ms

--- a/bench/BENCHMARK_DEV.md
+++ b/bench/BENCHMARK_DEV.md
@@ -1,529 +1,530 @@
 # Django-Bolt Benchmark
-Generated: Thu 02 Jul 2026 02:30:40 AM PKT
+Generated: Sun Jul 12 06:39:26 PM PKT 2026
 Config: 8 processes × 1 workers | C=100 N=10000
 
 ## Root Endpoint Performance
-  Reqs/sec    185702.47   23573.92  199741.37
-  Latency      534.73us   317.58us     4.47ms
+  Reqs/sec    193938.49    9567.84  203890.69
+  Latency      496.80us   274.15us     4.86ms
   Latency Distribution
-     50%   464.00us
-     75%   609.00us
-     90%   805.00us
-     99%     2.09ms
+     50%   481.00us
+     75%   570.00us
+     90%   674.00us
+     99%     1.54ms
 
 ## 10kb JSON Response Performance
 ### 10kb JSON (Async) (/10k-json)
-  Reqs/sec    119561.64   13058.99  128884.58
-  Latency      829.31us   395.81us     6.47ms
+  Reqs/sec    126558.13   11902.99  134453.92
+  Latency      774.13us   282.54us     5.62ms
   Latency Distribution
-     50%   749.00us
-     75%     0.99ms
-     90%     1.27ms
-     99%     2.88ms
+     50%   694.00us
+     75%     0.93ms
+     90%     1.19ms
+     99%     2.13ms
 ### 10kb JSON (Sync) (/sync-10k-json)
-  Reqs/sec    124424.75   12717.67  134418.62
-  Latency      788.82us   364.30us     4.89ms
+  Reqs/sec    123625.68   20875.40  137276.12
+  Latency      795.48us   423.34us     7.60ms
   Latency Distribution
-     50%   720.00us
-     75%     0.90ms
-     90%     1.27ms
-     99%     2.67ms
+     50%   737.00us
+     75%     0.96ms
+     90%     1.17ms
+     99%     3.21ms
 
 ## Response Type Endpoints
 ### Header Endpoint (/header)
-  Reqs/sec    108563.12    9519.99  118053.94
-  Latency        0.91ms   352.72us     5.41ms
+  Reqs/sec    116530.46    8970.96  123930.11
+  Latency      847.73us   273.66us     3.56ms
   Latency Distribution
-     50%   815.00us
-     75%     1.11ms
-     90%     1.44ms
-     99%     2.44ms
+     50%   783.00us
+     75%     1.03ms
+     90%     1.32ms
+     99%     2.10ms
 ### Cookie Endpoint (/cookie)
-  Reqs/sec    113082.65   11480.29  125597.58
-  Latency        0.88ms   266.15us     3.43ms
+  Reqs/sec    115526.78   10462.11  124896.27
+  Latency      836.99us   224.12us     3.05ms
   Latency Distribution
-     50%   816.00us
-     75%     1.08ms
-     90%     1.39ms
-     99%     2.11ms
+     50%   776.00us
+     75%     1.03ms
+     90%     1.29ms
+     99%     1.88ms
 ### Exception Endpoint (/exc)
-  Reqs/sec    153272.92    7150.44  157782.49
-  Latency      639.36us   226.62us     5.04ms
+  Reqs/sec    155112.28   11985.91  165030.79
+  Latency      639.11us   189.01us     4.18ms
   Latency Distribution
-     50%   601.00us
-     75%   759.00us
-     90%     0.89ms
-     99%     1.55ms
+     50%   609.00us
+     75%   760.00us
+     90%     0.95ms
+     99%     1.52ms
 ### HTML Response (/html)
-  Reqs/sec    168048.22   15979.16  177986.43
-  Latency      583.34us   236.81us     3.83ms
+  Reqs/sec    185345.89   15243.21  195557.65
+  Latency      526.35us   228.96us     4.34ms
   Latency Distribution
-     50%   526.00us
-     75%   696.00us
-     90%     0.87ms
-     99%     1.64ms
+     50%   497.00us
+     75%   602.00us
+     90%   712.00us
+     99%     1.61ms
 ### Redirect Response (/redirect)
 ### File Static via FileResponse (/file-static)
-  Reqs/sec     36734.39    7439.58   41337.29
-  Latency        2.72ms     1.42ms    16.35ms
+  Reqs/sec     41151.34    8075.01   46611.50
+  Latency        2.42ms     1.35ms    15.28ms
   Latency Distribution
-     50%     2.42ms
-     75%     3.14ms
-     90%     4.24ms
-     99%     8.61ms
+     50%     2.08ms
+     75%     2.78ms
+     90%     3.78ms
+     99%     7.92ms
 
 ## Native Static & Media File Serving
 ### Static 1KB CSS (GET /static/bench/asset_1k.css)
-  Reqs/sec    130014.88   16975.36  147961.89
-  Latency      761.80us   508.60us     7.11ms
+  Reqs/sec    161011.41   18925.48  175054.97
+  Latency      604.77us   285.76us     4.54ms
   Latency Distribution
-     50%   677.00us
-     75%   817.00us
-     90%     1.03ms
-     99%     3.55ms
+     50%   539.00us
+     75%   708.00us
+     90%   817.00us
+     99%     2.27ms
 ### Static 1KB CSS (HEAD /static/bench/asset_1k.css)
-  Reqs/sec    140456.10   11901.62  148249.95
-  Latency      690.96us   333.90us     7.38ms
+  Reqs/sec    167791.11   14335.80  176926.42
+  Latency      578.12us   195.31us     5.03ms
   Latency Distribution
-     50%   627.00us
-     75%   802.00us
-     90%     1.00ms
-     99%     2.20ms
+     50%   528.00us
+     75%   729.00us
+     90%   803.00us
+     99%     1.13ms
 ### Static 100KB JS (GET /static/bench/asset_100k.js)
-  Reqs/sec     60166.49   30648.52   84113.11
-  Latency        1.31ms     2.58ms    42.78ms
+  Reqs/sec     70985.43   38158.89   99301.74
+  Latency        1.18ms     3.22ms    42.66ms
   Latency Distribution
-     50%     0.97ms
-     75%     1.30ms
-     90%     1.87ms
-     99%     6.57ms
+     50%   767.00us
+     75%     0.95ms
+     90%     1.17ms
+     99%    12.35ms
 ### Static 404 miss (GET /static/bench/missing.css)
-  Reqs/sec    173621.30   20949.33  186126.47
-  Latency      563.32us   277.45us     4.59ms
+  Reqs/sec    195640.08   19960.63  209521.80
+  Latency      499.41us   239.53us     4.20ms
   Latency Distribution
-     50%   522.00us
-     75%   656.00us
-     90%   846.00us
-     99%     1.97ms
+     50%   472.00us
+     75%   540.00us
+     90%   702.00us
+     99%     1.39ms
 ### Media 1KB (GET /media/bench/upload_1k.bin)
-  Reqs/sec    146834.15   14578.21  155843.45
-  Latency      671.03us   312.52us     5.20ms
+  Reqs/sec    154647.66   17699.91  173785.18
+  Latency      604.82us   259.61us     4.44ms
   Latency Distribution
-     50%   615.00us
-     75%   762.00us
-     90%   843.00us
-     99%     1.84ms
+     50%   558.00us
+     75%   703.00us
+     90%     0.99ms
+     99%     2.23ms
 ### Media 100KB (GET /media/bench/upload_100k.bin)
-  Reqs/sec     55607.56   40233.39   92919.16
-  Latency        1.26ms     3.32ms    44.31ms
+  Reqs/sec     61430.43   43259.35   98690.97
+  Latency        1.18ms     3.38ms    43.24ms
   Latency Distribution
-     50%   847.00us
-     75%     1.05ms
-     90%     1.43ms
+     50%   728.00us
+     75%     0.91ms
+     90%     1.16ms
      99%    12.55ms
 
 ## Union Response Overhead
 ### Single struct, no union (/bench/single)
-  Reqs/sec    183180.21   19162.50  195673.23
-  Latency      535.21us   234.90us     5.69ms
+  Reqs/sec    186204.98   17735.14  197804.69
+  Latency      514.27us   181.32us     4.68ms
   Latency Distribution
-     50%   568.00us
-     75%   675.00us
-     90%   756.00us
-     99%     1.43ms
+     50%   451.00us
+     75%   643.00us
+     90%   743.00us
+     99%     1.24ms
 ### Single struct via tagged union (/bench/union-single)
-  Reqs/sec    163224.75   18354.19  178199.99
-  Latency      596.34us   389.04us     4.60ms
+  Reqs/sec    184075.61   20318.18  197735.40
+  Latency      532.22us   290.73us     5.02ms
   Latency Distribution
-     50%   509.00us
-     75%   681.00us
-     90%     0.96ms
-     99%     3.20ms
+     50%   528.00us
+     75%   620.00us
+     90%   690.00us
+     99%     1.65ms
 ### List of 100 structs, no union (/bench/list)
-  Reqs/sec     72646.59    4270.69   77506.33
-  Latency        1.36ms   326.29us     5.19ms
+  Reqs/sec     74344.97    4477.82   76898.86
+  Latency        1.33ms   352.05us     4.96ms
   Latency Distribution
-     50%     1.34ms
-     75%     1.63ms
-     90%     1.80ms
-     99%     2.69ms
+     50%     1.31ms
+     75%     1.51ms
+     90%     1.73ms
+     99%     2.81ms
 ### List of 100 structs via tagged union (/bench/union-list)
-  Reqs/sec     69465.02    4729.83   74631.81
-  Latency        1.40ms   327.95us     4.75ms
+  Reqs/sec     63612.15   20321.04   76175.50
+  Latency        1.40ms   454.24us     6.21ms
   Latency Distribution
-     50%     1.33ms
-     75%     1.70ms
-     90%     1.87ms
-     99%     2.71ms
+     50%     1.41ms
+     75%     1.66ms
+     90%     2.12ms
+     99%     3.28ms
 
 ## Authentication & Authorization Performance
 ### Auth NO User Access (/auth/no-user-access) - lazy loading, no DB query
-  Reqs/sec     82861.99    5982.94   86940.10
-  Latency        1.19ms   367.73us     4.74ms
+  Reqs/sec     84159.12    5392.06   88318.61
+  Latency        1.17ms   392.27us     4.10ms
   Latency Distribution
-     50%     1.11ms
-     75%     1.46ms
-     90%     1.82ms
-     99%     2.85ms
+     50%     1.05ms
+     75%     1.44ms
+     90%     1.93ms
+     99%     2.94ms
 ### Get Authenticated User (/auth/me) - accesses request.user, triggers DB query
-  Reqs/sec     18867.28    1808.99   22705.12
-  Latency        5.30ms     1.29ms    12.83ms
+ 3690 / 10000 [========================================================>------------------------------------------------------------------------------------------------]  36.90% 18404/s
+  Reqs/sec     18976.17    1508.06   21057.26
+  Latency        5.25ms     1.48ms    13.34ms
   Latency Distribution
-     50%     5.17ms
-     75%     6.07ms
-     90%     7.14ms
-     99%    10.16ms
+     50%     5.21ms
+     75%     6.54ms
+     90%     7.41ms
+     99%     9.84ms
 ### Get User via Dependency (/auth/me-dependency)
-  Reqs/sec     15586.21    3033.07   17466.81
-  Latency        6.16ms     4.17ms    68.59ms
+  Reqs/sec     15208.05    3933.91   18044.69
+  Latency        6.25ms     5.50ms    77.84ms
   Latency Distribution
-     50%     5.55ms
-     75%     7.21ms
-     90%     8.94ms
-     99%    13.82ms
+     50%     5.64ms
+     75%     6.77ms
+     90%     7.88ms
+     99%    11.00ms
 ### Get Auth Context (/auth/context) validated jwt no db
-  Reqs/sec     89098.83    5395.12   92670.21
-  Latency        1.11ms   347.68us     4.80ms
+  Reqs/sec     90229.89    6806.89  100936.70
+  Latency        1.09ms   375.56us     4.05ms
   Latency Distribution
-     50%     1.03ms
-     75%     1.38ms
-     90%     1.76ms
-     99%     2.53ms
+     50%     0.99ms
+     75%     1.32ms
+     90%     1.74ms
+     99%     2.84ms
 
 ## Items GET Performance (/items/1?q=hello)
-  Reqs/sec    165037.45   17829.75  176193.08
-  Latency      586.25us   235.42us     5.71ms
+  Reqs/sec    162773.60   20577.22  175295.28
+  Latency      600.42us   202.45us     3.84ms
   Latency Distribution
-     50%   524.00us
-     75%   615.00us
-     90%     0.92ms
-     99%     1.66ms
+     50%   590.00us
+     75%   705.00us
+     90%   816.00us
+     99%     1.51ms
 
 ## Items PUT JSON Performance (/items/1)
-  Reqs/sec    152146.75   14122.17  160626.40
-  Latency      644.55us   267.78us     5.02ms
+  Reqs/sec    151477.12   15410.46  166269.33
+  Latency      634.09us   334.58us     6.05ms
   Latency Distribution
-     50%   607.00us
-     75%   683.00us
-     90%     0.90ms
-     99%     1.92ms
+     50%   575.00us
+     75%   733.00us
+     90%     0.97ms
+     99%     1.75ms
 
 ## ORM Performance
 Seeding 1000 users for benchmark...
 Successfully seeded users
 Validated: 10 users exist in database
 ### Users Full10 (Async) (/users/full10)
-  Reqs/sec     16142.98    1694.70   21581.38
-  Latency        6.21ms     3.48ms    71.67ms
+  Reqs/sec     13741.78    1058.52   16150.27
+  Latency        7.26ms     3.05ms    73.15ms
   Latency Distribution
-     50%     6.01ms
-     75%     7.16ms
-     90%     9.47ms
-     99%    12.49ms
+     50%     7.24ms
+     75%     8.30ms
+     90%     9.55ms
+     99%    11.77ms
 ### Users Full10 (Sync) (/users/sync-full10)
-  Reqs/sec     12271.88    2159.46   15102.70
-  Latency        8.13ms     7.08ms    81.93ms
+  Reqs/sec     12012.53    9724.62   77220.08
+  Latency        9.36ms     7.43ms    99.88ms
   Latency Distribution
-     50%     6.82ms
-     75%     9.38ms
-     90%    13.07ms
-     99%    27.97ms
+     50%     7.98ms
+     75%    11.08ms
+     90%    14.81ms
+     99%    27.76ms
 ### Users Mini10 (Async) (/users/mini10)
-  Reqs/sec     19468.96    1436.38   21461.99
-  Latency        5.10ms     2.10ms    59.60ms
+  Reqs/sec     17053.28     655.30   18072.37
+  Latency        5.82ms     1.51ms    12.68ms
   Latency Distribution
-     50%     4.94ms
-     75%     6.07ms
-     90%     7.26ms
-     99%     9.23ms
+     50%     5.66ms
+     75%     6.89ms
+     90%     8.37ms
+     99%    10.44ms
 ### Users Mini10 (Sync) (/users/sync-mini10)
-  Reqs/sec     15244.13     931.62   16641.20
-  Latency        6.50ms     2.05ms    18.08ms
+  Reqs/sec     14554.17    1053.44   18375.22
+  Latency        6.87ms     3.33ms    74.20ms
   Latency Distribution
-     50%     6.16ms
-     75%     7.79ms
-     90%     9.61ms
-     99%    13.32ms
+     50%     6.55ms
+     75%     8.31ms
+     90%    10.17ms
+     99%    14.21ms
 Cleaning up test users...
 
 ## Class-Based Views (CBV) Performance
 ### Simple APIView GET (/cbv-simple)
-  Reqs/sec    110903.51    6984.54  116356.25
-  Latency        0.89ms   268.97us     3.24ms
+  Reqs/sec    115012.32   11583.81  125319.43
+  Latency        0.86ms   285.41us     4.40ms
   Latency Distribution
-     50%   822.00us
-     75%     1.09ms
-     90%     1.41ms
-     99%     2.11ms
+     50%   791.00us
+     75%     1.05ms
+     90%     1.35ms
+     99%     2.24ms
 ### Simple APIView POST (/cbv-simple)
-  Reqs/sec    110779.96    7833.22  115444.17
-  Latency        0.89ms   293.96us     4.07ms
+  Reqs/sec    117397.25    9833.19  124100.78
+  Latency      846.15us   238.94us     4.33ms
   Latency Distribution
-     50%   832.00us
-     75%     1.11ms
-     90%     1.39ms
-     99%     2.20ms
+     50%   800.00us
+     75%     1.05ms
+     90%     1.30ms
+     99%     1.95ms
 ### Items100 ViewSet GET (/cbv-items100)
-  Reqs/sec     68771.59    4768.04   73810.74
-  Latency        1.44ms   472.13us     4.80ms
+  Reqs/sec     71850.70    5521.92   78374.72
+  Latency        1.38ms   367.93us     4.32ms
   Latency Distribution
-     50%     1.29ms
-     75%     1.78ms
-     90%     2.28ms
-     99%     3.49ms
+     50%     1.30ms
+     75%     1.63ms
+     90%     2.08ms
+     99%     2.99ms
 
 ## CBV Items - Basic Operations
 ### CBV Items GET (Retrieve) (/cbv-items/1)
-  Reqs/sec    110670.63    6939.29  117088.61
-  Latency        0.89ms   293.63us     4.15ms
+  Reqs/sec    111319.15    9384.23  122133.45
+  Latency        0.87ms   278.42us     4.00ms
   Latency Distribution
-     50%   814.00us
-     75%     1.08ms
-     90%     1.41ms
-     99%     2.24ms
+     50%   797.00us
+     75%     1.06ms
+     90%     1.37ms
+     99%     2.12ms
 ### CBV Items PUT (Update) (/cbv-items/1)
-  Reqs/sec    106700.03    6390.22  111063.10
-  Latency        0.92ms   280.63us     3.13ms
+  Reqs/sec    109767.91    7076.40  115970.73
+  Latency        0.90ms   247.46us     3.30ms
   Latency Distribution
-     50%   846.00us
-     75%     1.15ms
-     90%     1.48ms
-     99%     2.25ms
+     50%   832.00us
+     75%     1.10ms
+     90%     1.41ms
+     99%     2.02ms
 
 ## CBV Additional Benchmarks
 ### CBV Bench Parse (POST /cbv-bench-parse)
-  Reqs/sec    108893.20    6700.57  114598.68
-  Latency        0.90ms   280.00us     4.88ms
+  Reqs/sec    111384.15   12737.59  123157.56
+  Latency        0.88ms   317.04us     5.10ms
   Latency Distribution
-     50%   836.00us
-     75%     1.11ms
-     90%     1.41ms
-     99%     2.15ms
+     50%   805.00us
+     75%     1.09ms
+     90%     1.37ms
+     99%     2.18ms
 ### CBV Response Types (/cbv-response)
-  Reqs/sec    111622.40    6094.53  119199.85
-  Latency        0.87ms   274.35us     3.18ms
+  Reqs/sec    122693.94    7153.51  128446.32
+  Latency      799.58us   235.42us     3.27ms
   Latency Distribution
-     50%   792.00us
-     75%     1.07ms
-     90%     1.41ms
-     99%     2.20ms
+     50%   741.00us
+     75%     0.96ms
+     90%     1.25ms
+     99%     1.95ms
 
 ## ORM Performance with CBV
 Seeding 1000 users for CBV benchmark...
 Successfully seeded users
 Validated: 10 users exist in database
 ### Users CBV Mini10 (List) (/users/cbv-mini10)
-  Reqs/sec     17700.93    1363.77   18921.09
-  Latency        5.61ms     2.56ms    62.88ms
+  Reqs/sec     17388.16    1678.57   19214.67
+  Latency        5.66ms     3.84ms    65.50ms
   Latency Distribution
-     50%     5.39ms
-     75%     6.61ms
-     90%     7.60ms
-     99%     9.59ms
+     50%     5.53ms
+     75%     7.07ms
+     90%     8.77ms
+     99%    12.05ms
 Cleaning up test users...
 
 
 ## Form and File Upload Performance
 ### Form Data (POST /form)
-  Reqs/sec    137854.40   12023.63  148563.57
-  Latency      709.94us   293.45us     4.81ms
+  Reqs/sec    142402.60   13004.47  149928.67
+  Latency      693.25us   340.63us     7.55ms
   Latency Distribution
-     50%   642.00us
-     75%   846.00us
-     90%     1.04ms
+     50%   638.00us
+     75%   799.00us
+     90%     1.01ms
      99%     1.85ms
 ### File Upload (POST /upload)
-  Reqs/sec    119336.10   10885.62  128706.23
-  Latency      836.13us   359.81us     6.62ms
+  Reqs/sec    120273.00    9798.92  126323.44
+  Latency      814.45us   289.95us     4.27ms
   Latency Distribution
-     50%   769.00us
+     50%   747.00us
      75%     1.00ms
-     90%     1.26ms
-     99%     1.96ms
-### Mixed Form with Files (POST /mixed-form)
-  Reqs/sec    112318.27   10225.94  121279.65
-  Latency        0.88ms   314.96us     5.32ms
-  Latency Distribution
-     50%   820.00us
-     75%     1.02ms
      90%     1.29ms
-     99%     2.12ms
+     99%     1.98ms
+### Mixed Form with Files (POST /mixed-form)
+  Reqs/sec    115476.91    9370.82  121878.89
+  Latency        0.85ms   438.76us     7.12ms
+  Latency Distribution
+     50%   803.00us
+     75%     1.01ms
+     90%     1.32ms
+     99%     2.17ms
 ### Form Repeated Keys urlencoded (POST /form-list)
-  Reqs/sec    130222.81   13334.06  139272.44
-  Latency      752.75us   344.07us     5.70ms
+  Reqs/sec    131107.85   11063.64  137812.49
+  Latency      747.61us   300.17us     4.64ms
   Latency Distribution
-     50%   724.00us
-     75%     0.92ms
-     90%     1.06ms
-     99%     1.91ms
+     50%   667.00us
+     75%     0.93ms
+     90%     1.12ms
+     99%     1.80ms
 ### Form Repeated Keys multipart (POST /form-list)
-  Reqs/sec    105184.20    5307.44  107903.76
-  Latency        0.93ms   279.32us     4.42ms
+  Reqs/sec     96621.47   25521.88  110578.02
+  Latency        1.03ms     0.88ms    12.89ms
   Latency Distribution
-     50%     0.91ms
-     75%     1.20ms
+     50%     0.88ms
+     75%     1.23ms
      90%     1.51ms
-     99%     2.13ms
+     99%     3.05ms
 
 ## Django Middleware Performance
 ### Django Middleware + Messages Framework (/middleware/demo)
 Tests: SessionMiddleware, AuthenticationMiddleware, MessageMiddleware, custom middleware, template rendering
-  Reqs/sec      8396.97    1479.84   15083.28
-  Latency       11.99ms     7.03ms    84.03ms
+  Reqs/sec      9119.93    2344.05   22953.93
+  Latency       11.20ms     6.93ms    84.98ms
   Latency Distribution
-     50%    11.51ms
-     75%    13.00ms
-     90%    16.37ms
-     99%    25.20ms
+     50%    10.09ms
+     75%    12.46ms
+     90%    14.02ms
+     99%    27.82ms
 
 ## Django Ninja-style Benchmarks
 ### JSON Parse/Validate (POST /bench/parse)
-  Reqs/sec    145891.37   14133.89  156525.31
-  Latency      666.69us   266.62us     4.35ms
+  Reqs/sec    150744.94   12277.70  158028.89
+  Latency      652.68us   257.31us     4.58ms
   Latency Distribution
-     50%   596.00us
-     75%   830.00us
-     90%     1.07ms
-     99%     1.90ms
+     50%   585.00us
+     75%   748.00us
+     90%     0.98ms
+     99%     1.89ms
 
 ## Serializer Performance Benchmarks
 ### Raw msgspec Serializer (POST /bench/serializer-raw)
-  Reqs/sec    153182.45   10006.13  159822.23
-  Latency      644.42us   293.50us     4.89ms
+  Reqs/sec    150759.62   19399.95  164264.93
+  Latency      651.71us   288.38us     5.63ms
   Latency Distribution
-     50%   580.00us
+     50%   594.00us
      75%   745.00us
-     90%     0.93ms
-     99%     2.06ms
+     90%     0.97ms
+     99%     2.17ms
 ### Django-Bolt Serializer with Validators (POST /bench/serializer-validated)
-  Reqs/sec     90606.15    9475.14  101804.31
-  Latency        1.09ms   428.89us     6.82ms
+  Reqs/sec    103625.12    7469.44  108825.90
+  Latency        0.95ms   282.62us     3.31ms
   Latency Distribution
-     50%     0.99ms
-     75%     1.32ms
-     90%     1.71ms
-     99%     3.19ms
+     50%     0.90ms
+     75%     1.19ms
+     90%     1.49ms
+     99%     2.29ms
 ### Users msgspec Serializer (POST /users/bench/msgspec)
-  Reqs/sec    146583.21   12371.29  160101.14
-  Latency      663.51us   264.61us     4.59ms
+  Reqs/sec    152827.23   12266.61  164770.55
+  Latency      632.06us   233.04us     5.76ms
   Latency Distribution
-     50%   627.00us
-     75%   786.00us
-     90%     1.01ms
-     99%     1.85ms
+     50%   578.00us
+     75%   755.00us
+     90%     0.91ms
+     99%     1.67ms
 
 ## Multi-Response Performance
 
 ### Multi-response tuple return (/bench/multi/tuple)
-  Reqs/sec    114514.32    9004.46  120252.69
-  Latency        0.87ms   250.16us     2.83ms
+  Reqs/sec    117500.22    9502.71  123856.32
+  Latency      840.69us   235.13us     3.42ms
   Latency Distribution
-     50%   805.00us
-     75%     1.05ms
-     90%     1.32ms
-     99%     2.12ms
+     50%   784.00us
+     75%     1.03ms
+     90%     1.31ms
+     99%     1.93ms
 
 ### Multi-response bare dict (/bench/multi/dict)
-  Reqs/sec    112771.14    8357.32  119383.34
-  Latency        0.87ms   215.54us     2.56ms
+  Reqs/sec    117620.37    9104.23  126221.37
+  Latency      846.14us   271.44us     4.90ms
   Latency Distribution
-     50%   821.00us
-     75%     1.08ms
-     90%     1.33ms
-     99%     1.91ms
+     50%   784.00us
+     75%     1.05ms
+     90%     1.30ms
+     99%     1.96ms
 
 ## Union Response Performance
 Polymorphic feed with tagged msgspec Struct union (PostActivity | CommentActivity | LikeActivity)
 
 ### Single union item — Post branch (/feed/0)
-  Reqs/sec    108086.12    7911.05  112200.09
-  Latency        0.91ms   255.66us     3.70ms
+  Reqs/sec    110295.08    7153.81  115778.84
+  Latency        0.89ms   237.58us     2.77ms
   Latency Distribution
-     50%   846.00us
-     75%     1.11ms
-     90%     1.42ms
-     99%     2.04ms
+     50%   834.00us
+     75%     1.09ms
+     90%     1.37ms
+     99%     2.00ms
 
 ### Single union item — Comment branch (/feed/1)
-  Reqs/sec    107282.18    6251.17  112143.29
-  Latency        0.92ms   238.08us     3.21ms
+  Reqs/sec    107892.17    7838.44  115807.01
+  Latency        0.92ms   260.29us     3.38ms
   Latency Distribution
-     50%     0.85ms
-     75%     1.12ms
-     90%     1.41ms
-     99%     2.04ms
+     50%   845.00us
+     75%     1.13ms
+     90%     1.43ms
+     99%     2.03ms
 
 ### Single union item — Like branch (/feed/2)
-  Reqs/sec    105836.84    7794.18  111491.91
-  Latency        0.93ms   264.69us     3.47ms
+  Reqs/sec    110576.88    7345.79  116180.99
+  Latency        0.89ms   235.36us     3.38ms
   Latency Distribution
-     50%     0.87ms
-     75%     1.15ms
-     90%     1.47ms
-     99%     2.18ms
+     50%   825.00us
+     75%     1.07ms
+     90%     1.33ms
+     99%     1.99ms
 
 ### Feed of 100 mixed union items (/feed)
-  Reqs/sec     72953.78    3701.70   75073.40
-  Latency        1.35ms   357.74us     5.55ms
+  Reqs/sec     75291.84    3982.51   78727.58
+  Latency        1.31ms   317.01us     4.14ms
   Latency Distribution
-     50%     1.31ms
-     75%     1.63ms
-     90%     1.88ms
-     99%     2.80ms
+     50%     1.27ms
+     75%     1.50ms
+     90%     1.81ms
+     99%     2.56ms
 
 ## Latency Percentile Benchmarks
 Measures p50/p75/p90/p99 latency for type coercion overhead analysis
 
 ### Baseline - No Parameters (/)
-  Reqs/sec    178947.48   17245.25  194591.58
-  Latency      553.68us   301.43us     4.22ms
+  Reqs/sec    196733.36   11252.57  204958.77
+  Latency      496.72us   207.66us     5.18ms
   Latency Distribution
-     50%   505.00us
-     75%   608.00us
-     90%   818.00us
-     99%     2.59ms
+     50%   458.00us
+     75%   572.00us
+     90%   711.00us
+     99%     1.21ms
 
 ### Path Parameter - int (/items/12345)
-  Reqs/sec    155036.89   17077.03  170270.58
-  Latency      606.35us   259.37us     5.10ms
+  Reqs/sec    164722.10   19314.81  176910.17
+  Latency      591.57us   233.99us     4.37ms
   Latency Distribution
-     50%   566.00us
-     75%   707.00us
-     90%     0.89ms
-     99%     1.69ms
+     50%   596.00us
+     75%   697.00us
+     90%     0.86ms
+     99%     1.72ms
 
 ### Path + Query Parameters (/items/12345?q=hello)
-  Reqs/sec    148434.15   15836.83  161392.78
-  Latency      629.19us   327.58us     5.92ms
+  Reqs/sec    164128.65   25260.33  188303.58
+  Latency      623.81us   307.63us     4.78ms
   Latency Distribution
-     50%   556.00us
-     75%   753.00us
-     90%     1.02ms
-     99%     1.87ms
+     50%   554.00us
+     75%   729.00us
+     90%     0.96ms
+     99%     2.31ms
 
 ### Header Parameter (/header)
-  Reqs/sec    111853.19   11179.85  120281.03
-  Latency        0.88ms   277.95us     3.87ms
+  Reqs/sec    121026.41   10510.93  131937.75
+  Latency      825.18us   253.69us     4.41ms
   Latency Distribution
-     50%   804.00us
-     75%     1.06ms
-     90%     1.39ms
-     99%     2.22ms
+     50%   761.00us
+     75%     1.00ms
+     90%     1.29ms
+     99%     1.97ms
 
 ### Cookie Parameter (/cookie)
-  Reqs/sec    112569.93    8362.68  118358.41
-  Latency        0.88ms   267.84us     3.67ms
+  Reqs/sec    113381.09    9496.89  121536.88
+  Latency        0.88ms   299.36us     6.81ms
   Latency Distribution
-     50%   816.00us
-     75%     1.09ms
-     90%     1.41ms
-     99%     2.17ms
+     50%   804.00us
+     75%     1.10ms
+     90%     1.45ms
+     99%     2.20ms
 
 ### Auth Context - JWT validated, no DB (/auth/context)
-  Reqs/sec     92626.61    4573.47   96216.48
-  Latency        1.06ms   319.66us     4.90ms
+  Reqs/sec     94219.93    7804.75  102163.59
+  Latency        1.04ms   332.45us     3.94ms
   Latency Distribution
-     50%     1.00ms
-     75%     1.30ms
-     90%     1.60ms
-     99%     2.40ms
+     50%     0.95ms
+     75%     1.28ms
+     90%     1.64ms
+     99%     2.53ms

--- a/docs/src/ref/auth.md
+++ b/docs/src/ref/auth.md
@@ -19,6 +19,7 @@ JWTAuthentication(
     secret=None,              # JWT secret (default: Django SECRET_KEY)
     algorithms=["HS256"],     # Allowed algorithms
     header="authorization",   # Header name
+    cookie=None,              # Cookie name to read the token from
     audience=None,            # Required audience claim
     issuer=None,              # Required issuer claim
     revocation_store=None,    # Token revocation store
@@ -32,6 +33,7 @@ JWTAuthentication(
 | `secret`           | `str`           | Django SECRET_KEY | JWT signing secret      |
 | `algorithms`       | `list[str]`     | `["HS256"]`       | Allowed JWT algorithms  |
 | `header`           | `str`           | `"authorization"` | Header containing token |
+| `cookie`           | `str`           | `None`            | Cookie containing token (replaces `header` when set) |
 | `audience`         | `str`           | `None`            | Required `aud` claim    |
 | `issuer`           | `str`           | `None`            | Required `iss` claim    |
 | `revocation_store` | RevocationStore | `None`            | Token revocation store  |

--- a/docs/src/topics/authentication.md
+++ b/docs/src/topics/authentication.md
@@ -207,7 +207,7 @@ async def profile(request):
 
 When `cookie=` is set, the token is read from the named cookie only — the
 `Authorization` header is ignored for that backend. The cookie value is the
-raw token, no `Bearer ` prefix needed. Extraction and validation both
+raw token, no `Bearer` prefix needed. Extraction and validation both
 happen in Rust, without acquiring the GIL.
 
 To serve both browser (cookie) and API (bearer header) clients on the same

--- a/docs/src/topics/authentication.md
+++ b/docs/src/topics/authentication.md
@@ -149,6 +149,10 @@ either alone is enough. If you define both, sync handlers use
 `get_user_sync` directly (no event-loop overhead) and it is also preferred
 for async handlers via a worker thread.
 
+The override is scoped to the routes that use that backend instance —
+routes authenticated with a plain `JWTAuthentication` keep the default
+pk-based query, even in the same app.
+
 ### Using dependency injection
 
 Alternatively, use the `get_current_user` dependency:

--- a/docs/src/topics/authentication.md
+++ b/docs/src/topics/authentication.md
@@ -122,6 +122,33 @@ async def get_me(request):
 
 The user is only loaded from the database when you access `request.user`. If you don't need the full user object, use `request.context` which is available without a database query.
 
+### Custom user query
+
+By default `request.user` runs `User.objects.get(pk=<sub claim>)`. To use a
+different query — `select_related`, `defer`, a custom user model, lookup by
+username — subclass the backend and override `get_user`:
+
+```python
+class MyJWT(JWTAuthentication):
+    async def get_user(self, user_id, auth_context):
+        return await (
+            User.objects
+            .select_related("track", "member")
+            .defer("track__image", "member__joined_at")
+            .aget(id=user_id)
+        )
+
+@api.get("/tasks", auth=[MyJWT()], guards=[IsAuthenticated()])
+async def tasks(request):
+    user = request.user  # loaded with your query
+    ...
+```
+
+Overriding the async `get_user` or the sync `get_user_sync` both work —
+either alone is enough. If you define both, sync handlers use
+`get_user_sync` directly (no event-loop overhead) and it is also preferred
+for async handlers via a worker thread.
+
 ### Using dependency injection
 
 Alternatively, use the `get_current_user` dependency:
@@ -147,6 +174,7 @@ JWTAuthentication(
     secret="your-secret-key",    # Default: Django's SECRET_KEY
     algorithms=["HS256"],        # Allowed algorithms
     header="authorization",      # Header name
+    cookie=None,                 # Cookie name to read the token from
     audience="your-app",         # Required audience claim
     issuer="your-issuer",        # Required issuer claim
 )
@@ -157,6 +185,36 @@ Supported algorithms:
 - `HS256`, `HS384`, `HS512` - HMAC with SHA-2
 - `RS256`, `RS384`, `RS512` - RSA with SHA-2
 - `ES256`, `ES384`, `ES512` - ECDSA with SHA-2
+
+### Cookie-based tokens
+
+For browser clients that store the JWT in a cookie (e.g. an `HttpOnly`
+`access_token` cookie), pass `cookie=` with the cookie name:
+
+```python
+@api.get(
+    "/profile",
+    auth=[JWTAuthentication(cookie="access_token")],
+    guards=[IsAuthenticated()],
+)
+async def profile(request):
+    return {"user_id": request["context"]["user_id"]}
+```
+
+When `cookie=` is set, the token is read from the named cookie only — the
+`Authorization` header is ignored for that backend. The cookie value is the
+raw token, no `Bearer ` prefix needed. Extraction and validation both
+happen in Rust, without acquiring the GIL.
+
+To serve both browser (cookie) and API (bearer header) clients on the same
+endpoint, register two backends — they're tried in order:
+
+```python
+auth=[
+    JWTAuthentication(cookie="access_token"),
+    JWTAuthentication(),
+]
+```
 
 ## API key authentication
 

--- a/python/django_bolt/api.py
+++ b/python/django_bolt/api.py
@@ -37,7 +37,7 @@ from ._view_context import _current_action, _current_request
 from .admin.routes import AdminRouteRegistrar
 from .analysis import analyze_dependency_tree, analyze_handler, warn_blocking_handler
 from .auth import get_default_authentication_classes, register_auth_backend
-from .auth.user_loader import load_user_sync
+from .auth.user_loader import default_django_user_loader, resolve_user_loader
 from .concurrency import sync_to_thread
 from .decorators import _RESPONSE_MODEL_UNSET, ActionHandler
 from .error_handlers import handle_exception
@@ -1607,6 +1607,16 @@ class BoltAPI:
             # below for revocation precomputation and _auth_backend_instances.
             effective_auth_backends = auth if auth is not None else (get_default_authentication_classes() or [])
 
+            # scheme_name → user loader for THIS route's backends. Must be
+            # per-route: JWTAuthentication subclasses all share scheme "jwt"
+            # but can carry different get_user overrides. First backend of a
+            # scheme wins (Rust reports only the scheme that authenticated).
+            user_loaders: dict[str, Any] = {}
+            for backend in effective_auth_backends:
+                if backend.scheme_name not in user_loaders:
+                    user_loaders[backend.scheme_name] = resolve_user_loader(backend)
+            meta["_user_loaders"] = user_loaders
+
             # scheme_name → handler. Lookup at dispatch is O(1) via the
             # matched backend's name. None when no backend has revocation.
             revocation_handlers: dict[str, Callable] = {
@@ -2639,11 +2649,18 @@ class BoltAPI:
 
                 user_id = auth_context.get("user_id")
                 if user_id:
-                    backend_name = auth_context.get("auth_backend")
-                    is_async_ctx = meta["is_async"]
-                    request["user"] = SimpleLazyObject(
-                        partial(load_user_sync, user_id, backend_name, auth_context, is_async_ctx)
+                    # Route-local loader for the scheme that authenticated;
+                    # schemes with no backend instance (Rust session auth)
+                    # fall back to the default pk query. A loader of None
+                    # means the backend has no user resolution — leave
+                    # request.user unset (PyRequest getter returns None).
+                    loader = meta["_user_loaders"].get(
+                        auth_context.get("auth_backend"), default_django_user_loader
                     )
+                    if loader is not None:
+                        request["user"] = SimpleLazyObject(
+                            partial(loader, user_id, auth_context, meta["is_async"])
+                        )
 
             # 3. Check if we need to execute middleware
             # Middleware runs for:
@@ -2707,10 +2724,11 @@ class BoltAPI:
             if auth_context:
                 user_id = auth_context.get("user_id")
                 if user_id:
-                    backend_name = auth_context.get("auth_backend")
-                    request["user"] = SimpleLazyObject(
-                        partial(load_user_sync, user_id, backend_name, auth_context, False)
+                    loader = meta["_user_loaders"].get(
+                        auth_context.get("auth_backend"), default_django_user_loader
                     )
+                    if loader is not None:
+                        request["user"] = SimpleLazyObject(partial(loader, user_id, auth_context, False))
 
             # Call pre-compiled sync executor directly (no coroutine, no await)
             return meta["_sync_executor"](handler, request)

--- a/python/django_bolt/api.py
+++ b/python/django_bolt/api.py
@@ -2654,13 +2654,9 @@ class BoltAPI:
                     # fall back to the default pk query. A loader of None
                     # means the backend has no user resolution — leave
                     # request.user unset (PyRequest getter returns None).
-                    loader = meta["_user_loaders"].get(
-                        auth_context.get("auth_backend"), default_django_user_loader
-                    )
+                    loader = meta["_user_loaders"].get(auth_context.get("auth_backend"), default_django_user_loader)
                     if loader is not None:
-                        request["user"] = SimpleLazyObject(
-                            partial(loader, user_id, auth_context, meta["is_async"])
-                        )
+                        request["user"] = SimpleLazyObject(partial(loader, user_id, auth_context, meta["is_async"]))
 
             # 3. Check if we need to execute middleware
             # Middleware runs for:
@@ -2724,9 +2720,7 @@ class BoltAPI:
             if auth_context:
                 user_id = auth_context.get("user_id")
                 if user_id:
-                    loader = meta["_user_loaders"].get(
-                        auth_context.get("auth_backend"), default_django_user_loader
-                    )
+                    loader = meta["_user_loaders"].get(auth_context.get("auth_backend"), default_django_user_loader)
                     if loader is not None:
                         request["user"] = SimpleLazyObject(partial(loader, user_id, auth_context, False))
 

--- a/python/django_bolt/api.py
+++ b/python/django_bolt/api.py
@@ -1617,6 +1617,14 @@ class BoltAPI:
                     user_loaders[backend.scheme_name] = resolve_user_loader(backend)
             meta["_user_loaders"] = user_loaders
 
+            # Execution context for request.user loads on the async dispatch
+            # path: async handlers run on the event loop, and non-blocking
+            # sync handlers are run inline on it too — both need the loader
+            # to use the executor (sync ORM on the loop thread raises
+            # SynchronousOnlyOperation). Only blocking sync handlers run in
+            # a worker thread, where a direct ORM call is safe and faster.
+            meta["_user_load_is_async_ctx"] = meta["is_async"] or not meta["is_blocking"]
+
             # scheme_name → handler. Lookup at dispatch is O(1) via the
             # matched backend's name. None when no backend has revocation.
             revocation_handlers: dict[str, Callable] = {
@@ -2656,7 +2664,9 @@ class BoltAPI:
                     # request.user unset (PyRequest getter returns None).
                     loader = meta["_user_loaders"].get(auth_context.get("auth_backend"), default_django_user_loader)
                     if loader is not None:
-                        request["user"] = SimpleLazyObject(partial(loader, user_id, auth_context, meta["is_async"]))
+                        request["user"] = SimpleLazyObject(
+                            partial(loader, user_id, auth_context, meta["_user_load_is_async_ctx"])
+                        )
 
             # 3. Check if we need to execute middleware
             # Middleware runs for:

--- a/python/django_bolt/auth/backends.py
+++ b/python/django_bolt/auth/backends.py
@@ -101,12 +101,16 @@ class JWTAuthentication(BaseAuthentication):
     JWT token authentication.
 
     Validates JWT tokens using the configured secret and algorithms.
-    Tokens should be provided in the Authorization header as "Bearer <token>".
+    Tokens should be provided in the Authorization header as "Bearer <token>",
+    or in a cookie when `cookie` is set.
 
     Args:
         secret: Secret key for JWT validation. If None, uses Django's SECRET_KEY.
         algorithms: List of allowed JWT algorithms (default: ["HS256"])
         header: Header name to extract token from (default: "authorization")
+        cookie: Optional cookie name to extract the token from. When set, the
+            token is read from the named cookie only (the header is ignored).
+            The cookie value is the raw token (no "Bearer " prefix needed).
         audience: Optional JWT audience claim to validate
         issuer: Optional JWT issuer claim to validate
     """
@@ -126,6 +130,7 @@ class JWTAuthentication(BaseAuthentication):
         secret: str | None = None,
         algorithms: list[str] | None = None,
         header: str = "authorization",
+        cookie: str | None = None,
         audience: str | None = None,
         issuer: str | None = None,
         revoked_token_handler: RevokedTokenHandler | None = None,
@@ -135,6 +140,7 @@ class JWTAuthentication(BaseAuthentication):
         self.secret = secret
         self.algorithms = algorithms or ["HS256"]
         self.header = header
+        self.cookie = cookie
         self.audience = audience
         self.issuer = issuer
 
@@ -183,6 +189,7 @@ class JWTAuthentication(BaseAuthentication):
             "secret": self.secret,
             "algorithms": self.algorithms,
             "header": self.header.lower(),
+            "cookie": self.cookie,
             "audience": self.audience,
             "issuer": self.issuer,
             "require_jti": self.require_jti,

--- a/python/django_bolt/auth/backends.py
+++ b/python/django_bolt/auth/backends.py
@@ -227,7 +227,8 @@ class JWTAuthentication(BaseAuthentication):
         Synchronously load user from database using the user_id from JWT token.
 
         This method does the actual DB query. Thread pool wrapping is handled
-        by user_loader.load_user_sync() based on the handler's async context.
+        by the loader resolved in user_loader.resolve_user_loader() based on
+        the handler's execution context.
         """
         if not user_id:
             return None

--- a/python/django_bolt/auth/user_loader.py
+++ b/python/django_bolt/auth/user_loader.py
@@ -7,8 +7,11 @@ Eager loading (optional): Loads user immediately at dispatch time
 
 Backends customize user loading by overriding get_user (async) and/or
 get_user_sync (sync) — overriding either one alone is honored. The effective
-strategy per backend is resolved once at registration time, so the per-request
-path is a single dict lookup plus a call.
+strategy is resolved once per route at registration time (resolve_user_loader,
+stored in the handler meta keyed by scheme name), so the per-request path is a
+single dict lookup plus a call. Resolution must be per-route, not per scheme
+name: two JWTAuthentication subclasses share scheme_name "jwt" but can carry
+different get_user overrides.
 """
 
 from __future__ import annotations
@@ -58,7 +61,7 @@ def _has_custom_get_user(cls: type) -> bool:
     return method is not None and method not in _FRAMEWORK_GET_USER
 
 
-def _resolve_user_loader(backend: Any) -> Callable[[str, dict | None, bool], Any] | None:
+def resolve_user_loader(backend: Any) -> Callable[[str, dict | None, bool], Any] | None:
     """
     Resolve the sync user-loading strategy for a backend, once at registration.
 
@@ -107,6 +110,16 @@ def _resolve_user_loader(backend: Any) -> Callable[[str, dict | None, bool], Any
     return None
 
 
+def default_django_user_loader(user_id: str, auth_context: dict | None, is_async_context: bool) -> Any:
+    """Default user query for schemes with no backend instance on the route
+    (e.g. Rust-side session auth): ``User.objects.get(pk=user_id)``."""
+    User = get_user_model()
+
+    if is_async_context:
+        return _get_executor().submit(User.objects.get, pk=user_id).result()
+    return User.objects.get(pk=user_id)
+
+
 def register_auth_backend(backend_name: str, backend_instance: Any) -> None:
     """
     Register an authentication backend instance for user resolution.
@@ -119,7 +132,7 @@ def register_auth_backend(backend_name: str, backend_instance: Any) -> None:
         backend_instance: Instance of the authentication backend class
     """
     _auth_backend_registry[backend_name] = backend_instance
-    _resolved_loader_registry[backend_name] = _resolve_user_loader(backend_instance)
+    _resolved_loader_registry[backend_name] = resolve_user_loader(backend_instance)
 
 
 def get_registered_backend(backend_name: str) -> Any | None:
@@ -189,8 +202,4 @@ def load_user_sync(
         return loader(user_id, auth_context, is_async_context)
 
     # Unregistered backend (e.g. session auth): default Django user query
-    User = get_user_model()
-
-    if is_async_context:
-        return _get_executor().submit(User.objects.get, pk=user_id).result()
-    return User.objects.get(pk=user_id)
+    return default_django_user_loader(user_id, auth_context, is_async_context)

--- a/python/django_bolt/auth/user_loader.py
+++ b/python/django_bolt/auth/user_loader.py
@@ -4,6 +4,11 @@ User loading system for request.user
 Supports both eager and lazy loading strategies.
 Lazy loading (default): Uses SimpleLazyObject to defer DB query until first access
 Eager loading (optional): Loads user immediately at dispatch time
+
+Backends customize user loading by overriding get_user (async) and/or
+get_user_sync (sync) — overriding either one alone is honored. The effective
+strategy per backend is resolved once at registration time, so the per-request
+path is a single dict lookup plus a call.
 """
 
 from __future__ import annotations
@@ -11,12 +16,24 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import inspect
+from collections.abc import Callable
 from typing import Any
 
 from django.contrib.auth import get_user_model
 
+from .backends import BaseAuthentication, JWTAuthentication
+
+# Framework-provided implementations. A backend method that is one of these
+# was NOT overridden by the user — only genuine overrides take priority.
+_FRAMEWORK_GET_USER = (BaseAuthentication.get_user, JWTAuthentication.get_user)
+_FRAMEWORK_GET_USER_SYNC = (JWTAuthentication.get_user_sync,)
+
 # Global registry of auth backend instances for user resolution
 _auth_backend_registry: dict[str, Any] = {}
+
+# (backend_name) -> resolved loader (user_id, auth_context, is_async_context) -> user,
+# or None when the backend has no user resolution. Built at registration time.
+_resolved_loader_registry: dict[str, Callable[[str, dict | None, bool], Any] | None] = {}
 
 # Global shared thread pool for user loading - avoids expensive pool creation per request
 # Using max_workers=4 to limit resource usage while allowing concurrent user loads
@@ -31,17 +48,78 @@ def _get_executor() -> concurrent.futures.ThreadPoolExecutor:
     return _user_loader_executor
 
 
+def _has_custom_get_user_sync(cls: type) -> bool:
+    method = getattr(cls, "get_user_sync", None)
+    return method is not None and method not in _FRAMEWORK_GET_USER_SYNC
+
+
+def _has_custom_get_user(cls: type) -> bool:
+    method = getattr(cls, "get_user", None)
+    return method is not None and method not in _FRAMEWORK_GET_USER
+
+
+def _resolve_user_loader(backend: Any) -> Callable[[str, dict | None, bool], Any] | None:
+    """
+    Resolve the sync user-loading strategy for a backend, once at registration.
+
+    Priority:
+    1. Overridden get_user_sync (fastest — direct call, no event loop)
+    2. Overridden get_user (async or sync)
+    3. Framework default get_user_sync (JWTAuthentication pk lookup)
+    4. None — backend has no user resolution (e.g. plain APIKeyAuthentication)
+    """
+    cls = type(backend)
+    custom_sync = _has_custom_get_user_sync(cls)
+    custom_async = _has_custom_get_user(cls)
+    has_framework_sync = getattr(cls, "get_user_sync", None) is not None
+
+    if custom_sync or (has_framework_sync and not custom_async):
+
+        def load_via_sync(user_id: str, auth_context: dict | None, is_async_context: bool) -> Any:
+            if is_async_context:
+                return _get_executor().submit(backend.get_user_sync, user_id).result()
+            return backend.get_user_sync(user_id)
+
+        return load_via_sync
+
+    if custom_async:
+        get_user = backend.get_user
+
+        if not inspect.iscoroutinefunction(get_user):
+
+            def load_via_plain(user_id: str, auth_context: dict | None, is_async_context: bool) -> Any:
+                if is_async_context:
+                    return _get_executor().submit(get_user, user_id, auth_context or {}).result()
+                return get_user(user_id, auth_context or {})
+
+            return load_via_plain
+
+        def load_via_async(user_id: str, auth_context: dict | None, is_async_context: bool) -> Any:
+            # asyncio.run needs a thread without a running loop — always use
+            # the executor, regardless of handler context.
+            def run_async_get_user():
+                return asyncio.run(get_user(user_id, auth_context or {}))
+
+            return _get_executor().submit(run_async_get_user).result()
+
+        return load_via_async
+
+    return None
+
+
 def register_auth_backend(backend_name: str, backend_instance: Any) -> None:
     """
     Register an authentication backend instance for user resolution.
 
     Called at server startup to make backends available for user loading.
+    Resolves the user-loading strategy once, so request-time lookup is O(1).
 
     Args:
         backend_name: Unique identifier for the backend (e.g., "jwt", "api_key")
         backend_instance: Instance of the authentication backend class
     """
     _auth_backend_registry[backend_name] = backend_instance
+    _resolved_loader_registry[backend_name] = _resolve_user_loader(backend_instance)
 
 
 def get_registered_backend(backend_name: str) -> Any | None:
@@ -67,18 +145,16 @@ async def load_user(user_id: str | None, backend_name: str | None, auth_context:
     if not user_id:
         return None
 
-    # Try to get registered backend with custom get_user method
-    backend = get_registered_backend(backend_name) if backend_name else None
+    backend = _auth_backend_registry.get(backend_name) if backend_name else None
+    if backend is None:
+        return None
 
-    # If backend has custom get_user, call it
-    if backend and hasattr(backend, "get_user"):
-        try:
-            return await backend.get_user(user_id, auth_context or {})
-        except Exception:
-            # User not found or backend error
-            raise
+    cls = type(backend)
+    if _has_custom_get_user_sync(cls) and not _has_custom_get_user(cls):
+        # Only the sync variant was customized — run it off the event loop
+        return await asyncio.to_thread(backend.get_user_sync, user_id)
 
-    return None
+    return await backend.get_user(user_id, auth_context or {})
 
 
 def load_user_sync(
@@ -105,33 +181,16 @@ def load_user_sync(
     if not user_id:
         return None
 
-    # Try to get registered backend with custom get_user_sync method
-    backend = get_registered_backend(backend_name) if backend_name else None
+    if backend_name in _auth_backend_registry:
+        loader = _resolved_loader_registry[backend_name]
+        if loader is None:
+            # Backend provides no user resolution (e.g. plain APIKeyAuthentication)
+            return None
+        return loader(user_id, auth_context, is_async_context)
 
-    # If backend has custom get_user_sync, call it (with thread pool wrapping if needed)
-    if backend and hasattr(backend, "get_user_sync"):
-        if is_async_context:
-            future = _get_executor().submit(backend.get_user_sync, user_id)
-            return future.result()
-        else:
-            return backend.get_user_sync(user_id)
-
-    # If backend has async get_user (but no sync version), call it via thread pool
-    if backend and hasattr(backend, "get_user"):
-        get_user_method = backend.get_user
-        if inspect.iscoroutinefunction(get_user_method):
-
-            def run_async_get_user():
-                return asyncio.run(get_user_method(user_id, auth_context or {}))
-
-            future = _get_executor().submit(run_async_get_user)
-            return future.result()
-
-    # Fallback: Django ORM call (with thread pool wrapping if needed)
+    # Unregistered backend (e.g. session auth): default Django user query
     User = get_user_model()
 
     if is_async_context:
-        future = _get_executor().submit(User.objects.get, pk=user_id)
-        return future.result()
-    else:
-        return User.objects.get(pk=user_id)
+        return _get_executor().submit(User.objects.get, pk=user_id).result()
+    return User.objects.get(pk=user_id)

--- a/python/django_bolt/auth/user_loader.py
+++ b/python/django_bolt/auth/user_loader.py
@@ -112,12 +112,19 @@ def resolve_user_loader(backend: Any) -> Callable[[str, dict | None, bool], Any]
 
 def default_django_user_loader(user_id: str, auth_context: dict | None, is_async_context: bool) -> Any:
     """Default user query for schemes with no backend instance on the route
-    (e.g. Rust-side session auth): ``User.objects.get(pk=user_id)``."""
+    (e.g. Rust-side session auth): ``User.objects.get(pk=user_id)``.
+
+    Returns None for a stale user_id (user deleted after the session/token
+    was issued), mirroring the framework get_user/get_user_sync defaults.
+    """
     User = get_user_model()
 
-    if is_async_context:
-        return _get_executor().submit(User.objects.get, pk=user_id).result()
-    return User.objects.get(pk=user_id)
+    try:
+        if is_async_context:
+            return _get_executor().submit(User.objects.get, pk=user_id).result()
+        return User.objects.get(pk=user_id)
+    except User.DoesNotExist:
+        return None
 
 
 def register_auth_backend(backend_name: str, backend_instance: Any) -> None:

--- a/python/tests/integration/apps/jwt_cookie_user.py
+++ b/python/tests/integration/apps/jwt_cookie_user.py
@@ -1,0 +1,75 @@
+"""App under test for cookie-based JWT auth and custom user loading.
+
+Defines routes protected by ``JWTAuthentication(cookie=...)`` so a real
+``runbolt`` server proves the cookie config flows from backend metadata into
+Rust extraction, plus a route whose backend overrides ``get_user`` to resolve
+``request.user`` by username instead of the default pk lookup. ``/seed``
+migrates the subprocess's sqlite database and creates the test user, since
+server projects start with an unmigrated DB. ``SECRET`` and ``USERNAME`` are
+exported so tests can mint matching tokens.
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth.models import User
+from django.core.management import call_command
+
+from django_bolt import BoltAPI
+from django_bolt.auth import IsAuthenticated, JWTAuthentication
+
+SECRET = "jwt-cookie-server-integration-secret"
+USERNAME = "cookieuser"
+
+
+class UsernameJWT(JWTAuthentication):
+    """Resolves request.user by username — the default pk lookup can never
+    satisfy these tokens, so a successful load proves the override ran."""
+
+    async def get_user(self, user_id, auth_context):
+        return await User.objects.aget(username=user_id)
+
+
+api = BoltAPI()
+
+
+@api.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@api.post("/seed")
+def seed():
+    call_command("migrate", interactive=False, verbosity=0)
+    user, _ = User.objects.get_or_create(username=USERNAME)
+    return {"user_id": user.id, "username": user.username}
+
+
+@api.get(
+    "/whoami",
+    auth=[JWTAuthentication(secret=SECRET, cookie="access_token")],
+    guards=[IsAuthenticated()],
+)
+async def whoami(request):
+    return {"user_id": request["context"]["user_id"]}
+
+
+@api.get(
+    "/dual",
+    auth=[
+        JWTAuthentication(secret=SECRET, cookie="access_token"),
+        JWTAuthentication(secret=SECRET),
+    ],
+    guards=[IsAuthenticated()],
+)
+async def dual(request):
+    return {"user_id": request["context"]["user_id"]}
+
+
+@api.get(
+    "/me",
+    auth=[UsernameJWT(secret=SECRET, cookie="access_token")],
+    guards=[IsAuthenticated()],
+)
+async def me(request):
+    user = request.user
+    return {"username": user.username if user else None}

--- a/python/tests/integration/test_jwt_cookie_server_integration.py
+++ b/python/tests/integration/test_jwt_cookie_server_integration.py
@@ -1,0 +1,78 @@
+"""Subprocess-based integration tests for cookie JWT auth and get_user overrides.
+
+Complements the in-process TestClient suite (`test_jwt_cookie_auth.py`):
+
+- TestClient suite covers extraction semantics exhaustively (wrong cookie
+  name, expired/forged tokens, override resolution priority) — fast,
+  in-process.
+- This suite proves the startup wiring over a real server: the ``cookie=``
+  backend config must survive runbolt startup (Python metadata → Rust
+  ``AppState``) for extraction to work on real HTTP Cookie headers, and the
+  ``get_user`` override must be registered at server startup for
+  ``request.user`` to use it.
+"""
+
+from __future__ import annotations
+
+import time
+
+import jwt
+import pytest
+
+from .apps import app_module
+from .apps.jwt_cookie_user import SECRET, USERNAME
+
+pytestmark = pytest.mark.server_integration
+
+
+def make_token(sub: str) -> str:
+    now = int(time.time())
+    return jwt.encode({"sub": sub, "iat": now, "exp": now + 3600}, SECRET, algorithm="HS256")
+
+
+def test_cookie_jwt_over_real_server(make_server_project):
+    """Cookie extraction against a real runbolt server.
+
+    A valid token in the ``access_token`` cookie authenticates; no cookie is
+    rejected; the Authorization header is NOT a fallback for a cookie-mode
+    backend; and a dual backend list serves cookie and header clients alike.
+    """
+    project = make_server_project(api_module=app_module("jwt_cookie_user"))
+    token = make_token("cookie-user")
+
+    with project.start() as server:
+        ok = server.get("/whoami", headers={"Cookie": f"access_token={token}"})
+        assert ok.status_code == 200, ok.text
+        assert ok.json()["user_id"] == "cookie-user"
+
+        missing = server.get("/whoami")
+        assert missing.status_code == 401, missing.text
+
+        header_only = server.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+        assert header_only.status_code == 401, header_only.text
+
+        via_cookie = server.get("/dual", headers={"Cookie": f"access_token={token}"})
+        assert via_cookie.status_code == 200, via_cookie.text
+
+        via_header = server.get("/dual", headers={"Authorization": f"Bearer {token}"})
+        assert via_header.status_code == 200, via_header.text
+
+
+def test_custom_get_user_over_real_server(make_server_project):
+    """request.user loads via the subclass's get_user in a real server.
+
+    The token's ``sub`` is a username, which the default pk-based query can
+    never resolve — a 200 with the right username proves the backend
+    registered at server startup resolved the override and used it.
+    """
+    project = make_server_project(api_module=app_module("jwt_cookie_user"))
+
+    with project.start() as server:
+        seeded = server.request("POST", "/seed")
+        assert seeded.status_code == 200, seeded.text
+        assert seeded.json()["username"] == USERNAME
+
+        token = make_token(USERNAME)
+        response = server.get("/me", headers={"Cookie": f"access_token={token}"})
+        assert response.status_code == 200, response.text
+        assert response.json()["username"] == USERNAME

--- a/python/tests/test_jwt_cookie_auth.py
+++ b/python/tests/test_jwt_cookie_auth.py
@@ -252,6 +252,38 @@ class TestGetUserOverrideResolution:
             assert response.json()["username"] == "syncoverride"
 
     @pytest.mark.django_db(transaction=True)
+    def test_override_honored_alongside_plain_backend_on_other_route(self):
+        """A custom get_user must win on its own route even when a plain JWT
+        backend (same scheme_name) is registered first on another route.
+
+        Guards against global scheme-keyed loader registration, where the
+        first "jwt" backend silently supplies user loading for all routes.
+        """
+        user = User.objects.create(username="perroute")
+
+        class UsernameJWT(JWTAuthentication):
+            async def get_user(self, user_id, auth_context):
+                return await User.objects.aget(username=user_id)
+
+        api = BoltAPI()
+
+        # Plain backend registers "jwt" first.
+        @api.get("/plain", auth=[JWTAuthentication(secret=SECRET)], guards=[IsAuthenticated()])
+        async def plain(request):
+            return {"ok": True}
+
+        @api.get("/custom-me", auth=[UsernameJWT(secret=SECRET)], guards=[IsAuthenticated()])
+        async def custom_me(request):
+            u = request.user
+            return {"username": u.username if u else None}
+
+        token = create_token(user_id=user.username)
+        with TestClient(api) as client:
+            response = client.get("/custom-me", headers={"Authorization": f"Bearer {token}"})
+            assert response.status_code == 200
+            assert response.json()["username"] == "perroute"
+
+    @pytest.mark.django_db(transaction=True)
     def test_default_backend_loads_by_pk(self):
         """Plain JWTAuthentication keeps the default pk-based query."""
         user = User.objects.create(username="plainuser")

--- a/python/tests/test_jwt_cookie_auth.py
+++ b/python/tests/test_jwt_cookie_auth.py
@@ -1,0 +1,273 @@
+"""
+Tests for cookie-based JWT extraction, validated entirely in Rust.
+
+JWTAuthentication(cookie="access_token") makes Rust extract the token from
+the named cookie only (no header fallback) and validate the signature/exp/nbf
+without touching Python.
+"""
+
+from __future__ import annotations
+
+import time
+
+import jwt
+import pytest
+from django.contrib.auth.models import User
+
+from django_bolt import BoltAPI
+from django_bolt.auth import IsAuthenticated, JWTAuthentication
+from django_bolt.testing import TestClient
+
+SECRET = "test-secret"
+
+
+def create_token(user_id="user123", **extra):
+    payload = {
+        "sub": user_id,
+        "exp": int(time.time()) + 3600,
+        "iat": int(time.time()),
+        **extra,
+    }
+    return jwt.encode(payload, SECRET, algorithm="HS256")
+
+
+@pytest.fixture(scope="module")
+def cookie_api():
+    """API using cookie-based JWT extraction."""
+    api = BoltAPI()
+
+    @api.get(
+        "/whoami",
+        auth=[JWTAuthentication(secret=SECRET, cookie="access_token")],
+        guards=[IsAuthenticated()],
+    )
+    async def whoami(request):
+        return {"user_id": request["context"]["user_id"]}
+
+    return api
+
+
+class TestJWTCookieAuth:
+    """Cookie-based JWT extraction, validated in Rust."""
+
+    def test_valid_token_in_cookie(self, cookie_api):
+        token = create_token(user_id="cookie-user")
+        with TestClient(cookie_api) as client:
+            response = client.get("/whoami", headers={"Cookie": f"access_token={token}"})
+            assert response.status_code == 200
+            assert response.json()["user_id"] == "cookie-user"
+
+    def test_valid_token_in_cookie_among_others(self, cookie_api):
+        token = create_token(user_id="cookie-user")
+        with TestClient(cookie_api) as client:
+            response = client.get(
+                "/whoami",
+                headers={"Cookie": f"csrftoken=abc; access_token={token}; theme=dark"},
+            )
+            assert response.status_code == 200
+            assert response.json()["user_id"] == "cookie-user"
+
+    def test_missing_token_rejected(self, cookie_api):
+        with TestClient(cookie_api) as client:
+            response = client.get("/whoami")
+            assert response.status_code == 401
+
+    def test_wrong_cookie_name_rejected(self, cookie_api):
+        token = create_token()
+        with TestClient(cookie_api) as client:
+            response = client.get("/whoami", headers={"Cookie": f"session={token}"})
+            assert response.status_code == 401
+
+    def test_invalid_token_in_cookie_rejected(self, cookie_api):
+        bad = jwt.encode({"sub": "x", "exp": int(time.time()) + 3600}, "wrong-secret", algorithm="HS256")
+        with TestClient(cookie_api) as client:
+            response = client.get("/whoami", headers={"Cookie": f"access_token={bad}"})
+            assert response.status_code == 401
+
+    def test_expired_token_in_cookie_rejected(self, cookie_api):
+        expired = jwt.encode({"sub": "x", "exp": int(time.time()) - 3600}, SECRET, algorithm="HS256")
+        with TestClient(cookie_api) as client:
+            response = client.get("/whoami", headers={"Cookie": f"access_token={expired}"})
+            assert response.status_code == 401
+
+    def test_authorization_header_ignored_in_cookie_mode(self, cookie_api):
+        """With cookie mode on, the Authorization header is NOT a fallback."""
+        token = create_token(user_id="header-user")
+        with TestClient(cookie_api) as client:
+            response = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+            assert response.status_code == 401
+
+    def test_cookie_is_sole_source(self, cookie_api):
+        cookie_token = create_token(user_id="from-cookie")
+        header_token = create_token(user_id="from-header")
+        with TestClient(cookie_api) as client:
+            response = client.get(
+                "/whoami",
+                headers={
+                    "Cookie": f"access_token={cookie_token}",
+                    "Authorization": f"Bearer {header_token}",
+                },
+            )
+            assert response.status_code == 200
+            assert response.json()["user_id"] == "from-cookie"
+
+    def test_dual_backends_serve_cookie_and_header(self):
+        """Cookie backend + header backend on one route: each source works."""
+        api = BoltAPI()
+
+        @api.get(
+            "/dual",
+            auth=[
+                JWTAuthentication(secret=SECRET, cookie="access_token"),
+                JWTAuthentication(secret=SECRET),
+            ],
+            guards=[IsAuthenticated()],
+        )
+        async def dual(request):
+            return {"user_id": request["context"]["user_id"]}
+
+        with TestClient(api) as client:
+            cookie_token = create_token(user_id="via-cookie")
+            response = client.get("/dual", headers={"Cookie": f"access_token={cookie_token}"})
+            assert response.status_code == 200
+            assert response.json()["user_id"] == "via-cookie"
+
+            header_token = create_token(user_id="via-header")
+            response = client.get("/dual", headers={"Authorization": f"Bearer {header_token}"})
+            assert response.status_code == 200
+            assert response.json()["user_id"] == "via-header"
+
+            response = client.get("/dual")
+            assert response.status_code == 401
+
+    def test_cookie_ignored_without_cookie_kwarg(self):
+        """Default backend (no cookie=) must NOT read tokens from cookies."""
+        api = BoltAPI()
+
+        @api.get(
+            "/header-only",
+            auth=[JWTAuthentication(secret=SECRET)],
+            guards=[IsAuthenticated()],
+        )
+        async def header_only(request):
+            return {"ok": True}
+
+        token = create_token()
+        with TestClient(api) as client:
+            response = client.get("/header-only", headers={"Cookie": f"access_token={token}"})
+            assert response.status_code == 401
+
+    @pytest.mark.django_db(transaction=True)
+    def test_cookie_auth_with_custom_get_user(self):
+        """Cookie extraction (Rust) composes with a custom user query (subclass)."""
+        user = User.objects.create(username="combo")
+        calls = []
+
+        class CustomQueryJWT(JWTAuthentication):
+            async def get_user(self, user_id, auth_context):
+                calls.append(user_id)
+                return await User.objects.only("id", "username").aget(pk=user_id)
+
+            def get_user_sync(self, user_id):
+                calls.append(user_id)
+                return User.objects.only("id", "username").get(pk=user_id)
+
+        api = BoltAPI()
+
+        @api.get(
+            "/combo-me",
+            auth=[CustomQueryJWT(secret=SECRET, cookie="access_token")],
+            guards=[IsAuthenticated()],
+        )
+        async def combo_me(request):
+            u = request.user
+            return {"username": u.username if u else None}
+
+        token = create_token(user_id=str(user.id))
+        with TestClient(api) as client:
+            response = client.get("/combo-me", headers={"Cookie": f"access_token={token}"})
+            assert response.status_code == 200
+            assert response.json()["username"] == "combo"
+            assert calls == [str(user.id)]
+
+
+class TestGetUserOverrideResolution:
+    """Overriding either get_user or get_user_sync alone must be honored."""
+
+    @pytest.mark.django_db(transaction=True)
+    def test_async_get_user_override_alone_is_used(self):
+        """Overriding ONLY the async get_user must drive request.user.
+
+        The token's sub is a username, which the default pk-based query can
+        never resolve — so a 200 with the right username proves the override
+        ran, and inheriting the default get_user_sync did not shadow it.
+        """
+        user = User.objects.create(username="asyncoverride")
+
+        class UsernameJWT(JWTAuthentication):
+            async def get_user(self, user_id, auth_context):
+                return await User.objects.aget(username=user_id)
+
+        api = BoltAPI()
+
+        @api.get(
+            "/async-override",
+            auth=[UsernameJWT(secret=SECRET)],
+            guards=[IsAuthenticated()],
+        )
+        async def me(request):
+            u = request.user
+            return {"username": u.username if u else None}
+
+        token = create_token(user_id=user.username)
+        with TestClient(api) as client:
+            response = client.get("/async-override", headers={"Authorization": f"Bearer {token}"})
+            assert response.status_code == 200
+            assert response.json()["username"] == "asyncoverride"
+
+    @pytest.mark.django_db(transaction=True)
+    def test_sync_get_user_sync_override_alone_is_used(self):
+        """Overriding ONLY get_user_sync must drive request.user."""
+        user = User.objects.create(username="syncoverride")
+
+        class UsernameSyncJWT(JWTAuthentication):
+            def get_user_sync(self, user_id):
+                return User.objects.get(username=user_id)
+
+        api = BoltAPI()
+
+        @api.get(
+            "/sync-override",
+            auth=[UsernameSyncJWT(secret=SECRET)],
+            guards=[IsAuthenticated()],
+        )
+        async def me(request):
+            u = request.user
+            return {"username": u.username if u else None}
+
+        token = create_token(user_id=user.username)
+        with TestClient(api) as client:
+            response = client.get("/sync-override", headers={"Authorization": f"Bearer {token}"})
+            assert response.status_code == 200
+            assert response.json()["username"] == "syncoverride"
+
+    @pytest.mark.django_db(transaction=True)
+    def test_default_backend_loads_by_pk(self):
+        """Plain JWTAuthentication keeps the default pk-based query."""
+        user = User.objects.create(username="plainuser")
+        api = BoltAPI()
+
+        @api.get(
+            "/plain-me",
+            auth=[JWTAuthentication(secret=SECRET)],
+            guards=[IsAuthenticated()],
+        )
+        async def me(request):
+            u = request.user
+            return {"username": u.username if u else None}
+
+        token = create_token(user_id=str(user.id))
+        with TestClient(api) as client:
+            response = client.get("/plain-me", headers={"Authorization": f"Bearer {token}"})
+            assert response.status_code == 200
+            assert response.json()["username"] == "plainuser"

--- a/python/tests/test_jwt_cookie_auth.py
+++ b/python/tests/test_jwt_cookie_auth.py
@@ -15,7 +15,8 @@ import pytest
 from django.contrib.auth.models import User
 
 from django_bolt import BoltAPI
-from django_bolt.auth import IsAuthenticated, JWTAuthentication
+from django_bolt.auth import InMemoryRevocation, IsAuthenticated, JWTAuthentication
+from django_bolt.auth.user_loader import default_django_user_loader
 from django_bolt.testing import TestClient
 
 SECRET = "test-secret"
@@ -282,6 +283,39 @@ class TestGetUserOverrideResolution:
             response = client.get("/custom-me", headers={"Authorization": f"Bearer {token}"})
             assert response.status_code == 200
             assert response.json()["username"] == "perroute"
+
+    @pytest.mark.django_db(transaction=True)
+    def test_default_loader_returns_none_for_stale_user_id(self):
+        """The fallback loader (unregistered schemes, e.g. session auth) must
+        return None for a deleted user, like the framework backend defaults —
+        not raise User.DoesNotExist into the handler."""
+        assert default_django_user_loader("999999", None, False) is None
+
+    @pytest.mark.django_db(transaction=True)
+    def test_sync_handler_on_async_dispatch_path_loads_user(self):
+        """A sync handler forced onto the async dispatch path (here via a
+        revocation store) runs inline on the event loop when it has no
+        detected ORM operations. request.user must still load — the loader
+        has to route the query through the executor, not call the sync ORM
+        on the event-loop thread (SynchronousOnlyOperation).
+        """
+        user = User.objects.create(username="syncloop")
+        api = BoltAPI()
+
+        @api.get(
+            "/sync-loop-me",
+            auth=[JWTAuthentication(secret=SECRET, revocation_store=InMemoryRevocation())],
+            guards=[IsAuthenticated()],
+        )
+        def sync_loop_me(request):
+            u = request.user
+            return {"username": u.username if u else None}
+
+        token = create_token(user_id=str(user.id), jti="sync-loop-jti")
+        with TestClient(api) as client:
+            response = client.get("/sync-loop-me", headers={"Authorization": f"Bearer {token}"})
+            assert response.status_code == 200, response.text
+            assert response.json()["username"] == "syncloop"
 
     @pytest.mark.django_db(transaction=True)
     def test_default_backend_loads_by_pk(self):

--- a/src/form_parsing.rs
+++ b/src/form_parsing.rs
@@ -247,14 +247,9 @@ pub fn parse_urlencoded(
 
     for (key, value) in parsed {
         let type_hint = type_hints.get(&key).copied().unwrap_or(TYPE_STRING);
-        let coerced =
-            coerce_param(&value, type_hint, max_param_length).map_err(|e| {
-                ValidationError::type_coercion_error(
-                    &key,
-                    type_hint_name(type_hint),
-                    &e.to_string(),
-                )
-            })?;
+        let coerced = coerce_param(&value, type_hint, max_param_length).map_err(|e| {
+            ValidationError::type_coercion_error(&key, type_hint_name(type_hint), &e.to_string())
+        })?;
 
         match result.entry(key) {
             std::collections::hash_map::Entry::Vacant(e) => {
@@ -446,14 +441,13 @@ pub async fn parse_multipart(
             let value = String::from_utf8_lossy(&value_bytes).to_string();
 
             // Type coercion
-            let coerced =
-                coerce_param(&value, type_hint, max_param_length).map_err(|e| {
-                    ValidationError::type_coercion_error(
-                        &field_name,
-                        type_hint_name(type_hint),
-                        &e.to_string(),
-                    )
-                })?;
+            let coerced = coerce_param(&value, type_hint, max_param_length).map_err(|e| {
+                ValidationError::type_coercion_error(
+                    &field_name,
+                    type_hint_name(type_hint),
+                    &e.to_string(),
+                )
+            })?;
 
             // Preserve duplicate keys (e.g. multi-select) as FormValue::Multi.
             // First occurrence is Single — zero extra alloc for the common case.

--- a/src/form_parsing.rs
+++ b/src/form_parsing.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::io::Write;
 use tempfile::NamedTempFile;
 
-use crate::type_coercion::{coerce_param_with_limit, CoerceError, CoercedValue, TYPE_STRING};
+use crate::type_coercion::{coerce_param, CoerceError, CoercedValue, TYPE_STRING};
 
 /// Memory limit for in-memory file storage (1MB default)
 pub const DEFAULT_MEMORY_LIMIT: usize = 1024 * 1024;
@@ -248,7 +248,7 @@ pub fn parse_urlencoded(
     for (key, value) in parsed {
         let type_hint = type_hints.get(&key).copied().unwrap_or(TYPE_STRING);
         let coerced =
-            coerce_param_with_limit(&value, type_hint, max_param_length).map_err(|e| {
+            coerce_param(&value, type_hint, max_param_length).map_err(|e| {
                 ValidationError::type_coercion_error(
                     &key,
                     type_hint_name(type_hint),
@@ -447,7 +447,7 @@ pub async fn parse_multipart(
 
             // Type coercion
             let coerced =
-                coerce_param_with_limit(&value, type_hint, max_param_length).map_err(|e| {
+                coerce_param(&value, type_hint, max_param_length).map_err(|e| {
                     ValidationError::type_coercion_error(
                         &field_name,
                         type_hint_name(type_hint),

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -826,6 +826,10 @@ fn parse_auth_backend(dict: &HashMap<String, Py<PyAny>>, py: Python) -> Option<A
                 .get("header")
                 .and_then(|h| h.extract::<String>(py).ok())
                 .unwrap_or_else(|| "authorization".to_string());
+            let cookie = dict
+                .get("cookie")
+                .and_then(|c| c.extract::<Option<String>>(py).ok())
+                .flatten();
             let audience = dict
                 .get("audience")
                 .and_then(|a| a.extract::<String>(py).ok());
@@ -837,6 +841,7 @@ fn parse_auth_backend(dict: &HashMap<String, Py<PyAny>>, py: Python) -> Option<A
                 secret,
                 algorithms,
                 header,
+                cookie,
                 audience,
                 issuer,
             })

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -84,6 +84,7 @@ pub enum AuthBackend {
         secret: String,
         algorithms: Vec<String>,
         header: String,
+        cookie: Option<String>,
         audience: Option<String>,
         issuer: Option<String>,
     },
@@ -106,6 +107,7 @@ pub fn authenticate(
                 secret,
                 algorithms,
                 header,
+                cookie,
                 audience,
                 issuer,
             } => {
@@ -114,6 +116,7 @@ pub fn authenticate(
                     secret,
                     algorithms,
                     header,
+                    cookie.as_deref(),
                     audience.as_deref(),
                     issuer.as_deref(),
                 ) {
@@ -134,23 +137,41 @@ pub fn authenticate(
     None
 }
 
+/// Find a cookie value by name in a raw Cookie header string.
+/// Zero-allocation scan — returns a slice into the header value.
+fn find_cookie_value<'a>(raw_cookie: &'a str, name: &str) -> Option<&'a str> {
+    for pair in raw_cookie.split(';') {
+        let part = pair.trim();
+        if let Some(eq) = part.find('=') {
+            let (k, v) = part.split_at(eq);
+            if k == name {
+                return Some(&v[1..]); // Skip '=' character
+            }
+        }
+    }
+    None
+}
+
 fn try_jwt_auth(
     headers: &AHashMap<String, String>,
     secret: &str,
     algorithms: &[String],
     header_name: &str,
+    cookie_name: Option<&str>,
     audience: Option<&str>,
     issuer: Option<&str>,
 ) -> Option<AuthContext> {
-    // Get auth header
-    let auth_header = headers.get(header_name)?;
-
-    // Extract token (remove "Bearer " prefix if present)
-    let token = if auth_header.starts_with("Bearer ") {
-        &auth_header[7..]
-    } else {
-        auth_header
+    // Extract raw token: the named cookie when configured, the auth header
+    // otherwise. No fallback between sources.
+    let raw_token = match cookie_name {
+        Some(name) => headers
+            .get("cookie")
+            .and_then(|raw| find_cookie_value(raw, name))?,
+        None => headers.get(header_name)?.as_str(),
     };
+
+    // Remove "Bearer " prefix if present
+    let token = raw_token.strip_prefix("Bearer ").unwrap_or(raw_token);
 
     // Use FIRST algorithm only (as specified in config) - don't try multiple algorithms
     // This is more efficient and follows the principle: one token, one algorithm

--- a/src/request_pipeline.rs
+++ b/src/request_pipeline.rs
@@ -8,7 +8,7 @@ use ahash::AHashMap;
 use std::collections::HashMap;
 
 use crate::responses;
-use crate::type_coercion::{coerce_param_with_limit, CoercedValue, TYPE_STRING};
+use crate::type_coercion::{coerce_param, CoercedValue, TYPE_STRING};
 
 /// Validate and pre-coerce path/query parameters against type hints.
 ///
@@ -45,7 +45,7 @@ pub fn validate_and_cache_typed_params(
             // Type validation for non-string types
             if let Some(&type_hint) = param_types.get(name) {
                 if type_hint != TYPE_STRING {
-                    match coerce_param_with_limit(value, type_hint, max_length) {
+                    match coerce_param(value, type_hint, max_length) {
                         Ok(coerced) => {
                             path_coerced
                                 .get_or_insert_with(AHashMap::new)
@@ -79,7 +79,7 @@ pub fn validate_and_cache_typed_params(
             // Type validation for non-string types
             if let Some(&type_hint) = param_types.get(name) {
                 if type_hint != TYPE_STRING {
-                    match coerce_param_with_limit(value, type_hint, max_length) {
+                    match coerce_param(value, type_hint, max_length) {
                         Ok(coerced) => {
                             query_coerced
                                 .get_or_insert_with(AHashMap::new)

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -45,7 +45,7 @@ use crate::handler::{
 };
 use crate::request_pipeline::validate_and_cache_typed_params;
 use crate::static_files::handle_file;
-use crate::type_coercion::{coerce_param_with_limit, params_to_py_dict, CoerceError, TYPE_STRING};
+use crate::type_coercion::{coerce_param, params_to_py_dict, CoerceError, TYPE_STRING};
 
 static ASYNC_RUNTIME_INITIALIZED: std::sync::Once = std::sync::Once::new();
 
@@ -1327,7 +1327,7 @@ pub fn handle_test_websocket(
     let path_params_dict = pyo3::types::PyDict::new(py);
     for (k, v) in path_params.iter() {
         let type_hint = param_types.get(k).copied().unwrap_or(TYPE_STRING);
-        match coerce_param_with_limit(v, type_hint, max_param_length) {
+        match coerce_param(v, type_hint, max_param_length) {
             Ok(coerced) => {
                 let py_value = coerced_value_to_py(py, &coerced);
                 path_params_dict.set_item(k, py_value)?;
@@ -1362,7 +1362,7 @@ pub fn handle_test_websocket(
                         .copied()
                         .unwrap_or(TYPE_STRING);
 
-                    match coerce_param_with_limit(&decoded_value, type_hint, max_param_length) {
+                    match coerce_param(&decoded_value, type_hint, max_param_length) {
                         Ok(coerced) => {
                             let py_value = coerced_value_to_py(py, &coerced);
                             query_dict.set_item(decoded_key.as_ref(), py_value)?;

--- a/src/type_coercion.rs
+++ b/src/type_coercion.rs
@@ -579,19 +579,31 @@ mod tests {
     fn test_coerce_datetime() {
         // ISO 8601 with Z suffix
         assert!(matches!(
-            coerce_param("2024-01-15T10:30:00Z", TYPE_DATETIME, DEFAULT_MAX_PARAM_LENGTH),
+            coerce_param(
+                "2024-01-15T10:30:00Z",
+                TYPE_DATETIME,
+                DEFAULT_MAX_PARAM_LENGTH
+            ),
             Ok(CoercedValue::DateTime(_))
         ));
 
         // ISO 8601 with timezone offset
         assert!(matches!(
-            coerce_param("2024-01-15T10:30:00+00:00", TYPE_DATETIME, DEFAULT_MAX_PARAM_LENGTH),
+            coerce_param(
+                "2024-01-15T10:30:00+00:00",
+                TYPE_DATETIME,
+                DEFAULT_MAX_PARAM_LENGTH
+            ),
             Ok(CoercedValue::DateTime(_))
         ));
 
         // Naive datetime
         assert!(matches!(
-            coerce_param("2024-01-15T10:30:00", TYPE_DATETIME, DEFAULT_MAX_PARAM_LENGTH),
+            coerce_param(
+                "2024-01-15T10:30:00",
+                TYPE_DATETIME,
+                DEFAULT_MAX_PARAM_LENGTH
+            ),
             Ok(CoercedValue::NaiveDateTime(_))
         ));
 

--- a/src/type_coercion.rs
+++ b/src/type_coercion.rs
@@ -153,7 +153,7 @@ impl CoercedValue {
     }
 }
 
-/// Error returned by [`coerce_param`] / [`coerce_param_with_limit`].
+/// Error returned by [`coerce_param`].
 ///
 /// Callers distinguish the two variants structurally:
 /// * [`CoerceError::TooLong`] is a hard security limit — it MUST always be
@@ -183,22 +183,10 @@ impl std::fmt::Display for CoerceError {
     }
 }
 
-/// Coerce a string value to the specified type
-///
-/// # Arguments
-/// * `value` - The string value to coerce
-/// * `type_hint` - Type hint constant (TYPE_INT, TYPE_FLOAT, etc.)
-///
-/// # Returns
-/// * `Ok(CoercedValue)` - Successfully coerced value
-/// * `Err(CoerceError)` - Structured error (`TooLong` vs `Invalid`)
-pub fn coerce_param(value: &str, type_hint: u8) -> Result<CoercedValue, CoerceError> {
-    coerce_param_with_limit(value, type_hint, DEFAULT_MAX_PARAM_LENGTH)
-}
-
-/// Same as [`coerce_param`] but takes the startup-resolved length limit
-/// (`AppState.max_param_length`) so the hot path never re-resolves config.
-pub(crate) fn coerce_param_with_limit(
+/// Coerce a string value to the specified type, with the startup-resolved
+/// length limit (`AppState.max_param_length`) so the hot path never
+/// re-resolves config.
+pub(crate) fn coerce_param(
     value: &str,
     type_hint: u8,
     max_length: usize,
@@ -511,68 +499,68 @@ mod tests {
     #[test]
     fn test_coerce_int() {
         assert!(matches!(
-            coerce_param("42", TYPE_INT),
+            coerce_param("42", TYPE_INT, DEFAULT_MAX_PARAM_LENGTH),
             Ok(CoercedValue::Int(42))
         ));
         assert!(matches!(
-            coerce_param("-123", TYPE_INT),
+            coerce_param("-123", TYPE_INT, DEFAULT_MAX_PARAM_LENGTH),
             Ok(CoercedValue::Int(-123))
         ));
-        assert!(coerce_param("abc", TYPE_INT).is_err());
+        assert!(coerce_param("abc", TYPE_INT, DEFAULT_MAX_PARAM_LENGTH).is_err());
     }
 
     #[test]
     fn test_coerce_float() {
         assert!(
-            matches!(coerce_param("3.14", TYPE_FLOAT), Ok(CoercedValue::Float(f)) if (f - 3.14).abs() < 0.001)
+            matches!(coerce_param("3.14", TYPE_FLOAT, DEFAULT_MAX_PARAM_LENGTH), Ok(CoercedValue::Float(f)) if (f - 3.14).abs() < 0.001)
         );
         assert!(
-            matches!(coerce_param("-2.5", TYPE_FLOAT), Ok(CoercedValue::Float(f)) if (f + 2.5).abs() < 0.001)
+            matches!(coerce_param("-2.5", TYPE_FLOAT, DEFAULT_MAX_PARAM_LENGTH), Ok(CoercedValue::Float(f)) if (f + 2.5).abs() < 0.001)
         );
-        assert!(coerce_param("not_a_float", TYPE_FLOAT).is_err());
+        assert!(coerce_param("not_a_float", TYPE_FLOAT, DEFAULT_MAX_PARAM_LENGTH).is_err());
     }
 
     #[test]
     fn test_coerce_bool() {
         assert!(matches!(
-            coerce_param("true", TYPE_BOOL),
+            coerce_param("true", TYPE_BOOL, DEFAULT_MAX_PARAM_LENGTH),
             Ok(CoercedValue::Bool(true))
         ));
         assert!(matches!(
-            coerce_param("True", TYPE_BOOL),
+            coerce_param("True", TYPE_BOOL, DEFAULT_MAX_PARAM_LENGTH),
             Ok(CoercedValue::Bool(true))
         ));
         assert!(matches!(
-            coerce_param("1", TYPE_BOOL),
+            coerce_param("1", TYPE_BOOL, DEFAULT_MAX_PARAM_LENGTH),
             Ok(CoercedValue::Bool(true))
         ));
         assert!(matches!(
-            coerce_param("yes", TYPE_BOOL),
+            coerce_param("yes", TYPE_BOOL, DEFAULT_MAX_PARAM_LENGTH),
             Ok(CoercedValue::Bool(true))
         ));
         assert!(matches!(
-            coerce_param("on", TYPE_BOOL),
+            coerce_param("on", TYPE_BOOL, DEFAULT_MAX_PARAM_LENGTH),
             Ok(CoercedValue::Bool(true))
         ));
 
         assert!(matches!(
-            coerce_param("false", TYPE_BOOL),
+            coerce_param("false", TYPE_BOOL, DEFAULT_MAX_PARAM_LENGTH),
             Ok(CoercedValue::Bool(false))
         ));
         assert!(matches!(
-            coerce_param("False", TYPE_BOOL),
+            coerce_param("False", TYPE_BOOL, DEFAULT_MAX_PARAM_LENGTH),
             Ok(CoercedValue::Bool(false))
         ));
         assert!(matches!(
-            coerce_param("0", TYPE_BOOL),
+            coerce_param("0", TYPE_BOOL, DEFAULT_MAX_PARAM_LENGTH),
             Ok(CoercedValue::Bool(false))
         ));
         assert!(matches!(
-            coerce_param("no", TYPE_BOOL),
+            coerce_param("no", TYPE_BOOL, DEFAULT_MAX_PARAM_LENGTH),
             Ok(CoercedValue::Bool(false))
         ));
         assert!(matches!(
-            coerce_param("off", TYPE_BOOL),
+            coerce_param("off", TYPE_BOOL, DEFAULT_MAX_PARAM_LENGTH),
             Ok(CoercedValue::Bool(false))
         ));
     }
@@ -581,46 +569,46 @@ mod tests {
     fn test_coerce_uuid() {
         let uuid_str = "550e8400-e29b-41d4-a716-446655440000";
         assert!(matches!(
-            coerce_param(uuid_str, TYPE_UUID),
+            coerce_param(uuid_str, TYPE_UUID, DEFAULT_MAX_PARAM_LENGTH),
             Ok(CoercedValue::Uuid(_))
         ));
-        assert!(coerce_param("not-a-uuid", TYPE_UUID).is_err());
+        assert!(coerce_param("not-a-uuid", TYPE_UUID, DEFAULT_MAX_PARAM_LENGTH).is_err());
     }
 
     #[test]
     fn test_coerce_datetime() {
         // ISO 8601 with Z suffix
         assert!(matches!(
-            coerce_param("2024-01-15T10:30:00Z", TYPE_DATETIME),
+            coerce_param("2024-01-15T10:30:00Z", TYPE_DATETIME, DEFAULT_MAX_PARAM_LENGTH),
             Ok(CoercedValue::DateTime(_))
         ));
 
         // ISO 8601 with timezone offset
         assert!(matches!(
-            coerce_param("2024-01-15T10:30:00+00:00", TYPE_DATETIME),
+            coerce_param("2024-01-15T10:30:00+00:00", TYPE_DATETIME, DEFAULT_MAX_PARAM_LENGTH),
             Ok(CoercedValue::DateTime(_))
         ));
 
         // Naive datetime
         assert!(matches!(
-            coerce_param("2024-01-15T10:30:00", TYPE_DATETIME),
+            coerce_param("2024-01-15T10:30:00", TYPE_DATETIME, DEFAULT_MAX_PARAM_LENGTH),
             Ok(CoercedValue::NaiveDateTime(_))
         ));
 
-        assert!(coerce_param("not-a-datetime", TYPE_DATETIME).is_err());
+        assert!(coerce_param("not-a-datetime", TYPE_DATETIME, DEFAULT_MAX_PARAM_LENGTH).is_err());
     }
 
     #[test]
     fn test_coerce_decimal() {
         assert!(matches!(
-            coerce_param("123.45", TYPE_DECIMAL),
+            coerce_param("123.45", TYPE_DECIMAL, DEFAULT_MAX_PARAM_LENGTH),
             Ok(CoercedValue::Decimal(_))
         ));
         assert!(matches!(
-            coerce_param("-99.99", TYPE_DECIMAL),
+            coerce_param("-99.99", TYPE_DECIMAL, DEFAULT_MAX_PARAM_LENGTH),
             Ok(CoercedValue::Decimal(_))
         ));
-        assert!(coerce_param("not_decimal", TYPE_DECIMAL).is_err());
+        assert!(coerce_param("not_decimal", TYPE_DECIMAL, DEFAULT_MAX_PARAM_LENGTH).is_err());
     }
 
     #[test]
@@ -628,11 +616,11 @@ mod tests {
         let max_length = DEFAULT_MAX_PARAM_LENGTH;
         // Valid length should work
         let valid = "a".repeat(max_length);
-        assert!(coerce_param(&valid, TYPE_STRING).is_ok());
+        assert!(coerce_param(&valid, TYPE_STRING, DEFAULT_MAX_PARAM_LENGTH).is_ok());
 
         // Exceeding limit should fail
         let too_long = "a".repeat(max_length + 1);
-        let result = coerce_param(&too_long, TYPE_STRING);
+        let result = coerce_param(&too_long, TYPE_STRING, DEFAULT_MAX_PARAM_LENGTH);
         assert!(matches!(result, Err(CoerceError::TooLong { .. })));
     }
 

--- a/src/websocket/handler.rs
+++ b/src/websocket/handler.rs
@@ -18,7 +18,7 @@ use crate::handler::coerced_value_to_py;
 use crate::metadata::CorsConfig;
 use crate::middleware::rate_limit::check_rate_limit;
 use crate::state::{AppState, ROUTE_METADATA, TASK_LOCALS};
-use crate::type_coercion::{coerce_param_with_limit, CoerceError, TYPE_STRING};
+use crate::type_coercion::{coerce_param, CoerceError, TYPE_STRING};
 use crate::validation::{validate_auth_and_guards, AuthGuardResult};
 
 use super::actor::WebSocketActor;
@@ -104,7 +104,7 @@ fn build_scope(
                     .copied()
                     .unwrap_or(TYPE_STRING);
 
-                match coerce_param_with_limit(&decoded_value, type_hint, max_param_length) {
+                match coerce_param(&decoded_value, type_hint, max_param_length) {
                     Ok(coerced) => {
                         let py_value = coerced_value_to_py(py, &coerced);
                         query_dict.set_item(decoded_key.as_ref(), py_value)?;
@@ -140,7 +140,7 @@ fn build_scope(
     let params_dict = PyDict::new(py);
     for (k, v) in path_params.iter() {
         let type_hint = param_types.get(k).copied().unwrap_or(TYPE_STRING);
-        match coerce_param_with_limit(v, type_hint, max_param_length) {
+        match coerce_param(v, type_hint, max_param_length) {
             Ok(coerced) => {
                 let py_value = coerced_value_to_py(py, &coerced);
                 params_dict.set_item(k.as_str(), py_value)?;


### PR DESCRIPTION
## Summary

Two related auth features plus a correctness fix the new tests uncovered:

1. **Cookie-based JWT tokens** — `JWTAuthentication(cookie="access_token")` reads the token from the named cookie instead of the `Authorization` header, for browser clients using `HttpOnly` cookies.
2. **Custom user loading** — backends can override `get_user` (async) and/or `get_user_sync` (sync) to control the query behind `request.user` (`select_related`, `defer`, lookup by username, custom user model). Either override alone is honored.
3. **Fix: user loaders resolve per route, not per scheme name** — without this, the override feature silently breaks in any app that mixes a subclass with a plain JWT backend.

## Cookie extraction (Rust)

- `cookie=` compiles into the backend metadata and flows to Rust `AppState`; extraction is a zero-allocation scan of the raw `Cookie` header, so cookie auth stays GIL-free like header auth.
- When `cookie=` is set, the named cookie is the **sole** token source — the `Authorization` header is not a fallback. Serving both browser and API clients on one route is done by listing two backends, tried in order:

  ```python
  auth=[JWTAuthentication(cookie="access_token"), JWTAuthentication()]
  ```

## Custom `get_user` / `get_user_sync`

- The loading strategy is resolved **once at registration** (override introspection, `iscoroutinefunction` checks) and baked into a closure; the per-request path is one dict lookup plus the pre-resolved closure. No new per-request work.
- Priority: overridden `get_user_sync` (direct call, no event loop) → overridden `get_user` → framework default pk query. Backends with no user resolution now skip the `SimpleLazyObject` allocation entirely.

## The per-route fix

User loaders were registered globally keyed by `scheme_name` with first-registration-wins. Every `JWTAuthentication` subclass shares scheme `"jwt"`, so in an app with:

```python
@api.get("/a", auth=[JWTAuthentication()])          # registers "jwt" first
@api.get("/b", auth=[MyJWT()])                       # override silently ignored
```

route `/b` used the plain backend's default pk lookup — `request.user` came back wrong/`None` with no error. `_route_decorator` now resolves a `{scheme: loader}` map from each route's own backend instances at registration (`meta["_user_loaders"]`), and both dispatch paths use the route-local loader. Unknown schemes (Rust session auth) keep the default Django pk-query fallback.

Also folds `coerce_param_with_limit` into `coerce_param` — every caller already passed the startup-resolved limit, so the wrapper was dead code.

## Tests

- `python/tests/test_jwt_cookie_auth.py` — in-process TestClient suite: extraction semantics (wrong cookie name, expired/forged tokens, no header fallback, dual backends), override resolution priority, and a regression test for the per-route fix (custom backend must win on its own route when a plain `"jwt"` backend registered first).
- `python/tests/integration/test_jwt_cookie_server_integration.py` — real `runbolt` subprocess (`server_integration`): proves `cookie=` survives startup wiring into Rust `AppState` over real HTTP, and that `get_user` overrides registered at server startup drive `request.user`. This test is what caught the per-route bug.

Full suite: 2313 passed, 7 skipped. `just lint-lib` clean.

## Docs

`docs/src/topics/authentication.md` and `docs/src/ref/auth.md`: cookie-based tokens section, custom user query section, and a note that overrides are scoped to routes using that backend instance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Hot request path assessment

Yes—this PR touches hot request-path code in the authentication flow (Rust), request dispatch/user resolution (Python), and request parameter/form coercion paths (Rust).

### Hot-path impact
- **Cookie JWT extraction (Rust `authenticate` → `try_jwt_auth`)**: When `cookie` is configured, token extraction switches from a single header lookup to parsing the raw `Cookie` header and scanning `;`-separated pairs to find the named cookie (`find_cookie_value`). This is additional per-request work, but it’s required for cookie-based auth and avoids any cross-source fallback between cookie and `Authorization`.
- **User resolution in request dispatch (Python `_dispatch` / `_dispatch_sync`)**: Per-request work is kept minimal:
  - loader selection is an **O(1) dict lookup** into route-local `meta["_user_loaders"]`
  - it **only creates** `request["user"]` (`SimpleLazyObject` / `partial`) when a resolved loader exists
  - async-vs-sync loader execution context is precomputed/stored at registration time (`meta["_user_load_is_async_ctx"]`), avoiding per-request override introspection/branching.
- **Typed parameter/form coercion (Rust `request_pipeline`, `form_parsing`, `websocket`, and shared test/coercion utilities)**: Swaps `coerce_param_with_limit` → `coerce_param`. This does the same required work (length check + typed coercion) and keeps error-handling semantics; it’s a refactor, not extra processing.

### Is it “stupid work”?
No obvious wasteful work was added to the per-request path. The only meaningful additional per-request cost is the unavoidable **cookie header scan** when cookie-mode JWT is enabled; everything else is structured to shift expensive decisions to registration time and keep per-request overhead to small lookups and conditional lazy object creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->