### PR TITLE
JWKS runtime refresh & OIDC discovery, add `kid` support and ready-made JWT cookie auth views

### DIFF
--- a/docs/src/ref/auth.md
+++ b/docs/src/ref/auth.md
@@ -23,6 +23,8 @@ JWTAuthentication(
     audience=None,            # Required audience claim
     issuer=None,              # Required issuer claim
     revocation_store=None,    # Token revocation store
+    oidc_issuer=None,         # OIDC discovery issuer
+    jwks_refresh_interval=300,
 )
 ```
 
@@ -40,8 +42,10 @@ JWTAuthentication(
 | `leeway`           | `int`           | `60`              | Clock-skew tolerance (seconds) for `exp`/`nbf` |
 | `token_type`       | `str`           | `None`            | Required `typ` claim (e.g. `"refresh"` for a rotation endpoint); access routes reject `typ:"refresh"` |
 | `csrf`             | `bool`          | `True`            | For cookie tokens, enforce a cross-site origin check on unsafe methods that carry the auth cookie |
-| `jwks_url`         | `str`           | `None`            | HTTPS JWKS endpoint; requires `issuer` and `audience`, fetched once at startup |
+| `jwks_url`         | `str`           | `None`            | HTTPS JWKS endpoint; requires `issuer` and `audience`, refreshed at runtime |
 | `jwks`             | `dict \| str`   | `None`            | JWKS document supplied directly (alternative to `jwks_url`) |
+| `oidc_issuer`      | `str`           | `None`            | HTTPS issuer for OIDC discovery; requires `audience` |
+| `jwks_refresh_interval` | `int`       | `300`             | Periodic remote JWKS refresh interval in seconds |
 | `revocation_store` | RevocationStore | `None`            | Token revocation store  |
 
 #### Supported algorithms
@@ -265,7 +269,7 @@ tokens](../topics/authentication.md#access-and-refresh-tokens) for usage.
 ```python
 from django_bolt.auth import create_token_pair
 
-pair = create_token_pair(user, method="pwd")
+pair = create_token_pair(user, method="pwd", kid="signing-key-2026-07")
 pair.access_token     # JWT with typ "access"
 pair.refresh_token    # JWT with typ "refresh"
 pair.access_claims    # decoded claims of the access token
@@ -279,6 +283,7 @@ pair.refresh_claims   # decoded claims of the refresh token
 | `user`        | User \| `str` \| `int` | required        | Django user instance, or a bare user id        |
 | `secret`      | `str`                | Django SECRET_KEY | Signing key                                    |
 | `algorithm`   | `str`                | `"HS256"`         | JWT signing algorithm                          |
+| `kid`         | `str`                | `None`            | Optional signing-key identifier added to both JWT headers |
 | `access_ttl`  | `int`                | `900`             | Access token lifetime in seconds               |
 | `refresh_ttl` | `int`                | `604800`          | Refresh token lifetime in seconds              |
 | `claims`      | `dict`               | `None`            | Extra claims copied into both tokens           |
@@ -310,6 +315,7 @@ pair = await rotate_refresh_token(claims, store=store)
 | `store`                | RevocationStore | required          | Store used for revocation and version checks         |
 | `secret`               | `str`           | Django SECRET_KEY | Signing key for the new tokens                       |
 | `algorithm`            | `str`           | `"HS256"`         | JWT signing algorithm                                |
+| `kid`                  | `str`           | `None`            | Optional signing-key identifier added to newly issued JWT headers |
 | `access_ttl`           | `int`           | `900`             | New access token lifetime in seconds                 |
 | `refresh_ttl`          | `int`           | `604800`          | New refresh token lifetime in seconds                |
 | `rotate`               | `bool`          | `True`            | Issue a new refresh token and revoke the old one; `False` issues an access token only |

--- a/docs/src/topics/authentication.md
+++ b/docs/src/topics/authentication.md
@@ -230,11 +230,24 @@ JWTAuthentication(
 `jwks_url` must be an absolute HTTPS URL and must be paired with both
 `issuer=` and `audience=`. This binds accepted tokens to the intended
 provider and API instead of accepting another application's token merely
-because the provider signed it. The key set is fetched once when the
-server starts and parsed into
-per-`kid` verification keys; on each request, the token's `kid` header
-selects the key. If the provider rotates its signing keys to a new
-`kid`, restart the server to pick up the new set.
+because the provider signed it. The key set is fetched when the server
+starts and parsed into per-`kid` verification keys. It is refreshed every
+`jwks_refresh_interval` seconds and immediately when a token names an unknown
+`kid`. Refreshes are single-flight within a process, and a provider outage
+leaves the last known-good keys active.
+
+OIDC discovery can supply the issuer, JWKS endpoint, and signing algorithms:
+
+```python
+JWTAuthentication(
+    oidc_issuer="https://issuer.example",
+    audience="my-api",
+)
+```
+
+The issuer must be HTTPS. Django-Bolt fetches its
+`/.well-known/openid-configuration` document and rejects discovery documents
+without an issuer or JWKS URI.
 
 To supply a key set directly rather than fetching it — in tests, or in
 deployments without network access — pass the document itself as `jwks=`,
@@ -312,6 +325,21 @@ token**, sent only to a rotation endpoint, that is exchanged for fresh
 access tokens as they expire. Django-Bolt implements this pattern with
 `create_token_pair()`, `rotate_refresh_token()`, and
 `set_token_cookies()`.
+
+For the conventional password-and-cookie flow, `JWTAuthViews` registers all
+four routes and documents them in OpenAPI:
+
+```python
+from django_bolt.auth import InMemoryRevocation, JWTAuthViews
+
+auth_views = JWTAuthViews(store=InMemoryRevocation())
+auth_views.register(api)
+```
+
+This adds `POST /auth/login`, `/auth/refresh`, `/auth/logout`, and
+`/auth/logout-all`. Supply `credential_validator=` when credentials are not a
+username/password pair; lower-level helpers remain available for fully custom
+flows.
 
 ### Issuing a pair
 

--- a/python/django_bolt/auth/__init__.py
+++ b/python/django_bolt/auth/__init__.py
@@ -62,6 +62,7 @@ from .user_loader import (
     load_user,
     register_auth_backend,
 )
+from .views import JWTAuthViews, LoginCredentials
 
 __all__ = [
     # Authentication
@@ -102,4 +103,7 @@ __all__ = [
     "register_auth_backend",
     "get_registered_backend",
     "load_user",
+    # Ready-made lifecycle endpoints
+    "JWTAuthViews",
+    "LoginCredentials",
 ]

--- a/python/django_bolt/auth/backends.py
+++ b/python/django_bolt/auth/backends.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 import json
 import sys
+import threading
+import time
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -144,15 +146,19 @@ class JWTAuthentication(BaseAuthentication):
             ``Sec-Fetch-Site: none``, use header tokens, or set False for
             API-only cookie deployments that provide their own protection.
         jwks_url: Absolute HTTPS URL of a JWKS endpoint (e.g. a provider's
-            ``/.well-known/jwks.json``). Fetched once at server startup; the
-            key set is parsed into per-``kid`` decoding keys in Rust and the
-            token's ``kid`` header selects the key. Use with an asymmetric
-            ``algorithms`` list (e.g. ``["RS256"]``), plus ``issuer`` and
-            ``audience``. Rotation to a new ``kid`` is picked up on the next
-            server start.
+            ``/.well-known/jwks.json``). The key set is parsed into per-``kid``
+            decoding keys in Rust, refreshed periodically and immediately for
+            an unknown ``kid``. Use with an asymmetric ``algorithms`` list
+            (e.g. ``["RS256"]``), plus ``issuer`` and ``audience``.
         jwks: A JWKS document (dict or JSON string) supplied directly instead
             of fetching a ``jwks_url`` — useful for tests or air-gapped
             deployments. Mutually exclusive with ``secret``/``public_key``.
+        oidc_issuer: HTTPS issuer URL used for OpenID Connect discovery. The
+            discovery document supplies ``issuer``, ``jwks_uri``, and the
+            signing algorithm allowlist. Requires ``audience``.
+        jwks_refresh_interval: Seconds between runtime refresh attempts for a
+            remote JWKS (default: 300). An unknown ``kid`` refreshes
+            immediately; failed refreshes retain the last known-good keys.
     """
 
     # Class-level cached User model - resolved once on first use
@@ -182,11 +188,17 @@ class JWTAuthentication(BaseAuthentication):
         csrf: bool = True,
         jwks_url: str | None = None,
         jwks: dict[str, Any] | str | None = None,
+        oidc_issuer: str | None = None,
+        jwks_refresh_interval: int = 300,
     ):
         provided_keys = [k for k in (secret, public_key) if k is not None]
         if len(provided_keys) > 1:
             raise ImproperlyConfigured(
                 "JWTAuthentication accepts either 'secret' (HMAC) or 'public_key' (asymmetric), not both."
+            )
+        if oidc_issuer is not None and (jwks_url is not None or jwks is not None or issuer is not None):
+            raise ImproperlyConfigured(
+                "JWTAuthentication oidc_issuer is mutually exclusive with 'issuer', 'jwks_url', and 'jwks'."
             )
         if jwks_url is not None and jwks is not None:
             raise ImproperlyConfigured("JWTAuthentication accepts either 'jwks_url' or 'jwks', not both.")
@@ -194,6 +206,29 @@ class JWTAuthentication(BaseAuthentication):
             raise ImproperlyConfigured(
                 "JWTAuthentication accepts JWKS (jwks_url/jwks) or a static key (secret/public_key), not both."
             )
+        if jwks_refresh_interval <= 0:
+            raise ImproperlyConfigured("JWTAuthentication jwks_refresh_interval must be > 0 seconds.")
+        if oidc_issuer is not None:
+            parsed_oidc_issuer = urlsplit(oidc_issuer)
+            if parsed_oidc_issuer.scheme.lower() != "https" or not parsed_oidc_issuer.hostname:
+                raise ImproperlyConfigured("JWTAuthentication oidc_issuer must be an absolute HTTPS URL.")
+            if audience is None:
+                raise ImproperlyConfigured("JWTAuthentication with oidc_issuer requires 'audience'.")
+            discovery_url = f"{oidc_issuer.rstrip('/')}/.well-known/openid-configuration"
+            discovery_response = httpx.get(discovery_url, timeout=10.0)
+            discovery_response.raise_for_status()
+            discovery = discovery_response.json()
+            discovered_issuer = discovery.get("issuer")
+            discovered_jwks_url = discovery.get("jwks_uri")
+            discovered_algorithms = discovery.get("id_token_signing_alg_values_supported")
+            if not isinstance(discovered_issuer, str) or not isinstance(discovered_jwks_url, str):
+                raise ImproperlyConfigured("OIDC discovery document must contain string 'issuer' and 'jwks_uri'.")
+            if discovered_issuer.rstrip("/") != oidc_issuer.rstrip("/"):
+                raise ImproperlyConfigured("OIDC discovery issuer does not match oidc_issuer.")
+            issuer = discovered_issuer
+            jwks_url = discovered_jwks_url
+            if algorithms is None and isinstance(discovered_algorithms, list):
+                algorithms = [value for value in discovered_algorithms if isinstance(value, str) and value != "none"]
         if jwks_url is not None:
             parsed_jwks_url = urlsplit(jwks_url)
             if parsed_jwks_url.scheme.lower() != "https" or not parsed_jwks_url.hostname:
@@ -219,6 +254,10 @@ class JWTAuthentication(BaseAuthentication):
         self.csrf = csrf
         self.jwks_url = jwks_url
         self._jwks = jwks
+        self.oidc_issuer = oidc_issuer
+        self.jwks_refresh_interval = jwks_refresh_interval
+        self._jwks_refresh_lock = threading.Lock()
+        self._jwks_refreshed_at = 0.0
 
         # If no key material provided at all (and no JWKS), fall back to
         # Django's SECRET_KEY.
@@ -264,12 +303,9 @@ class JWTAuthentication(BaseAuthentication):
         """Return the JWKS document as a JSON string, or None.
 
         A ``jwks`` dict/string is used verbatim; a ``jwks_url`` is fetched
-        once here (at server startup, when ``to_metadata`` first runs) via
-        httpx and cached on the instance — a backend shared across routes
-        does not re-fetch per route. The resulting key set is parsed into
-        per-``kid`` decoding keys in Rust. Key rotation to a *new* ``kid``
-        is picked up on the next server start — the standard trade-off for
-        a startup-cached key set.
+        here when ``to_metadata`` first runs and cached on the instance. The
+        resulting key set is parsed into per-``kid`` decoding keys in Rust;
+        remote sets are subsequently refreshed through ``_refresh_jwks``.
         """
         if self._jwks is not None:
             return self._jwks if isinstance(self._jwks, str) else json.dumps(self._jwks)
@@ -277,8 +313,30 @@ class JWTAuthentication(BaseAuthentication):
             response = httpx.get(self.jwks_url, timeout=10.0)
             response.raise_for_status()
             self._jwks = response.text
+            self._jwks_refreshed_at = time.monotonic()
             return self._jwks
         return None
+
+    def _refresh_jwks(self) -> str | None:
+        """Fetch and atomically replace remote JWKS, retaining stale keys on failure."""
+        if self.jwks_url is None:
+            return None
+        if not self._jwks_refresh_lock.acquire(blocking=False):
+            return None
+        try:
+            response = httpx.get(self.jwks_url, timeout=10.0)
+            response.raise_for_status()
+            # Validate the shape before replacing a known-good cached value.
+            document = response.json()
+            if not isinstance(document, dict) or not isinstance(document.get("keys"), list):
+                raise ValueError("JWKS response must contain a keys array")
+            self._jwks = response.text
+            self._jwks_refreshed_at = time.monotonic()
+            return self._jwks
+        except (httpx.HTTPError, ValueError):
+            return None
+        finally:
+            self._jwks_refresh_lock.release()
 
     def to_metadata(self) -> dict[str, Any]:
         metadata = {
@@ -306,6 +364,9 @@ class JWTAuthentication(BaseAuthentication):
         jwks = self._resolve_jwks()
         if jwks is not None:
             metadata["jwks"] = jwks
+            if self.jwks_url is not None:
+                metadata["jwks_refresh"] = self._refresh_jwks
+                metadata["jwks_refresh_interval"] = self.jwks_refresh_interval
 
         # Add revocation handler reference (will be called from Rust if present)
         if self.revoked_token_handler:

--- a/python/django_bolt/auth/tokens.py
+++ b/python/django_bolt/auth/tokens.py
@@ -88,6 +88,7 @@ def create_token_pair(
     *,
     secret: str | None = None,
     algorithm: str = "HS256",
+    kid: str | None = None,
     access_ttl: int = DEFAULT_ACCESS_TTL,
     refresh_ttl: int = DEFAULT_REFRESH_TTL,
     claims: dict[str, Any] | None = None,
@@ -102,6 +103,9 @@ def create_token_pair(
             assume password login.
         secret: Signing key (default: Django ``SECRET_KEY``).
         algorithm: JWT algorithm (default ``HS256``).
+        kid: Optional signing-key identifier added to both JWT headers. This
+            lets verifiers select the matching public key during asymmetric
+            signing-key rotation.
         access_ttl / refresh_ttl: Lifetimes in seconds.
         claims: Extra claims copied into *both* tokens (e.g. ``role``,
             ``tenant_id``). Overriding a reserved lifecycle claim
@@ -142,9 +146,10 @@ def create_token_pair(
     }
 
     key = _secret(secret)
+    headers = {"kid": kid} if kid is not None else None
     return TokenPair(
-        access_token=jwt.encode(access_claims, key, algorithm=algorithm),
-        refresh_token=jwt.encode(refresh_claims, key, algorithm=algorithm),
+        access_token=jwt.encode(access_claims, key, algorithm=algorithm, headers=headers),
+        refresh_token=jwt.encode(refresh_claims, key, algorithm=algorithm, headers=headers),
         access_claims=access_claims,
         refresh_claims=refresh_claims,
     )
@@ -156,6 +161,7 @@ async def rotate_refresh_token(
     store: Any,
     secret: str | None = None,
     algorithm: str = "HS256",
+    kid: str | None = None,
     access_ttl: int = DEFAULT_ACCESS_TTL,
     refresh_ttl: int = DEFAULT_REFRESH_TTL,
     rotate: bool = True,
@@ -164,6 +170,9 @@ async def rotate_refresh_token(
     claims: dict[str, Any] | None = None,
 ) -> TokenPair:
     """Exchange a validated refresh token for a new token pair.
+
+    ``kid`` optionally identifies the signing key in every newly issued JWT
+    header, matching the parameter accepted by :func:`create_token_pair`.
 
     ``refresh_claims`` is the already cryptographically-validated claim dict
     from ``request["context"]["auth_claims"]`` — the Rust layer verified the
@@ -295,6 +304,7 @@ async def rotate_refresh_token(
         carried.update(claims)
 
     key = _secret(secret)
+    headers = {"kid": kid} if kid is not None else None
 
     if not rotate:
         # Mode B: new access token only; refresh token stays valid.
@@ -310,7 +320,7 @@ async def rotate_refresh_token(
         if parsed_oat is not None:
             access_claims["oat"] = parsed_oat
         return TokenPair(
-            access_token=jwt.encode(access_claims, key, algorithm=algorithm),
+            access_token=jwt.encode(access_claims, key, algorithm=algorithm, headers=headers),
             refresh_token="",
             access_claims=access_claims,
             refresh_claims=refresh_claims,
@@ -322,6 +332,7 @@ async def rotate_refresh_token(
         user_id,
         secret=secret,
         algorithm=algorithm,
+        kid=kid,
         access_ttl=effective_access_ttl,
         refresh_ttl=refresh_ttl,
         claims=carried or None,
@@ -330,7 +341,7 @@ async def rotate_refresh_token(
     )
     if fam is not None:
         pair.refresh_claims["fam"] = fam
-        pair.refresh_token = jwt.encode(pair.refresh_claims, key, algorithm=algorithm)
+        pair.refresh_token = jwt.encode(pair.refresh_claims, key, algorithm=algorithm, headers=headers)
     return pair
 
 

--- a/python/django_bolt/auth/views.py
+++ b/python/django_bolt/auth/views.py
@@ -1,0 +1,150 @@
+"""Ready-made cookie-based JWT lifecycle endpoints."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import msgspec
+from django.contrib.auth import aauthenticate
+
+from django_bolt.exceptions import HTTPException
+from django_bolt.responses import JSON
+
+from .backends import JWTAuthentication
+from .guards import IsAuthenticated
+from .tokens import TokenRotationError, create_token_pair, rotate_refresh_token, set_token_cookies
+
+
+class LoginCredentials(msgspec.Struct):
+    """Default request body accepted by :class:`JWTAuthViews`."""
+
+    username: str
+    password: str
+
+
+CredentialValidator = Callable[[Any, LoginCredentials], Awaitable[Any | None]]
+
+
+class JWTAuthViews:
+    """Register conventional login, refresh, logout, and logout-all routes.
+
+    Applications with different credential requirements can replace
+    ``credential_validator`` while retaining consistent cookie, rotation,
+    revocation, error, and OpenAPI behavior.
+    """
+
+    def __init__(
+        self,
+        *,
+        store: Any,
+        secret: str | None = None,
+        algorithm: str = "HS256",
+        kid: str | None = None,
+        prefix: str = "/auth",
+        access_cookie: str = "access_token",
+        refresh_cookie: str = "refresh_token",
+        secure_cookies: bool = True,
+        credential_validator: CredentialValidator | None = None,
+    ) -> None:
+        self.store = store
+        self.secret = secret
+        self.algorithm = algorithm
+        self.kid = kid
+        self.prefix = prefix.rstrip("/")
+        self.access_cookie = access_cookie
+        self.refresh_cookie = refresh_cookie
+        self.secure_cookies = secure_cookies
+        self.credential_validator = credential_validator or self._authenticate
+
+    async def _authenticate(self, request: Any, credentials: LoginCredentials) -> Any | None:
+        return await aauthenticate(request=request, username=credentials.username, password=credentials.password)
+
+    def _clear_cookies(self, response: JSON) -> JSON:
+        response.delete_cookie(self.access_cookie, path="/")
+        response.delete_cookie(self.refresh_cookie, path=self.prefix)
+        return response
+
+    def register(self, api: Any) -> None:
+        """Attach the four lifecycle routes to a :class:`BoltAPI`."""
+        refresh_auth = JWTAuthentication(
+            secret=self.secret,
+            algorithms=[self.algorithm],
+            cookie=self.refresh_cookie,
+            token_type="refresh",
+            require_jti=True,
+        )
+
+        @api.post(f"{self.prefix}/login", tags=["auth"], summary="Log in")
+        async def login(request: Any, credentials: LoginCredentials):
+            user = await self.credential_validator(request, credentials)
+            if user is None or not getattr(user, "is_active", True):
+                raise HTTPException(status_code=401, detail="Invalid credentials")
+            user_id = str(user.pk)
+            version = await self.store.get_user_version(user_id)
+            pair = create_token_pair(
+                user,
+                secret=self.secret,
+                algorithm=self.algorithm,
+                kid=self.kid,
+                version=version,
+                method="pwd",
+            )
+            return set_token_cookies(
+                JSON({"ok": True}),
+                pair,
+                access_cookie=self.access_cookie,
+                refresh_cookie=self.refresh_cookie,
+                refresh_path=self.prefix,
+                secure=self.secure_cookies,
+            )
+
+        @api.post(
+            f"{self.prefix}/refresh",
+            auth=[refresh_auth],
+            guards=[IsAuthenticated()],
+            tags=["auth"],
+            summary="Refresh tokens",
+        )
+        async def refresh(request: Any):
+            try:
+                pair = await rotate_refresh_token(
+                    request["context"]["auth_claims"],
+                    store=self.store,
+                    secret=self.secret,
+                    algorithm=self.algorithm,
+                    kid=self.kid,
+                )
+            except TokenRotationError:
+                raise HTTPException(status_code=401, detail="Invalid token") from None
+            return set_token_cookies(
+                JSON({"ok": True}),
+                pair,
+                access_cookie=self.access_cookie,
+                refresh_cookie=self.refresh_cookie,
+                refresh_path=self.prefix,
+                secure=self.secure_cookies,
+            )
+
+        @api.post(
+            f"{self.prefix}/logout",
+            auth=[refresh_auth],
+            guards=[IsAuthenticated()],
+            tags=["auth"],
+            summary="Log out",
+        )
+        async def logout(request: Any):
+            claims = request["context"]["auth_claims"]
+            await self.store.revoke_family(claims["fam"], exp=claims.get("exp"))
+            return self._clear_cookies(JSON({"ok": True}))
+
+        @api.post(
+            f"{self.prefix}/logout-all",
+            auth=[refresh_auth],
+            guards=[IsAuthenticated()],
+            tags=["auth"],
+            summary="Log out everywhere",
+        )
+        async def logout_all(request: Any):
+            await self.store.bump_user_version(request["context"]["user_id"])
+            return self._clear_cookies(JSON({"ok": True}))

--- a/python/tests/test_jwt_auth_views.py
+++ b/python/tests/test_jwt_auth_views.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pytest
+
+from django_bolt import BoltAPI
+from django_bolt.auth import InMemoryRevocation, JWTAuthViews
+from django_bolt.testing import TestClient
+
+pytestmark = pytest.mark.django_db
+
+
+class User:
+    pk = "view-user"
+    is_active = True
+
+
+def test_ready_made_cookie_lifecycle_routes():
+    api = BoltAPI()
+    store = InMemoryRevocation()
+
+    async def validate(request, credentials):
+        if credentials.username == "alice" and credentials.password == "correct":
+            return User()
+        return None
+
+    JWTAuthViews(
+        store=store,
+        secret="a-secure-test-secret-that-is-long-enough",
+        secure_cookies=False,
+        credential_validator=validate,
+    ).register(api)
+
+    with TestClient(api) as client:
+        denied = client.post("/auth/login", json={"username": "alice", "password": "wrong"})
+        assert denied.status_code == 401
+
+        login = client.post("/auth/login", json={"username": "alice", "password": "correct"})
+        assert login.status_code == 200
+        assert client.cookies.get("access_token")
+        assert client.cookies.get("refresh_token")
+
+        headers = {"Sec-Fetch-Site": "none"}
+        refreshed = client.post("/auth/refresh", headers=headers)
+        assert refreshed.status_code == 200
+
+        logout_all = client.post("/auth/logout-all", headers=headers)
+        assert logout_all.status_code == 200
+        assert client.cookies.get("access_token") is None
+        assert client.cookies.get("refresh_token") is None
+
+
+def test_auth_views_are_documented_in_openapi():
+    api = BoltAPI()
+    JWTAuthViews(store=InMemoryRevocation(), secret="a-secure-test-secret-that-is-long-enough").register(api)
+    api._register_openapi_routes()
+
+    with TestClient(api) as client:
+        schema = client.get("/docs/openapi.json").json()
+    assert set(schema["paths"]) >= {
+        "/auth/login",
+        "/auth/refresh",
+        "/auth/logout",
+        "/auth/logout-all",
+    }

--- a/python/tests/test_jwt_jwks.py
+++ b/python/tests/test_jwt_jwks.py
@@ -151,6 +151,47 @@ class TestJwks:
 
 
 class TestJwksUrlCaching:
+    def test_unknown_kid_triggers_runtime_refresh(self, monkeypatch):
+        documents = [{"keys": [KEY1_JWK]}, {"keys": [KEY1_JWK, KEY2_JWK]}]
+
+        class FakeResponse:
+            def __init__(self, document):
+                self.document = document
+                self.text = json.dumps(document)
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return self.document
+
+        def fake_get(url, timeout):
+            return FakeResponse(documents.pop(0))
+
+        monkeypatch.setattr(auth_backends.httpx, "get", fake_get)
+        api = BoltAPI()
+
+        @api.get(
+            "/rotating",
+            auth=[
+                JWTAuthentication(
+                    jwks_url="https://issuer.example/jwks.json",
+                    algorithms=["RS256"],
+                    issuer="https://issuer.example/",
+                    audience="api",
+                )
+            ],
+            guards=[IsAuthenticated()],
+        )
+        async def rotating():
+            return {"ok": True}
+
+        with TestClient(api) as client:
+            token = make_token(KEY2_PRIV, "key-2", iss="https://issuer.example/", aud="api")
+            assert client.get("/rotating", headers={"Authorization": f"Bearer {token}"}).status_code == 200
+
+        assert documents == []
+
     def test_jwks_url_fetched_once_across_metadata_calls(self, monkeypatch):
         """A backend reused as a global default or across routes runs
         ``to_metadata()`` once per route; the fetched document must be cached
@@ -181,3 +222,108 @@ class TestJwksUrlCaching:
 
         assert first["jwks"] == second["jwks"] == json.dumps(JWKS)
         assert len(calls) == 1
+
+    def test_remote_metadata_exposes_single_flight_refresh_callback(self, monkeypatch):
+        responses = [JWKS, {"keys": [KEY2_JWK]}]
+
+        class FakeResponse:
+            def __init__(self, document):
+                self.document = document
+                self.text = json.dumps(document)
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return self.document
+
+        def next_response(_url, timeout):
+            assert timeout == 10.0
+            return FakeResponse(responses.pop(0))
+
+        monkeypatch.setattr(auth_backends.httpx, "get", next_response)
+        auth = JWTAuthentication(
+            jwks_url="https://issuer.example/jwks.json",
+            algorithms=["RS256"],
+            issuer="https://issuer.example/",
+            audience="api",
+            jwks_refresh_interval=60,
+        )
+
+        metadata = auth.to_metadata()
+        refreshed = metadata["jwks_refresh"]()
+
+        assert json.loads(refreshed) == {"keys": [KEY2_JWK]}
+        assert metadata["jwks_refresh_interval"] == 60
+
+    def test_failed_refresh_keeps_cached_jwks(self, monkeypatch):
+        class FakeResponse:
+            text = json.dumps(JWKS)
+
+            def raise_for_status(self):
+                pass
+
+        def initial_response(_url, timeout):
+            assert timeout == 10.0
+            return FakeResponse()
+
+        monkeypatch.setattr(auth_backends.httpx, "get", initial_response)
+        auth = JWTAuthentication(
+            jwks_url="https://issuer.example/jwks.json",
+            algorithms=["RS256"],
+            issuer="https://issuer.example/",
+            audience="api",
+        )
+        metadata = auth.to_metadata()
+
+        def unavailable(url, timeout):
+            raise auth_backends.httpx.ConnectError("offline")
+
+        monkeypatch.setattr(auth_backends.httpx, "get", unavailable)
+        assert metadata["jwks_refresh"]() is None
+        assert auth._resolve_jwks() == json.dumps(JWKS)
+
+
+class TestOidcDiscovery:
+    def test_discovery_configures_issuer_jwks_and_algorithms(self, monkeypatch):
+        calls = []
+
+        class FakeResponse:
+            def __init__(self, document):
+                self.document = document
+                self.text = json.dumps(document)
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return self.document
+
+        def fake_get(url, timeout):
+            calls.append(url)
+            if url.endswith("openid-configuration"):
+                return FakeResponse(
+                    {
+                        "issuer": "https://issuer.example",
+                        "jwks_uri": "https://issuer.example/keys",
+                        "id_token_signing_alg_values_supported": ["RS256", "none"],
+                    }
+                )
+            return FakeResponse(JWKS)
+
+        monkeypatch.setattr(auth_backends.httpx, "get", fake_get)
+        metadata = JWTAuthentication(
+            oidc_issuer="https://issuer.example",
+            audience="my-api",
+        ).to_metadata()
+
+        assert metadata["issuer"] == "https://issuer.example"
+        assert metadata["algorithms"] == ["RS256"]
+        assert calls == [
+            "https://issuer.example/.well-known/openid-configuration",
+            "https://issuer.example/keys",
+        ]
+
+    def test_discovery_requires_audience(self):
+        with pytest.raises(ImproperlyConfigured, match="audience"):
+            JWTAuthentication(oidc_issuer="https://issuer.example")

--- a/python/tests/test_token_pair.py
+++ b/python/tests/test_token_pair.py
@@ -63,6 +63,12 @@ class TestCreateTokenPair:
         assert pair.access_claims["role"] == "admin"
         assert pair.refresh_claims["role"] == "admin"
 
+    def test_kid_added_to_both_token_headers(self):
+        pair = create_token_pair("u", secret=SECRET, kid="signing-key-2026-07")
+
+        assert jwt.get_unverified_header(pair.access_token)["kid"] == "signing-key-2026-07"
+        assert jwt.get_unverified_header(pair.refresh_token)["kid"] == "signing-key-2026-07"
+
     def test_accepts_django_user_pk(self):
         class FakeUser:
             pk = 7
@@ -95,6 +101,21 @@ class TestCreateTokenPair:
 
 
 class TestRotation:
+    @pytest.mark.asyncio
+    async def test_rotation_adds_kid_to_new_tokens(self):
+        store = InMemoryRevocation()
+        pair = create_token_pair("u", secret=SECRET)
+
+        rotated = await rotate_refresh_token(
+            pair.refresh_claims,
+            store=store,
+            secret=SECRET,
+            kid="replacement-key",
+        )
+
+        assert jwt.get_unverified_header(rotated.access_token)["kid"] == "replacement-key"
+        assert jwt.get_unverified_header(rotated.refresh_token)["kid"] == "replacement-key"
+
     @pytest.mark.asyncio
     async def test_full_rotation_issues_new_pair_and_revokes_old(self):
         store = InMemoryRevocation()

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -13,6 +13,7 @@ use std::collections::{HashMap, HashSet};
 use crate::form_parsing::FileFieldConstraints;
 use crate::middleware::auth::{
     build_jwks_key_source, build_jwt_decoding_key, parse_jwt_algorithm, AuthBackend, JwtKeySource,
+    RefreshingJwks,
 };
 use crate::permissions::Guard;
 
@@ -924,7 +925,24 @@ fn parse_auth_backend(dict: &HashMap<String, Py<PyAny>>, py: Python) -> PyResult
                 None => None,
             };
             let keys = if let Some(jwks_json) = jwks {
-                build_jwks_key_source(&jwks_json).map_err(PyValueError::new_err)?
+                let parsed = build_jwks_key_source(&jwks_json).map_err(PyValueError::new_err)?;
+                match dict.get("jwks_refresh") {
+                    Some(callback) if !callback.is_none(py) => {
+                        let interval = match dict.get("jwks_refresh_interval") {
+                            Some(value) => value.extract::<Option<u64>>(py)?.unwrap_or(300),
+                            None => 300,
+                        };
+                        let JwtKeySource::Jwks(initial_keys) = parsed else {
+                            unreachable!("build_jwks_key_source always returns Jwks")
+                        };
+                        JwtKeySource::RefreshingJwks(std::sync::Arc::new(RefreshingJwks::new(
+                            initial_keys,
+                            callback.clone_ref(py),
+                            std::time::Duration::from_secs(interval),
+                        )))
+                    }
+                    _ => parsed,
+                }
             } else {
                 let secret = dict
                     .get("secret")

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -8,6 +8,10 @@ use pyo3::types::PyDict;
 use pyo3::IntoPyObjectExt;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parking_lot::{Mutex, RwLock};
 use std::str::FromStr;
 
 /// JWT `aud` claim: RFC 7519 §4.1.3 allows a single string or an array of
@@ -117,20 +121,93 @@ pub enum JwtKeySource {
     /// A JWKS: keys indexed by `kid`, selected per request from the token's
     /// `kid` header (RS/ES providers like Clerk, Auth0, Okta).
     Jwks(HashMap<String, DecodingKey>),
+    /// Remotely sourced JWKS. The last known-good keys remain available while
+    /// one worker refreshes them periodically or after an unknown `kid`.
+    RefreshingJwks(Arc<RefreshingJwks>),
+}
+
+pub struct RefreshingJwks {
+    keys: RwLock<HashMap<String, DecodingKey>>,
+    refresh: Py<PyAny>,
+    refresh_interval: Duration,
+    last_refresh: Mutex<Instant>,
+    refreshing: Mutex<()>,
+}
+
+impl std::fmt::Debug for RefreshingJwks {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RefreshingJwks")
+            .field("key_count", &self.keys.read().len())
+            .field("refresh_interval", &self.refresh_interval)
+            .finish_non_exhaustive()
+    }
 }
 
 impl JwtKeySource {
     /// Select the verification key for a token, given its `kid` header.
     /// For a JWKS with exactly one key the `kid` may be omitted.
-    fn select(&self, kid: Option<&str>) -> Option<&DecodingKey> {
+    fn select(&self, kid: Option<&str>) -> Option<DecodingKey> {
         match self {
-            JwtKeySource::Static(key) => Some(key),
+            JwtKeySource::Static(key) => Some(key.clone()),
             JwtKeySource::Jwks(keys) => match kid {
-                Some(kid) => keys.get(kid),
-                None if keys.len() == 1 => keys.values().next(),
+                Some(kid) => keys.get(kid).cloned(),
+                None if keys.len() == 1 => keys.values().next().cloned(),
                 None => None,
             },
+            JwtKeySource::RefreshingJwks(remote) => remote.select(kid),
         }
+    }
+}
+
+impl RefreshingJwks {
+    pub fn new(
+        keys: HashMap<String, DecodingKey>,
+        refresh: Py<PyAny>,
+        refresh_interval: Duration,
+    ) -> Self {
+        Self {
+            keys: RwLock::new(keys),
+            refresh,
+            refresh_interval,
+            last_refresh: Mutex::new(Instant::now()),
+            refreshing: Mutex::new(()),
+        }
+    }
+
+    fn cached(&self, kid: Option<&str>) -> Option<DecodingKey> {
+        let keys = self.keys.read();
+        match kid {
+            Some(kid) => keys.get(kid).cloned(),
+            None if keys.len() == 1 => keys.values().next().cloned(),
+            None => None,
+        }
+    }
+
+    fn select(&self, kid: Option<&str>) -> Option<DecodingKey> {
+        let cached = self.cached(kid);
+        let due = self.last_refresh.lock().elapsed() >= self.refresh_interval;
+        if cached.is_some() && !due {
+            return cached;
+        }
+
+        // try_lock provides single-flight refresh: other workers immediately
+        // continue with cached keys instead of piling onto the provider.
+        if let Some(_guard) = self.refreshing.try_lock() {
+            let result = Python::attach(|py| {
+                self.refresh
+                    .call0(py)
+                    .ok()
+                    .and_then(|value| value.extract::<Option<String>>(py).ok())
+                    .flatten()
+            });
+            *self.last_refresh.lock() = Instant::now();
+            if let Some(document) = result {
+                if let Ok(JwtKeySource::Jwks(keys)) = build_jwks_key_source(&document) {
+                    *self.keys.write() = keys;
+                }
+            }
+        }
+        self.cached(kid).or(cached)
     }
 }
 
@@ -376,7 +453,7 @@ fn decode_and_validate(
         }
     };
 
-    match crypto::verify(signature, message.as_bytes(), key, alg) {
+    match crypto::verify(signature, message.as_bytes(), &key, alg) {
         Ok(true) => {}
         Ok(false) => {
             log::debug!("JWT rejected: invalid signature");


### PR DESCRIPTION
### Motivation

- Enable robust verification of tokens signed by external providers by supporting runtime JWKS refresh and OpenID Connect discovery. 
- Support signing-key rotation by emitting `kid` headers on issued tokens so verifiers can select the correct key. 
- Provide a small, reusable set of cookie-based auth endpoints (login/refresh/logout/logout-all) to simplify conventional password+cookie flows.

### Description

- Added OIDC discovery support via `oidc_issuer` and automatic discovery of `issuer`, `jwks_uri`, and signing `algorithms` in `JWTAuthentication` initialization. 
- Implemented runtime JWKS refresh: `jwks_refresh_interval` and `_refresh_jwks` in Python `JWTAuthentication`, with a single-flight lock and stale-key fallback, and expose a `jwks_refresh` callback and interval into metadata. 
- Added `kid` parameter to `create_token_pair` and `rotate_refresh_token`, and include the `kid` in JWT headers when provided. 
- Introduced `JWTAuthViews` and `LoginCredentials` with ready-made cookie lifecycle endpoints and OpenAPI documentation wiring (`/auth/login`, `/auth/refresh`, `/auth/logout`, `/auth/logout-all`). 
- Exported `JWTAuthViews` and `LoginCredentials` from `django_bolt.auth` package. 
- Rust side: added `RefreshingJwks` type and wired `JwtKeySource::RefreshingJwks` to accept the Python refresh callback and interval, added single-flight refresh behavior, atomic key replacement, and selection logic; updated metadata parsing to construct a `RefreshingJwks` when `jwks_refresh` is provided. 
- Minor Rust adjustments to key selection and verification call signatures. 
- Documentation updates to `auth.md` and `authentication.md` describing the new options and routes. 
- Added unit tests covering JWKS refresh/unknown-`kid` behavior, OIDC discovery, `kid` headers on tokens, and the cookie-based auth views.

### Testing

- Ran the test suite with `pytest` focusing on new and modified tests: `test_jwt_jwks.py`, `test_token_pair.py`, and `test_jwt_auth_views.py`. 
- `test_jwt_jwks.py` verifies remote JWKS fetching, single-flight refresh callback, failed-refresh fallback, unknown-`kid` runtime refresh, and OIDC discovery configuration and all checks passed. 
- `test_token_pair.py` verifies `kid` is added to issued tokens and rotation preserves/updates `kid`, and all checks passed. 
- `test_jwt_auth_views.py` verifies the ready-made cookie lifecycle routes and OpenAPI exposure and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d5eae33808333909896b05a96d427)