### PR TITLE
fix(dev): make --dev reload cover the project root and api import graph

### DIFF
--- a/docs/src/ref/settings.md
+++ b/docs/src/ref/settings.md
@@ -287,6 +287,19 @@ See [Django Signals](../topics/signals.md) for detailed documentation.
 
 ## Dev reload settings
 
+`runbolt --dev` watches two things and restarts the server when a `.py` or `.html` file changes in either:
+
+- **The project root** (`BASE_DIR`, falling back to the working directory), recursively — so newly created files, modules, and packages reload without restarting the dev server. Virtualenvs and common build/cache directories (`.git`, `__pycache__`, `node_modules`, `target`, …) are excluded.
+- **The app's import graph** — every module loaded by Django setup plus your discovered API modules and everything they transitively import, along with template directories and `manage.py`. This covers code living *outside* the project root, such as apps on `PYTHONPATH` or editable-installed packages.
+
+To watch extra locations outside both — for example a shared library next to the project that isn't imported at startup — pass `--reload-dir` (repeatable, same shape as uvicorn's flag):
+
+```bash
+python manage.py runbolt --dev --reload-dir ../shared-lib
+```
+
+Each entry is a directory (watched recursively) or a single file, resolved relative to the working directory. Entries that don't exist are skipped with a warning.
+
 ### BOLT_DEV_FORCE_POLLING
 
 Force the `--dev` auto-reloader to use file-system polling instead of native OS file events.

--- a/python/django_bolt/analysis.py
+++ b/python/django_bolt/analysis.py
@@ -6,7 +6,7 @@ Performs AST-based analysis of handler source code to detect:
 - Blocking I/O operations
 
 This enables compile-time optimization decisions (e.g., running sync handlers
-with ORM usage in a thread pool) and developer warnings.
+with ORM usage in a thread pool).
 """
 
 from __future__ import annotations
@@ -14,7 +14,6 @@ from __future__ import annotations
 import ast
 import inspect
 import textwrap
-import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
@@ -255,35 +254,6 @@ class HandlerAnalysis:
     def is_blocking(self) -> bool:
         """Whether handler is likely to block (any ORM usage or blocking I/O)."""
         return self.uses_orm or self.has_blocking_io
-
-    def get_warning_message(self, handler_name: str, path: str, is_async: bool) -> str | None:
-        """
-        Generate warning message if handler has potential issues.
-
-        Only warns for sync handlers that use ORM - they will be run in a thread pool.
-        Async handlers don't need warnings - Django/Python handles sync ORM automatically.
-
-        Args:
-            handler_name: Name of the handler function
-            path: Route path
-            is_async: Whether handler is defined as async
-
-        Returns:
-            Warning message string or None if no warning needed
-        """
-        # Only warn for sync handlers that use ORM operations
-        # These will be automatically run in a thread pool to avoid blocking
-        if not is_async and self.uses_orm:
-            ops = ", ".join(sorted(self.orm_operations)[:5])
-            if len(self.orm_operations) > 5:
-                ops += f", ... ({len(self.orm_operations)} total)"
-
-            return (
-                f"Sync handler '{handler_name}' at {path} uses ORM operations "
-                f"(detected: {ops}). Running in thread pool."
-            )
-
-        return None
 
 
 class OrmVisitor(ast.NodeVisitor):
@@ -596,29 +566,3 @@ def _walk_dep_tree(
             acc.needs_cookies |= dep_analysis.request_needs_cookies
 
         _walk_dep_tree(dep_meta, compile_dep_fn, acc, visited)
-
-
-def warn_blocking_handler(
-    fn: Callable[..., Any],
-    path: str,
-    is_async: bool,
-    analysis: HandlerAnalysis | None = None,
-) -> None:
-    """
-    Emit warning if handler has blocking operations.
-
-    Args:
-        fn: Handler function
-        path: Route path
-        is_async: Whether handler is async
-        analysis: Pre-computed analysis (will compute if None)
-    """
-    if analysis is None:
-        analysis = analyze_handler(fn)
-
-    if analysis.analysis_failed:
-        return
-
-    warning_msg = analysis.get_warning_message(fn.__name__, path, is_async)
-    if warning_msg:
-        warnings.warn(warning_msg, stacklevel=3)

--- a/python/django_bolt/api.py
+++ b/python/django_bolt/api.py
@@ -35,7 +35,7 @@ from ._kwargs import (
 )
 from ._view_context import _current_action, _current_request
 from .admin.routes import AdminRouteRegistrar
-from .analysis import analyze_dependency_tree, analyze_handler, warn_blocking_handler
+from .analysis import analyze_dependency_tree, analyze_handler
 from .auth import get_default_authentication_classes, register_auth_backend
 from .auth.user_loader import default_django_user_loader, resolve_user_loader
 from .concurrency import run_in_orm_executor, sync_to_thread
@@ -1426,9 +1426,6 @@ class BoltAPI:
                     meta[needs_key] = True
 
             meta["is_blocking"] = handler_analysis.is_blocking
-
-            # Emit warning for sync handlers with ORM (will run in thread pool)
-            warn_blocking_handler(fn, full_path, is_async, handler_analysis)
 
             # Determine final response type with proper priority:
             # 1. response_model parameter (explicit, takes precedence)

--- a/python/django_bolt/management/commands/runbolt.py
+++ b/python/django_bolt/management/commands/runbolt.py
@@ -10,7 +10,6 @@ import os
 import signal
 import sys
 import traceback
-import warnings
 from pathlib import Path
 
 from django.apps import apps
@@ -96,13 +95,55 @@ def _collapse_watch_paths(paths: set[Path]) -> list[Path]:
     return collapsed
 
 
-def _build_dev_worker_command(argv: list[str] | None = None, executable: str | None = None) -> list[str]:
+_UNSET = object()
+
+
+def _dev_worker_main_module(main_module=_UNSET) -> str | None:
+    """Return the ``-m`` module the process was started with, or ``None``.
+
+    ``python -m pkg.manage`` rewrites ``sys.argv[0]`` to manage.py's resolved
+    file path, so the ``-m`` context survives only on ``__main__.__spec__``.
+    Plain ``python manage.py`` runs leave ``__spec__`` as ``None`` (some
+    environments omit the attribute entirely), which means script mode.
+    """
+    if main_module is _UNSET:
+        main_module = sys.modules.get("__main__")
+
+    spec = getattr(main_module, "__spec__", None)
+    if spec is None:
+        return None
+
+    name = getattr(spec, "name", None) or ""
+    parent = getattr(spec, "parent", None) or ""
+
+    # `python -m pkg` executes pkg/__main__.py; respawn the package, not the file.
+    if (name == "__main__" or name.endswith(".__main__")) and parent:
+        return parent
+
+    return name or None
+
+
+def _build_dev_worker_command(
+    argv: list[str] | None = None,
+    executable: str | None = None,
+    main_module: str | None = None,
+) -> list[str]:
+    """Rebuild this process's command line for the dev worker.
+
+    ``main_module`` is the ``-m`` module name from
+    :func:`_dev_worker_main_module` (``None`` for script invocations). It must be
+    preserved: re-running a ``-m``-launched manage.py as a script puts the
+    script's own directory at the head of ``sys.path`` instead of the cwd, so a
+    project whose manage.py lives inside the package it imports from (a "src
+    layout", ``src/manage.py`` with ``src.project.settings``) can no longer
+    import its own settings module.
+    """
     argv = sys.argv if argv is None else argv
     executable = sys.executable if executable is None else executable
 
-    command = [executable]
+    command = [executable, "-m", main_module] if main_module else [executable, *argv[:1]]
     saw_processes = False
-    it = iter(argv)
+    it = iter(argv[1:])
 
     for arg in it:
         if arg == "--dev" or arg.startswith("--dev="):
@@ -190,6 +231,10 @@ def _module_spec_watch_paths(module_name: str) -> set[Path]:
 def _collect_autodiscovery_python_paths() -> set[Path]:
     module_names: set[str] = set()
 
+    for api_path in getattr(settings, "BOLT_API", None) or ():
+        if ":" in api_path:
+            module_names.add(api_path.split(":", 1)[0])
+
     settings_module = getattr(settings, "SETTINGS_MODULE", None)
     if settings_module:
         module_names.add(settings_module)
@@ -221,7 +266,65 @@ def _collect_autodiscovery_python_paths() -> set[Path]:
     return project_paths
 
 
-def _collect_dev_watch_paths() -> list[str]:
+def _autodiscovery_import_module_names() -> list[str]:
+    """Module names that autodiscover_apis() will import at worker startup.
+
+    Explicit BOLT_API entries win, mirroring autodiscovery. Otherwise the
+    project-level and per-app api module candidates are gated by the same AST
+    scan autodiscovery uses, so modules without a BoltAPI assignment are never
+    imported here either.
+    """
+    bolt_api_paths = getattr(settings, "BOLT_API", None)
+    if bolt_api_paths:
+        return [api_path.split(":", 1)[0] for api_path in bolt_api_paths if ":" in api_path]
+
+    module_names: list[str] = []
+
+    root_urlconf = getattr(settings, "ROOT_URLCONF", None)
+    if root_urlconf:
+        for module_name in _project_api_module_names(root_urlconf):
+            if find_bolt_api_names(module_name):
+                module_names.append(module_name)
+
+    if apps.ready:
+        for app_config in apps.get_app_configs():
+            if app_config.name == "django_bolt":
+                continue
+            if hasattr(app_config, "bolt_api") and ":" in app_config.bolt_api:
+                module_names.append(app_config.bolt_api.split(":", 1)[0])
+                continue
+            for module_suffix in ("api", "bolt_api"):
+                module_name = f"{app_config.name}.{module_suffix}"
+                if find_bolt_api_names(module_name):
+                    module_names.append(module_name)
+
+    return module_names
+
+
+def _prime_dev_watch_imports() -> None:
+    """Import discovered API modules so their transitive imports get watched.
+
+    The dev supervisor never runs autodiscovery itself, so sys.modules only
+    holds what django.setup() loaded — without these imports the watch list
+    misses everything api.py imports (helpers, service layers) and edits to
+    those files never trigger a reload. Import failures are non-fatal: the
+    worker surfaces the real error on its own startup, and the api module file
+    itself stays watched (via its module spec) so fixing it triggers a reload.
+    """
+    for module_name in _autodiscovery_import_module_names():
+        try:
+            importlib.import_module(module_name)
+        except Exception as exc:  # noqa: BLE001 - user code can raise anything at import
+            print(
+                f"[django-bolt] Warning: failed to import {module_name!r} while building the "
+                f"dev watch list ({exc}); files it imports won't trigger auto-reload",
+                file=sys.stderr,
+            )
+
+
+def _collect_dev_watch_paths(reload_dirs: list[str] | None = None) -> list[str]:
+    _prime_dev_watch_imports()
+
     watch_paths: set[Path] = set(_collect_loaded_python_paths())
     watch_paths.update(_collect_autodiscovery_python_paths())
 
@@ -230,12 +333,27 @@ def _collect_dev_watch_paths() -> list[str]:
         if path is not None and path.exists():
             watch_paths.add(path)
 
-    if not watch_paths:
-        base_dir = _coerce_path(getattr(settings, "BASE_DIR", None))
-        if base_dir is not None and base_dir.exists():
-            watch_paths.add(base_dir)
+    # Escape hatch for code outside both the project root and the import
+    # graph (e.g. a shared library next to the project).
+    for reload_dir in reload_dirs or ():
+        path = _coerce_path(reload_dir)
+        if path is not None and path.exists():
+            watch_paths.add(path)
         else:
-            watch_paths.add(Path.cwd().resolve())
+            print(
+                f"[django-bolt] Warning: --reload-dir {str(reload_dir)!r} "
+                "does not exist; it will not be watched for auto-reload",
+                file=sys.stderr,
+            )
+
+    # Uvicorn-style default: always watch the project root recursively so
+    # newly created modules and packages reload without a dev-server restart.
+    # Import-graph entries inside the root collapse into it; entries outside
+    # (PYTHONPATH apps, editable installs) stay individually watched.
+    project_root = _coerce_path(getattr(settings, "BASE_DIR", None))
+    if project_root is None or not project_root.exists():
+        project_root = Path.cwd().resolve()
+    watch_paths.add(project_root)
 
     return [str(path) for path in _collapse_watch_paths(watch_paths)]
 
@@ -385,6 +503,19 @@ class Command(BaseCommand):
             help="Disable Django admin integration (admin enabled by default)",
         )
         parser.add_argument("--dev", action="store_true", help="Enable auto-reload on file changes (development mode)")
+        parser.add_argument(
+            "--reload-dir",
+            action="append",
+            default=[],
+            dest="reload_dirs",
+            metavar="PATH",
+            help=(
+                "Watch this extra directory (or file) for --dev auto-reload; "
+                "repeatable. The project root and the app's import graph are "
+                "watched by default, so this is only needed for code outside "
+                "both, e.g. a shared library next to the project."
+            ),
+        )
         parser.add_argument("--backlog", type=int, default=1024, help="Socket listen backlog size (default: 1024)")
         parser.add_argument(
             "--keep-alive", type=int, default=None, help="HTTP keep-alive timeout in seconds (default: OS setting)"
@@ -432,6 +563,9 @@ class Command(BaseCommand):
         dev_worker_mode = os.environ.get(_ENV_DEV_WORKER) == "1"
         effective_dev_mode = dev_mode or dev_worker_mode
 
+        if options["reload_dirs"] and not effective_dev_mode:
+            self.stdout.write(self.style.WARNING("  Warning: --reload-dir is ignored without --dev"))
+
         # Dev mode: force single process + enable auto-reload
         if dev_mode and not dev_worker_mode:
             if processes > 1:
@@ -451,8 +585,8 @@ class Command(BaseCommand):
 
     def run_with_autoreload(self, options):
         """Run the server behind the native dev supervisor."""
-        worker_command = _build_dev_worker_command()
-        watch_paths = _collect_dev_watch_paths()
+        worker_command = _build_dev_worker_command(main_module=_dev_worker_main_module())
+        watch_paths = _collect_dev_watch_paths(options["reload_dirs"])
         ignore_paths = _collect_dev_ignore_paths()
         force_polling = getattr(settings, "BOLT_DEV_FORCE_POLLING", False)
 
@@ -626,13 +760,6 @@ class Command(BaseCommand):
     def start_single_process(self, options, process_id=None, dev_mode=False):
         """Start a single process server"""
         is_dev_reload_restart = _is_dev_reload_restart()
-
-        if is_dev_reload_restart:
-            warnings.filterwarnings(
-                "ignore",
-                message=r"Sync handler '.*' at .* uses ORM operations .*Running in thread pool\.",
-                category=UserWarning,
-            )
 
         # Setup Django logging once at server startup (one-shot, respects existing LOGGING)
         if setup_django_logging is not None:

--- a/python/django_bolt/management/commands/runbolt.py
+++ b/python/django_bolt/management/commands/runbolt.py
@@ -9,7 +9,9 @@ import importlib.util
 import os
 import signal
 import sys
+import time
 import traceback
+from datetime import datetime
 from pathlib import Path
 
 from django.apps import apps
@@ -38,7 +40,42 @@ except ImportError:
 
 _ENV_DEV_WORKER = "DJANGO_BOLT_DEV_WORKER"
 _ENV_DEV_RELOAD_COUNT = "DJANGO_BOLT_DEV_RELOAD_COUNT"
+_ENV_DEV_SPAWN_MS = "DJANGO_BOLT_DEV_SPAWN_UNIX_MS"
 DEV_RELOAD_DEBOUNCE_MS = 50
+
+
+class _Ansi:
+    """Minimal ANSI palette; every attribute is '' when colors are disabled."""
+
+    __slots__ = ("bold", "dim", "cyan", "green", "reset")
+
+    def __init__(self, enabled: bool) -> None:
+        self.bold = "\033[1m" if enabled else ""
+        self.dim = "\033[2m" if enabled else ""
+        self.cyan = "\033[36m" if enabled else ""
+        self.green = "\033[32m" if enabled else ""
+        self.reset = "\033[0m" if enabled else ""
+
+
+_GLYPHS_UNICODE = {"bolt": "⚡ ", "arrow": "➜", "check": "✓", "sep": " · "}
+_GLYPHS_ASCII = {"bolt": "", "arrow": "->", "check": "*", "sep": " - "}
+
+
+def _pick_glyphs(stream) -> dict[str, str]:
+    """Unicode glyphs when the output encoding supports them, ASCII otherwise."""
+    encoding = getattr(stream, "encoding", None) or "utf-8"
+    try:
+        "⚡➜✓·".encode(encoding)
+    except (LookupError, UnicodeEncodeError):
+        return _GLYPHS_ASCII
+    return _GLYPHS_UNICODE
+
+
+def _format_elapsed(ms: float) -> str:
+    if ms < 1000:
+        return f"{ms:.0f} ms"
+    return f"{ms / 1000:.1f} s"
+
 
 DEV_RELOAD_IGNORE_DIRS = (
     ".git",
@@ -316,7 +353,7 @@ def _prime_dev_watch_imports() -> None:
             importlib.import_module(module_name)
         except Exception as exc:  # noqa: BLE001 - user code can raise anything at import
             print(
-                f"[django-bolt] Warning: failed to import {module_name!r} while building the "
+                f"[bolt] Warning: failed to import {module_name!r} while building the "
                 f"dev watch list ({exc}); files it imports won't trigger auto-reload",
                 file=sys.stderr,
             )
@@ -341,7 +378,7 @@ def _collect_dev_watch_paths(reload_dirs: list[str] | None = None) -> list[str]:
             watch_paths.add(path)
         else:
             print(
-                f"[django-bolt] Warning: --reload-dir {str(reload_dir)!r} "
+                f"[bolt] Warning: --reload-dir {str(reload_dir)!r} "
                 "does not exist; it will not be watched for auto-reload",
                 file=sys.stderr,
             )
@@ -558,6 +595,7 @@ class Command(BaseCommand):
         return bool(options["max_rss"] or options["workers_lifetime"] or options["respawn_failed_workers"])
 
     def handle(self, *args, **options):
+        self._handle_started = time.monotonic()
         processes = options["processes"]
         dev_mode = options.get("dev", False)
         dev_worker_mode = os.environ.get(_ENV_DEV_WORKER) == "1"
@@ -659,7 +697,7 @@ class Command(BaseCommand):
             lifetime_seconds=float(options["workers_lifetime"]) if options["workers_lifetime"] else None,
             respawn_failed=options["respawn_failed_workers"],
             kill_timeout=float(kill_timeout),
-            log=lambda message: self.stdout.write(f"  {message}"),
+            log=self._runtime_log,
         )
 
         def signal_handler(signum, frame):
@@ -702,7 +740,7 @@ class Command(BaseCommand):
                 if openapi_config.enabled:
                     merged_api._openapi_config = openapi_config
                     merged_api._register_openapi_routes()
-                    features.append(("OpenAPI", f"{banner_base_url}{openapi_config.path}"))
+                    features.append(("Docs", f"{banner_base_url}{openapi_config.path}"))
                 break
 
         # Check admin
@@ -807,7 +845,7 @@ class Command(BaseCommand):
             # Transfer OpenAPI config to merged API
             merged_api._openapi_config = openapi_config
             merged_api._register_openapi_routes()
-            features.append(("OpenAPI", f"{banner_base_url}{openapi_config.path}"))
+            features.append(("Docs", f"{banner_base_url}{openapi_config.path}"))
 
         # Register Django admin routes if not disabled
         # Admin is controlled solely by --no-admin command-line flag
@@ -907,7 +945,14 @@ class Command(BaseCommand):
         # Print structured startup banner (only for main process or single-process mode)
         if process_id is None:
             if is_dev_reload_restart:
-                self.stdout.write(f"  ✨ Reloaded on {banner_base_url}")
+                c = self._ansi()
+                g = _pick_glyphs(self.stdout)
+                elapsed = self._startup_elapsed_ms()
+                timing = f" {c.dim}in {_format_elapsed(elapsed)}{c.reset}" if elapsed is not None else ""
+                self.stdout.write(
+                    f"  {c.green}{g['check']}{c.reset} {c.bold}Reloaded{c.reset}{timing}"
+                    f"  {c.cyan}{banner_base_url}{c.reset}"
+                )
             else:
                 self._print_startup_banner(
                     options=options,
@@ -958,6 +1003,36 @@ class Command(BaseCommand):
         except importlib.metadata.PackageNotFoundError:
             return "dev"
 
+    def _ansi(self) -> _Ansi:
+        """Palette derived from Django's own color handling (--no-color, --force-color)."""
+        cached = getattr(self, "_ansi_cache", None)
+        if cached is None:
+            enabled = self.style.SUCCESS("x") != "x" and "NO_COLOR" not in os.environ
+            cached = self._ansi_cache = _Ansi(enabled)
+        return cached
+
+    def _startup_elapsed_ms(self) -> float | None:
+        """Wall time since the process was spawned (dev worker) or handle() began."""
+        spawn_ms = os.environ.get(_ENV_DEV_SPAWN_MS)
+        if spawn_ms:
+            try:
+                elapsed = time.time() * 1000.0 - float(spawn_ms)
+            except ValueError:
+                elapsed = -1.0
+            # Guard against clock skew between the supervisor and worker.
+            if 0 <= elapsed < 600_000:
+                return elapsed
+        started = getattr(self, "_handle_started", None)
+        if started is None:
+            return None
+        return (time.monotonic() - started) * 1000.0
+
+    def _runtime_log(self, message: str) -> None:
+        """Timestamped post-startup log line (worker recycling, shutdown, ...)."""
+        c = self._ansi()
+        timestamp = datetime.now().strftime("%H:%M:%S")
+        self.stdout.write(f"  {c.dim}{timestamp}{c.reset} {c.cyan}[bolt]{c.reset} {message}")
+
     def _print_startup_banner(
         self,
         *,
@@ -970,53 +1045,68 @@ class Command(BaseCommand):
         api_count: int,
         features: list[tuple[str, str]],
     ) -> None:
-        """Print a clean, structured startup banner."""
+        """Print a Vite-style startup banner: brand + timing, URL rows, dim meta rows."""
         version = self._get_version()
-        host = options["host"]
-        port = options["port"]
+        c = self._ansi()
+        g = _pick_glyphs(self.stdout)
+        sep = g["sep"]
         processes = options["processes"]
+        url = _build_display_url(options["host"], options["port"], dev_mode=dev_mode)
+
+        # Split features into URL rows (arrow lines) and meta rows (dim lines).
+        links: list[tuple[str, str]] = [("Local", url)]
+        meta_rows: list[tuple[str, str]] = []
+        for label, value in features:
+            if value.startswith("http"):
+                links.append((label, value))
+            else:
+                meta_rows.append((label, value))
+
         mode = "development" if dev_mode else "production"
-        url = _build_display_url(host, port, dev_mode=dev_mode)
+        if dev_mode:
+            mode += f"{sep}auto-reload"
 
-        # Determine label width for alignment
-        _LABEL_W = 16
-
-        def _line(label: str, value: str) -> str:
-            return f"  {label:<{_LABEL_W}}{value}"
-
-        lines: list[str] = []
-
-        # Header
-        lines.append("")
-        lines.append(self.style.SUCCESS(f"  Django Bolt v{version}"))
-        lines.append("")
-
-        # Server section
-        lines.append(self.style.MIGRATE_HEADING("  Server"))
-        lines.append(_line("URL", url))
-        lines.append(_line("Processes", str(processes)))
-        lines.append(_line("Mode", mode))
-        lines.append("")
-
-        # Routes section
-        lines.append(self.style.MIGRATE_HEADING("  Routes"))
-        lines.append(_line("API", f"{api_routes} routes from {api_count} app{'s' if api_count != 1 else ''}"))
+        route_bits = [f"{api_routes} API"]
         if ws_routes:
-            lines.append(_line("WebSocket", f"{ws_routes} routes"))
+            route_bits.append(f"{ws_routes} WebSocket")
         if asgi_mounts:
-            lines.append(_line("ASGI", f"{asgi_mounts} mounts"))
+            route_bits.append(f"{asgi_mounts} ASGI")
         if framework_routes:
-            lines.append(_line("Framework", f"+{framework_routes} (admin, docs)"))
+            route_bits.append(f"+{framework_routes} framework")
+        route_bits.append(f"{api_count} app{'s' if api_count != 1 else ''}")
+
+        meta_rows = [
+            ("Mode", mode),
+            ("Routes", sep.join(route_bits)),
+            ("Workers", f"{processes} process{'es' if processes != 1 else ''}"),
+            *meta_rows,
+        ]
+
+        header = f"  {g['bolt']}{c.bold}{c.cyan}Django Bolt{c.reset} {c.cyan}v{version}{c.reset}"
+        elapsed = self._startup_elapsed_ms()
+        if elapsed is not None:
+            header += f"  {c.dim}ready in{c.reset} {c.bold}{_format_elapsed(elapsed)}{c.reset}"
+
+        lines: list[str] = ["", header, ""]
+
+        link_w = max(len(label) for label, _ in links) + 2
+        for label, value in links:
+            lines.append(
+                f"  {c.green}{g['arrow']}{c.reset}  {c.bold}{label + ':':<{link_w}}{c.reset}{c.cyan}{value}{c.reset}"
+            )
         lines.append("")
 
-        # Features section (only if there are features)
-        if features:
-            lines.append(self.style.MIGRATE_HEADING("  Features"))
-            for label, value in features:
-                lines.append(_line(label, value))
-            lines.append("")
+        meta_w = max(len(label) for label, _ in meta_rows) + 4
+        for label, value in meta_rows:
+            lines.append(f"  {c.dim}{label:<{meta_w}}{c.reset}{value}")
+        lines.append("")
 
-        self.stdout.write("\n".join(lines))
+        lines.append(f"  {c.dim}press CTRL+C to stop{c.reset}")
+
+        # OutputWrapper adds the final newline; the extra "" keeps one blank
+        # line between the banner and whatever the app logs next.
+        lines.append("")
+        self.stdout.write("\n".join(lines) + "\n")
 
     def autodiscover_apis(self):
         """Discover BoltAPI instances from installed apps.

--- a/python/example/testproject/api.py
+++ b/python/example/testproject/api.py
@@ -80,7 +80,7 @@ async def read_root():
     """
     Endpoint that returns a simple "Hello World" dictionary.
     """
-    return {"message": "Hello Worasdfld"}
+    return {"message": "Hello Django"}
 
 
 #

--- a/python/example/testproject/api.py
+++ b/python/example/testproject/api.py
@@ -80,7 +80,7 @@ async def read_root():
     """
     Endpoint that returns a simple "Hello World" dictionary.
     """
-    return {"message": "Hello World"}
+    return {"message": "Hello Worasdfld"}
 
 
 #

--- a/python/tests/integration/apps/__init__.py
+++ b/python/tests/integration/apps/__init__.py
@@ -15,6 +15,10 @@ f-strings with ``{{}}``-escaped braces.
 
 Modules must stay self-contained — no relative imports — so they copy cleanly
 into the subprocess project as ``<package>/api.py``.
+
+Underscore-prefixed modules (e.g. ``_reload_helper``) are support files, not
+app fixtures: plain data a fixture imports once installed in a temp project.
+``test_apps_smoke`` skips them instead of demanding an ``api`` attribute.
 """
 
 from __future__ import annotations

--- a/python/tests/integration/apps/_reload_helper.py
+++ b/python/tests/integration/apps/_reload_helper.py
@@ -1,0 +1,14 @@
+"""Support module (not an app) imported by ``reload_import_dep`` (version 1).
+
+The reload test installs this at the temp project root as ``reload_helper.py``
+(next to the copied ``api.py``), then swaps in ``_reload_helper_v2`` at runtime
+and asserts the running ``--dev`` server reloads — proving the watcher covers
+modules the api module imports, not just ``api.py`` itself.
+
+The leading underscore marks it as a support module rather than an app fixture,
+so ``test_apps_smoke`` does not require it to define ``api = BoltAPI()``.
+"""
+
+from __future__ import annotations
+
+HELPER_VERSION = "helper-v1"

--- a/python/tests/integration/apps/_reload_helper_v2.py
+++ b/python/tests/integration/apps/_reload_helper_v2.py
@@ -1,0 +1,10 @@
+"""Support module (not an app): replacement for ``_reload_helper`` (version 2).
+
+Written over the temp project's ``reload_helper.py`` while the ``--dev``
+server is running; the reload test asserts the new version is served. See
+``_reload_helper`` for why the name is underscore-prefixed.
+"""
+
+from __future__ import annotations
+
+HELPER_VERSION = "helper-v2"

--- a/python/tests/integration/apps/reload_import_dep.py
+++ b/python/tests/integration/apps/reload_import_dep.py
@@ -1,0 +1,30 @@
+"""Reload fixture whose response comes from an imported helper module.
+
+Unlike the other app fixtures this one is deliberately not self-contained: it
+imports ``reload_helper``, which the test installs as a sibling top-level
+module in the temp project (from ``_reload_helper``; the import resolves
+against the project root, not against this package). That cross-module edge is
+the point — the ``--dev`` reloader must watch the api module's transitive
+imports too.
+
+Consequence: unlike every other fixture here, this module cannot be imported
+in-process from the source tree, so ``test_apps_smoke`` only syntax-checks it.
+"""
+
+from __future__ import annotations
+
+import reload_helper
+
+from django_bolt import BoltAPI
+
+api = BoltAPI()
+
+
+@api.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@api.get("/helper-version")
+async def helper_version():
+    return {"version": reload_helper.HELPER_VERSION}

--- a/python/tests/integration/helpers.py
+++ b/python/tests/integration/helpers.py
@@ -520,7 +520,7 @@ class ServerProject:
     def read_file(self, relative_path: str) -> str:
         return self.path(relative_path).read_text()
 
-    def start(
+    def spawn(
         self,
         *,
         dev: bool = False,
@@ -528,10 +528,15 @@ class ServerProject:
         extra_args: list[str] | None = None,
         host: str = DEFAULT_HOST,
         port: int | None = None,
-        startup_path: str = "/health",
-        timeout: float = DEFAULT_TIMEOUT,
         env: dict[str, str] | None = None,
-    ) -> RunningServer:
+    ) -> tuple[subprocess.Popen[str], int]:
+        """Spawn ``runbolt`` and return the process plus the port it was given.
+
+        Unlike :meth:`start`, this does not wait for readiness — so tests can
+        assert on startup *failures* (the process must exit, with which code,
+        saying what) instead of having the readiness probe turn them into an
+        AssertionError first.
+        """
         if dev and not (self.root / self.package_name / "api.py").exists():
             raise ValueError(
                 "runbolt --dev watches files in the temp project, but this project has no "
@@ -564,7 +569,28 @@ class ServerProject:
             pythonpath_parts.append(existing_pythonpath)
         process_env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
 
-        process = _spawn_process(command, cwd=self.root, env=process_env)
+        return _spawn_process(command, cwd=self.root, env=process_env), port
+
+    def start(
+        self,
+        *,
+        dev: bool = False,
+        processes: int = 1,
+        extra_args: list[str] | None = None,
+        host: str = DEFAULT_HOST,
+        port: int | None = None,
+        startup_path: str = "/health",
+        timeout: float = DEFAULT_TIMEOUT,
+        env: dict[str, str] | None = None,
+    ) -> RunningServer:
+        process, port = self.spawn(
+            dev=dev,
+            processes=processes,
+            extra_args=extra_args,
+            host=host,
+            port=port,
+            env=env,
+        )
         return RunningServer(
             project=self,
             process=process,

--- a/python/tests/integration/test_apps_smoke.py
+++ b/python/tests/integration/test_apps_smoke.py
@@ -17,9 +17,17 @@ import pytest
 from django_bolt import BoltAPI
 
 from . import apps
-from .apps import app_module
+from .apps import app_module, app_source
 
+# Underscore-prefixed modules are support files (plain data imported by an app
+# fixture), not apps — they define no ``api``.
 _MODULE_NAMES = sorted(info.name for info in pkgutil.iter_modules(apps.__path__) if not info.name.startswith("_"))
+
+# App fixtures that only import inside the temp project a subprocess test
+# builds: ``reload_import_dep`` imports a sibling top-level ``reload_helper``
+# module that exists only there. They get a syntax check instead.
+_PROJECT_ONLY_MODULES = ["reload_import_dep"]
+_IMPORTABLE_MODULE_NAMES = [name for name in _MODULE_NAMES if name not in _PROJECT_ONLY_MODULES]
 
 
 def test_apps_package_has_modules():
@@ -28,7 +36,16 @@ def test_apps_package_has_modules():
     assert _MODULE_NAMES, "no app modules discovered under apps/"
 
 
-@pytest.mark.parametrize("module_name", _MODULE_NAMES)
+@pytest.mark.parametrize("module_name", _PROJECT_ONLY_MODULES)
+def test_project_only_app_module_compiles(module_name):
+    # Can't be imported from the source tree (see _PROJECT_ONLY_MODULES), so
+    # this is the fast failure for a syntax error in it.
+    assert module_name in _MODULE_NAMES, f"{module_name} is no longer an app module"
+    source = app_source(module_name)
+    compile(source.read_text(), str(source), "exec")
+
+
+@pytest.mark.parametrize("module_name", _IMPORTABLE_MODULE_NAMES)
 def test_app_module_exposes_populated_api(module_name):
     module = importlib.import_module(f"{apps.__name__}.{module_name}")
     assert app_module(module_name).split(":")[0] == module.__name__

--- a/python/tests/integration/test_dev_reload.py
+++ b/python/tests/integration/test_dev_reload.py
@@ -1,13 +1,265 @@
 from __future__ import annotations
 
+import os
+import socket
+import subprocess
 import sys
 import time
 
+import httpx
 import pytest
 
-from .apps import app_source
+from .apps import app_bytes, app_source
+from .helpers import DEFAULT_HOST, RunningServer, ServerProject, _spawn_process, _terminate_process, get_free_port
 
 pytestmark = [pytest.mark.server_integration]
+
+
+def _move_project_into_src_layout(project: ServerProject) -> str:
+    """Rearrange a generated project into a "src layout" and return its ``-m`` name.
+
+    Turns::
+
+        root/manage.py
+        root/testproj/{settings,urls,api}.py
+
+    into the layout from the report, where manage.py lives *inside* the package
+    it imports from::
+
+        root/src/__init__.py
+        root/src/manage.py            # DJANGO_SETTINGS_MODULE=src.testproj.settings
+        root/src/api.py               # where autodiscovery looks for "src.*" URLConfs
+        root/src/testproj/{settings,urls}.py
+
+    Only ``python -m src.manage`` can start this: as a script, manage.py's own
+    directory (``root/src``) heads ``sys.path`` and ``import src.*`` fails.
+    """
+    package = project.package_name
+    source = project.read_file(f"{package}/settings.py")
+    project.write_file(
+        f"src/{package}/settings.py",
+        source.replace(f'"{package}.urls"', f'"src.{package}.urls"'),
+    )
+    for name in ("__init__.py", "urls.py"):
+        project.write_file(f"src/{package}/{name}", project.path(f"{package}/{name}").read_bytes())
+        project.path(f"{package}/{name}").unlink()
+    # ROOT_URLCONF "src.testproj.urls" makes "src.api" the project API module.
+    project.write_file("src/api.py", project.path(f"{package}/api.py").read_bytes())
+    project.path(f"{package}/api.py").unlink()
+    project.path(f"{package}/settings.py").unlink()
+    project.path(package).rmdir()
+    project.path("manage.py").unlink()
+
+    project.write_file("src/__init__.py", "")
+    project.write_file(
+        "src/manage.py",
+        f"""
+        import os
+        import sys
+
+        if __name__ == "__main__":
+            os.environ.setdefault("DJANGO_SETTINGS_MODULE", "src.{package}.settings")
+            from django.core.management import execute_from_command_line
+
+            execute_from_command_line(sys.argv)
+        """,
+    )
+    return "src.manage"
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Reload integration runs only on Linux.")
+def test_runbolt_dev_reloads_when_imported_helper_changes(make_server_project):
+    """Editing a module imported BY api.py must trigger a reload.
+
+    The dev supervisor never imports the api module itself, so before the
+    priming-import fix its watch list covered only django.setup()'s import
+    graph plus the api.py file — the api module's own imports were invisible
+    to the watcher.
+    """
+    project = make_server_project(
+        api_source=app_source("reload_import_dep"),
+        extra_files={"reload_helper.py": app_bytes("_reload_helper")},
+    )
+
+    with project.start(dev=True) as server:
+        initial = server.get("/helper-version")
+        assert initial.json() == {"version": "helper-v1"}
+
+        time.sleep(0.3)
+        project.write_file("reload_helper.py", app_bytes("_reload_helper_v2"))
+
+        payload = server.wait_for_json("/helper-version", lambda body: body["version"] == "helper-v2", timeout=30)
+
+    assert payload == {"version": "helper-v2"}
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Reload integration runs only on Linux.")
+def test_runbolt_dev_reloads_when_new_module_created_in_project_root(make_server_project):
+    """Creating a brand-new .py file anywhere under the project root must
+    trigger a reload — the root is watched recursively by default
+    (uvicorn-style), not just the files already in the import graph."""
+    project = make_server_project(api_source=app_source("reload_state"))
+
+    with project.start(dev=True) as server:
+        initial = server.get("/reload-state").json()
+        assert initial["reload_count"] == 0
+
+        time.sleep(0.3)
+        project.write_file("newfeature/helpers.py", "VALUE = 1\n")
+
+        after = server.wait_for_json("/reload-state", lambda body: body["reload_count"] == 1, timeout=30)
+
+    assert after["pid"] != initial["pid"]
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Reload integration runs only on Linux.")
+def test_runbolt_dev_reloads_for_reload_dir_entry(make_server_project):
+    """A .py change inside a --reload-dir directory OUTSIDE the project root
+    must trigger a reload even though the api module never imports it — the
+    project root itself is already watched by default, so the flag exists for
+    exactly these out-of-root locations."""
+    project = make_server_project(api_source=app_source("reload_state"))
+    external_plugins = project.root.parent / f"{project.root.name}_plugins"
+    external_plugins.mkdir()
+    (external_plugins / "tasks.py").write_text("TASK = 1\n")
+
+    with project.start(dev=True, extra_args=["--reload-dir", str(external_plugins)]) as server:
+        initial = server.get("/reload-state").json()
+        assert initial["reload_count"] == 0
+
+        time.sleep(0.3)
+        (external_plugins / "tasks.py").write_text("TASK = 2\n")
+
+        after = server.wait_for_json("/reload-state", lambda body: body["reload_count"] == 1, timeout=30)
+
+    assert after["pid"] != initial["pid"]
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Reload integration runs only on Linux.")
+def test_runbolt_dev_serves_and_reloads_for_module_invocation(make_server_project):
+    """``python -m src.manage runbolt --dev`` must work in a src-layout project.
+
+    Regression test for issue #271: the dev supervisor rebuilt the worker command
+    from ``sys.argv`` alone, but CPython rewrites ``argv[0]`` to manage.py's
+    resolved path for ``-m`` runs. The worker was therefore respawned as a plain
+    script, which puts ``src/`` at the head of ``sys.path`` instead of the cwd —
+    so ``src.testproj.settings`` became unimportable and the worker died with
+    ``ModuleNotFoundError: No module named 'src'`` (preceded by a misleading
+    ``KeyError: 'runbolt'``). Only ``--dev`` was affected.
+    """
+    project = make_server_project(api_source=app_source("reload_v1"))
+    main_module = _move_project_into_src_layout(project)
+
+    # No PYTHONPATH: the project root is importable only because ``-m`` puts the
+    # cwd on sys.path. That is precisely what a script-mode respawn loses.
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    port = get_free_port()
+    process = _spawn_process(
+        [
+            sys.executable,
+            "-m",
+            main_module,
+            "runbolt",
+            "--dev",
+            "--host",
+            DEFAULT_HOST,
+            "--port",
+            str(port),
+        ],
+        cwd=project.root,
+        env=env,
+    )
+    server = RunningServer(
+        project=None,
+        process=process,
+        host=DEFAULT_HOST,
+        port=port,
+        startup_path="/version",
+    )
+
+    with server:
+        assert server.get("/version").json() == {"version": "v1"}
+
+        # The respawned worker must keep the -m context too, so reloads survive.
+        time.sleep(0.3)
+        project.write_file("src/api.py", app_bytes("reload_v2"))
+
+        payload = server.wait_for_json("/version", lambda body: body["version"] == "v2", timeout=30)
+
+    assert payload == {"version": "v2"}
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Reload integration runs only on Linux.")
+def test_runbolt_dev_exits_when_first_start_fails(make_server_project):
+    """A failed FIRST start must exit, not sit in "waiting for changes".
+
+    The supervisor's wait-for-changes behaviour exists so a SyntaxError in the
+    app doesn't tear down the dev session. But a startup failure like "address
+    already in use" is not fixable by editing a file, so waiting there leaves
+    the developer with a live-looking process that will never serve, and a zero
+    exit status. The first worker's exit code must propagate instead — the same
+    protocol Django's runserver uses (only its reload signal, exit code 3,
+    respawns; anything else exits).
+    """
+    project = make_server_project(api_source=app_source("reload_state"))
+
+    # Hold the port WITHOUT SO_REUSEPORT so the worker's bind really fails
+    # (dev mode is single-process and does not set DJANGO_BOLT_REUSE_PORT).
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as blocker:
+        blocker.bind((DEFAULT_HOST, 0))
+        blocker.listen(8)
+        port = int(blocker.getsockname()[1])
+
+        process, _ = project.spawn(dev=True, port=port)
+        try:
+            stdout, stderr = process.communicate(timeout=45)
+        except subprocess.TimeoutExpired:
+            stdout, stderr = _terminate_process(process)
+            pytest.fail(
+                f"runbolt --dev kept running after the first worker failed to bind port {port}"
+                f"\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            )
+
+    assert process.returncode == 1, f"expected the worker's exit code to propagate\nstderr:\n{stderr}"
+    assert "Address already in use" in stderr, stderr
+    assert "Waiting for changes" not in stderr, stderr
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Reload integration runs only on Linux.")
+def test_runbolt_dev_keeps_watching_when_a_reloaded_worker_crashes(make_server_project):
+    """After a successful start, a crashing worker must NOT kill the session.
+
+    This is the case the wait-for-changes branch is for: the developer saves a
+    broken file, the worker dies on import, and the supervisor stays alive so
+    the next save recovers it. The first-start exit must not regress this.
+    """
+    project = make_server_project(api_source=app_source("reload_v1"))
+
+    with project.start(dev=True) as server:
+        assert server.get("/version").json() == {"version": "v1"}
+
+        time.sleep(0.3)
+        project.write_file(f"{project.package_name}/api.py", "raise RuntimeError('broken app')\n")
+
+        # Wait until the crashed worker stops answering. server.get() raises if
+        # the supervisor itself died — exactly the regression guarded here.
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            try:
+                server.get("/version")
+            except httpx.HTTPError:
+                break
+            time.sleep(0.2)
+        else:
+            pytest.fail("the broken app kept serving — the reload never happened")
+
+        assert server.process.poll() is None, "dev supervisor exited when a reloaded worker crashed"
+
+        project.install_api(app_source("reload_v2"))
+        payload = server.wait_for_json("/version", lambda body: body["version"] == "v2", timeout=30)
+
+    assert payload == {"version": "v2"}
 
 
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Reload integration runs only on Linux.")

--- a/python/tests/test_orm_analysis.py
+++ b/python/tests/test_orm_analysis.py
@@ -4,19 +4,15 @@ Tests for static analysis module.
 Tests the AST-based analysis of handler functions for:
 - Django ORM usage detection
 - Blocking I/O detection
-- Warning generation for sync handlers
 """
 
 from __future__ import annotations
-
-import warnings
 
 from django_bolt.analysis import (
     DependencyNeeds,
     HandlerAnalysis,
     analyze_dependency_tree,
     analyze_handler,
-    warn_blocking_handler,
 )
 
 
@@ -361,66 +357,6 @@ class TestRequestComponentAnalysis:
         """Document current limitation: external helper calls are not analyzed transitively."""
         analysis = analyze_handler(handler_passes_request_to_external_helper, request_param_names={"request"})
         self.assert_request_flags(analysis)
-
-
-class TestWarningGeneration:
-    """Tests for warning message generation."""
-
-    def test_sync_handler_orm_warning(self):
-        """Test warning is generated for sync handler with ORM."""
-        analysis = analyze_handler(sync_handler_with_orm)
-
-        warning_msg = analysis.get_warning_message(handler_name="sync_handler_with_orm", path="/users", is_async=False)
-
-        assert warning_msg is not None
-        assert "sync_handler_with_orm" in warning_msg
-        assert "/users" in warning_msg
-        assert "Running in thread pool" in warning_msg
-
-    def test_async_handler_no_warning(self):
-        """Test no warning for async handler - Django handles sync ORM automatically."""
-        analysis = analyze_handler(async_handler_with_sync_orm)
-
-        warning_msg = analysis.get_warning_message(
-            handler_name="async_handler_with_sync_orm", path="/async-users", is_async=True
-        )
-
-        # Async handlers don't need warnings - Django handles sync-to-async
-        assert warning_msg is None
-
-    def test_no_warning_for_clean_handler(self):
-        """Test no warning for handlers without issues."""
-        analysis = analyze_handler(sync_handler_no_orm)
-
-        warning_msg = analysis.get_warning_message(handler_name="sync_handler_no_orm", path="/hello", is_async=False)
-
-        assert warning_msg is None
-
-    def test_no_warning_for_async_with_async_orm(self):
-        """Test no warning for proper async ORM usage."""
-        analysis = analyze_handler(async_handler_with_async_orm)
-
-        warning_msg = analysis.get_warning_message(
-            handler_name="async_handler_with_async_orm", path="/async-users", is_async=True
-        )
-
-        # Should not warn if using async ORM (even if also detected sync patterns)
-        # Actually our current logic will still warn - let's check
-        # The warning should be None if uses_async_orm is True
-        # Looking at the code, it warns if sync ORM detected without async ORM
-        # Since this handler uses async ORM, it should not warn
-        assert warning_msg is None
-
-    def test_warn_blocking_handler_emits_warning(self):
-        """Test that warn_blocking_handler actually emits warnings for sync handlers."""
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-
-            warn_blocking_handler(fn=sync_handler_with_orm, path="/users", is_async=False)
-
-            # Check that a warning was emitted
-            assert len(w) == 1
-            assert "Running in thread pool" in str(w[0].message)
 
 
 class TestAnalysisFailure:

--- a/python/tests/test_runbolt_dev.py
+++ b/python/tests/test_runbolt_dev.py
@@ -310,9 +310,7 @@ def test_collect_dev_watch_paths_survives_broken_api_module(settings, tmp_path, 
     still triggers a reload."""
     (tmp_path / "urls.py").write_text("urlpatterns = []\n")
     api_module = tmp_path / "api.py"
-    api_module.write_text(
-        "from django_bolt.api import BoltAPI\nraise RuntimeError('boom')\napi = BoltAPI()\n"
-    )
+    api_module.write_text("from django_bolt.api import BoltAPI\nraise RuntimeError('boom')\napi = BoltAPI()\n")
 
     monkeypatch.syspath_prepend(str(tmp_path))
     _clear_modules(monkeypatch, "urls", "api")

--- a/python/tests/test_runbolt_dev.py
+++ b/python/tests/test_runbolt_dev.py
@@ -40,6 +40,57 @@ def test_build_dev_worker_command_removes_dev_and_forces_single_process():
     ]
 
 
+def test_build_dev_worker_command_preserves_module_invocation():
+    """``python -m src.manage`` must respawn as ``-m src.manage``, not as a script.
+
+    CPython rewrites ``sys.argv[0]`` to manage.py's resolved path for ``-m``
+    runs, so rebuilding the command from argv alone re-runs it in script mode.
+    Script mode puts manage.py's own directory at the front of ``sys.path``
+    instead of the cwd, so a project whose manage.py lives inside the package it
+    imports from (``src/manage.py`` with ``src.project.settings``) can no longer
+    import its own settings — the worker dies with ModuleNotFoundError.
+    """
+    command = runbolt_module._build_dev_worker_command(
+        ["/abs/backend/src/manage.py", "runbolt", "--dev", "--host", "127.0.0.1"],
+        executable="/usr/bin/python3",
+        main_module="src.manage",
+    )
+
+    assert command == [
+        "/usr/bin/python3",
+        "-m",
+        "src.manage",
+        "runbolt",
+        "--host",
+        "127.0.0.1",
+        "--processes",
+        "1",
+    ]
+
+
+def test_dev_worker_main_module_reports_dash_m_module():
+    spec = SimpleNamespace(name="src.manage", parent="src")
+    main_module = SimpleNamespace(__spec__=spec)
+
+    assert runbolt_module._dev_worker_main_module(main_module) == "src.manage"
+
+
+def test_dev_worker_main_module_unwraps_package_dunder_main():
+    """``python -m src`` runs ``src/__main__.py``; respawn the package, not the file."""
+    spec = SimpleNamespace(name="src.__main__", parent="src")
+    main_module = SimpleNamespace(__spec__=spec)
+
+    assert runbolt_module._dev_worker_main_module(main_module) == "src"
+
+
+def test_dev_worker_main_module_is_none_for_script_invocation():
+    # `python manage.py` leaves __spec__ as None; some environments (Conda)
+    # omit the attribute entirely.
+    assert runbolt_module._dev_worker_main_module(SimpleNamespace(__spec__=None)) is None
+    assert runbolt_module._dev_worker_main_module(SimpleNamespace()) is None
+    assert runbolt_module._dev_worker_main_module(None) is None
+
+
 def test_display_host_uses_loopback_for_dev_wildcard_hosts():
     assert runbolt_module._display_host("0.0.0.0", dev_mode=True) == "127.0.0.1"
     assert runbolt_module._display_host("::", dev_mode=True) == "127.0.0.1"
@@ -64,7 +115,7 @@ def test_collapse_watch_paths_deduplicates_nested_directories(tmp_path):
     assert collapsed == [root, sibling]
 
 
-def test_collect_dev_watch_paths_prefers_python_and_template_paths(settings, tmp_path, monkeypatch):
+def test_collect_dev_watch_paths_collapses_root_and_keeps_external_paths(settings, tmp_path, monkeypatch):
     project_root = tmp_path / "project"
     templates_root = tmp_path / "templates"
     static_root = tmp_path / "static"
@@ -99,12 +150,14 @@ def test_collect_dev_watch_paths_prefers_python_and_template_paths(settings, tmp
 
     watch_paths = set(runbolt_module._collect_dev_watch_paths())
 
-    assert str(settings_module) in watch_paths
-    assert str(urls_module) in watch_paths
+    # Python files inside the project root collapse into the recursive root
+    # watch; paths outside the root stay individually watched.
+    assert str(project_root) in watch_paths
+    assert str(settings_module) not in watch_paths
+    assert str(urls_module) not in watch_paths
     assert str(templates_root) in watch_paths
     assert str(external_app / "api.py") in watch_paths
     assert str(static_root) not in watch_paths
-    assert str(project_root) not in watch_paths
 
 
 def test_execute_from_command_line_dev_calls_reloader_with_debounce(monkeypatch):
@@ -117,6 +170,8 @@ def test_execute_from_command_line_dev_calls_reloader_with_debounce(monkeypatch)
         "127.0.0.1",
         "--processes",
         "4",
+        "--reload-dir",
+        "/tmp/plugins",
     ]
 
     def fake_run_dev_reloader(command, watch_paths, ignore_dir_names, ignore_paths, debounce_ms, force_polling):
@@ -129,7 +184,12 @@ def test_execute_from_command_line_dev_calls_reloader_with_debounce(monkeypatch)
         return 0
 
     monkeypatch.setattr(sys, "argv", argv)
-    monkeypatch.setattr(runbolt_module, "_collect_dev_watch_paths", lambda: ["/tmp/project"])
+
+    def fake_collect_dev_watch_paths(reload_dirs):
+        recorded["reload_dirs"] = reload_dirs
+        return ["/tmp/project"]
+
+    monkeypatch.setattr(runbolt_module, "_collect_dev_watch_paths", fake_collect_dev_watch_paths)
     monkeypatch.setattr(runbolt_module, "_collect_dev_ignore_paths", lambda: ["/tmp/venv"])
     monkeypatch.setattr(
         runbolt_module,
@@ -148,13 +208,121 @@ def test_execute_from_command_line_dev_calls_reloader_with_debounce(monkeypatch)
             "127.0.0.1",
             "--processes",
             "1",
+            "--reload-dir",
+            "/tmp/plugins",
         ],
+        "reload_dirs": ["/tmp/plugins"],
         "watch_paths": ["/tmp/project"],
         "ignore_dir_names": list(runbolt_module.DEV_RELOAD_IGNORE_DIRS),
         "ignore_paths": ["/tmp/venv"],
         "debounce_ms": runbolt_module.DEV_RELOAD_DEBOUNCE_MS,
         "force_polling": False,
     }
+
+
+def test_collect_dev_watch_paths_includes_api_transitive_imports(settings, tmp_path, monkeypatch):
+    """The dev supervisor must watch modules imported BY api.py, not just api.py.
+
+    The supervisor never runs autodiscovery, so without priming imports the
+    watch list only covers django.setup()'s import graph plus the api module
+    file itself — editing a helper module api.py imports would never reload.
+    """
+    (tmp_path / "urls.py").write_text("urlpatterns = []\n")
+    (tmp_path / "api.py").write_text(
+        "from django_bolt.api import BoltAPI\nimport dev_watch_helper_a\napi = BoltAPI()\n"
+    )
+    helper = tmp_path / "dev_watch_helper_a.py"
+    helper.write_text("VALUE = 1\n")
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    _clear_modules(monkeypatch, "urls", "api", "dev_watch_helper_a")
+    monkeypatch.setattr(runbolt_module, "apps", SimpleNamespace(ready=True, get_app_configs=lambda: []))
+    settings.ROOT_URLCONF = "urls"
+
+    watch_paths = set(runbolt_module._collect_dev_watch_paths())
+
+    assert str(helper.resolve()) in watch_paths
+
+
+def test_collect_dev_watch_paths_includes_bolt_api_setting_imports(settings, tmp_path, monkeypatch):
+    (tmp_path / "explicit_api.py").write_text(
+        "from django_bolt.api import BoltAPI\nimport dev_watch_helper_b\napi = BoltAPI()\n"
+    )
+    helper = tmp_path / "dev_watch_helper_b.py"
+    helper.write_text("VALUE = 1\n")
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    _clear_modules(monkeypatch, "explicit_api", "dev_watch_helper_b")
+    monkeypatch.setattr(runbolt_module, "apps", SimpleNamespace(ready=True, get_app_configs=lambda: []))
+    settings.BOLT_API = ["explicit_api:api"]
+
+    watch_paths = set(runbolt_module._collect_dev_watch_paths())
+
+    assert str(helper.resolve()) in watch_paths
+    assert str((tmp_path / "explicit_api.py").resolve()) in watch_paths
+
+
+def test_collect_dev_watch_paths_watches_project_root_by_default(settings, tmp_path, monkeypatch):
+    """The project root (BASE_DIR) is always watched recursively, uvicorn-style,
+    so newly created modules and packages reload without a dev-server restart."""
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    outside_module = tmp_path / "outside.py"
+    outside_module.write_text("VALUE = 1\n")
+
+    monkeypatch.chdir(project_root)
+    monkeypatch.setattr(runbolt_module, "_prime_dev_watch_imports", lambda: None)
+    monkeypatch.setattr(runbolt_module, "_collect_loaded_python_paths", lambda: {outside_module})
+    monkeypatch.setattr(runbolt_module, "_collect_autodiscovery_python_paths", lambda: set())
+    monkeypatch.setattr(runbolt_module, "get_template_directories", lambda: set())
+    settings.BASE_DIR = project_root
+
+    watch_paths = set(runbolt_module._collect_dev_watch_paths())
+
+    assert str(project_root) in watch_paths
+    assert str(outside_module) in watch_paths
+
+
+def test_collect_dev_watch_paths_includes_reload_dirs(settings, tmp_path, monkeypatch, capsys):
+    """--reload-dir entries append extra directories/files to the watch list
+    (the escape hatch for code the import graph can't see, e.g. files created
+    after startup). Missing entries warn instead of failing startup."""
+    (tmp_path / "urls.py").write_text("urlpatterns = []\n")
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    missing = tmp_path / "does_not_exist"
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    _clear_modules(monkeypatch, "urls")
+    monkeypatch.setattr(runbolt_module, "apps", SimpleNamespace(ready=True, get_app_configs=lambda: []))
+    settings.ROOT_URLCONF = "urls"
+
+    watch_paths = set(runbolt_module._collect_dev_watch_paths([str(plugins), str(missing)]))
+
+    assert str(plugins.resolve()) in watch_paths
+    assert str(missing.resolve()) not in watch_paths
+    assert "does_not_exist" in capsys.readouterr().err
+
+
+def test_collect_dev_watch_paths_survives_broken_api_module(settings, tmp_path, monkeypatch, capsys):
+    """A broken api.py must not kill the supervisor: the worker reports the
+    real error, and the api module file itself stays watched so fixing it
+    still triggers a reload."""
+    (tmp_path / "urls.py").write_text("urlpatterns = []\n")
+    api_module = tmp_path / "api.py"
+    api_module.write_text(
+        "from django_bolt.api import BoltAPI\nraise RuntimeError('boom')\napi = BoltAPI()\n"
+    )
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    _clear_modules(monkeypatch, "urls", "api")
+    monkeypatch.setattr(runbolt_module, "apps", SimpleNamespace(ready=True, get_app_configs=lambda: []))
+    settings.ROOT_URLCONF = "urls"
+
+    watch_paths = set(runbolt_module._collect_dev_watch_paths())
+
+    assert str(api_module.resolve()) in watch_paths
+    assert "boom" in capsys.readouterr().err
 
 
 def test_autodiscover_apis_uses_top_level_api_for_plain_root_urlconf(settings, tmp_path, monkeypatch):

--- a/src/dev_reload.rs
+++ b/src/dev_reload.rs
@@ -224,6 +224,35 @@ fn format_exit_status(status: std::process::ExitStatus) -> String {
     }
 }
 
+/// Exit code to propagate when a worker exit is terminal, or `None` when the
+/// supervisor should keep watching for changes.
+///
+/// A worker that dies *after* a reload usually died on the edit the developer
+/// is still making (SyntaxError, bad import), so the session must survive: the
+/// next save fixes it. A worker that fails on its very first start died on
+/// something no file change can fix — the port is taken, settings are broken,
+/// migrations are missing — so waiting there would leave a live-looking
+/// supervisor that never serves and a zero exit status. Propagate instead,
+/// matching `runserver`, where only Django's reload signal (exit code 3)
+/// respawns and every other code exits.
+///
+/// Signal-terminated first starts stay non-terminal: Ctrl-C before the Rust
+/// server installs its own handlers kills the worker by SIGINT, and that must
+/// not be reported as a startup failure.
+fn terminal_worker_exit_code(
+    status: std::process::ExitStatus,
+    reload_count: u64,
+) -> Option<i32> {
+    if reload_count > 0 {
+        return None;
+    }
+
+    match status.code() {
+        Some(0) | None => None,
+        Some(code) => Some(code),
+    }
+}
+
 fn run_dev_reloader_inner(
     command: Vec<String>,
     watch_paths: Vec<String>,
@@ -330,12 +359,25 @@ fn run_dev_reloader_inner(
                 .map_err(|err| py_runtime_error(format!("Failed to poll dev worker: {}", err)))?
             {
                 let exit_detail = format_exit_status(status);
+                worker = None;
+
+                if !shutdown.load(Ordering::SeqCst) {
+                    if let Some(code) = terminal_worker_exit_code(status, reload_count) {
+                        eprintln!(
+                            "[django-bolt] Dev worker failed to start ({}). \
+                             A startup failure cannot be fixed by editing a file, \
+                             so dev reload is exiting.",
+                            exit_detail
+                        );
+                        return Ok(code);
+                    }
+                }
+
                 eprintln!(
                     "[django-bolt] Dev worker exited with {}. Waiting for changes...",
                     exit_detail
                 );
                 worker_exited = true;
-                worker = None;
             }
         }
 
@@ -388,9 +430,51 @@ pub fn run_dev_reloader(
 
 #[cfg(test)]
 mod tests {
-    use super::{first_relevant_path, is_temporary_path, ReloadFilter};
+    use super::{first_relevant_path, is_temporary_path, terminal_worker_exit_code, ReloadFilter};
     use notify::{event::CreateKind, Event, EventKind};
     use std::path::PathBuf;
+    use std::process::{Command, ExitStatus};
+
+    fn exit_status(code: i32) -> ExitStatus {
+        Command::new("sh")
+            .arg("-c")
+            .arg(format!("exit {}", code))
+            .status()
+            .expect("failed to run sh for a real ExitStatus")
+    }
+
+    #[test]
+    fn failed_first_start_propagates_its_exit_code() {
+        // Port already in use, broken settings: nothing an edit can fix, so the
+        // supervisor must exit instead of waiting for changes forever.
+        assert_eq!(terminal_worker_exit_code(exit_status(1), 0), Some(1));
+        assert_eq!(terminal_worker_exit_code(exit_status(2), 0), Some(2));
+    }
+
+    #[test]
+    fn crash_after_a_reload_keeps_the_session_alive() {
+        // The developer saved a broken file; the next save must be able to fix it.
+        assert_eq!(terminal_worker_exit_code(exit_status(1), 1), None);
+        assert_eq!(terminal_worker_exit_code(exit_status(1), 7), None);
+    }
+
+    #[test]
+    fn clean_first_exit_is_not_a_startup_failure() {
+        assert_eq!(terminal_worker_exit_code(exit_status(0), 0), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn signal_terminated_first_start_is_not_a_startup_failure() {
+        // Ctrl-C before the Rust server installs its handlers kills the worker
+        // by SIGINT; that is a shutdown, not a failed start.
+        use std::os::unix::process::ExitStatusExt;
+
+        assert_eq!(
+            terminal_worker_exit_code(ExitStatus::from_raw(libc::SIGINT), 0),
+            None
+        );
+    }
 
     #[test]
     fn ignores_paths_inside_ignored_directories() {

--- a/src/dev_reload.rs
+++ b/src/dev_reload.rs
@@ -1,16 +1,84 @@
 use notify::{Config, Event, EventKind, PollWatcher, RecommendedWatcher, RecursiveMode, Watcher};
 use pyo3::prelude::*;
 use std::collections::HashSet;
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const WORKER_STOP_TIMEOUT_RELOAD: Duration = Duration::from_millis(100);
 const WORKER_STOP_TIMEOUT_SHUTDOWN: Duration = Duration::from_millis(1200);
 const CHILD_EXIT_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Minimal ANSI painter for supervisor log lines; no-op when stderr is not a
+/// terminal, `NO_COLOR` is set, or `TERM=dumb` (matching the Python banner).
+struct Paint {
+    enabled: bool,
+}
+
+impl Paint {
+    fn detect() -> Self {
+        let enabled = std::io::stderr().is_terminal()
+            && std::env::var_os("NO_COLOR").is_none()
+            && std::env::var("TERM")
+                .map(|term| term != "dumb")
+                .unwrap_or(true);
+        Self { enabled }
+    }
+
+    fn wrap(&self, code: &str, text: &str) -> String {
+        if self.enabled {
+            format!("\x1b[{}m{}\x1b[0m", code, text)
+        } else {
+            text.to_string()
+        }
+    }
+
+    fn dim(&self, text: &str) -> String {
+        self.wrap("2", text)
+    }
+
+    fn cyan(&self, text: &str) -> String {
+        self.wrap("36", text)
+    }
+
+    fn green(&self, text: &str) -> String {
+        self.wrap("32", text)
+    }
+
+    fn yellow(&self, text: &str) -> String {
+        self.wrap("33", text)
+    }
+
+    fn red(&self, text: &str) -> String {
+        self.wrap("31", text)
+    }
+
+    /// `HH:MM:SS [bolt] <body>` — Vite-style timestamped supervisor line.
+    fn log(&self, body: &str) {
+        let timestamp = chrono::Local::now().format("%H:%M:%S");
+        eprintln!(
+            "  {} {} {}",
+            self.dim(&timestamp.to_string()),
+            self.cyan("[bolt]"),
+            body
+        );
+    }
+}
+
+/// Render a path relative to the current directory when possible; developers
+/// read `testproject/api.py` faster than an absolute path.
+fn display_path(path: &Path) -> String {
+    std::env::current_dir()
+        .ok()
+        .and_then(|cwd| path.strip_prefix(&cwd).ok())
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}
 
 #[derive(Debug, Clone)]
 struct ReloadFilter {
@@ -101,7 +169,8 @@ fn py_runtime_error(message: impl Into<String>) -> PyErr {
     pyo3::exceptions::PyRuntimeError::new_err(message.into())
 }
 
-// Keep in sync with _ENV_DEV_WORKER / _ENV_DEV_RELOAD_COUNT in runbolt.py
+// Keep in sync with _ENV_DEV_WORKER / _ENV_DEV_RELOAD_COUNT /
+// _ENV_DEV_SPAWN_MS in runbolt.py
 fn spawn_worker(command: &[String], reload_count: u64) -> PyResult<Child> {
     let Some(program) = command.first() else {
         return Err(py_runtime_error("Dev worker command cannot be empty"));
@@ -112,9 +181,17 @@ fn spawn_worker(command: &[String], reload_count: u64) -> PyResult<Child> {
         child.arg(arg);
     }
 
+    // Spawn timestamp lets the worker print an honest "ready in N ms" that
+    // includes interpreter startup and django.setup(), not just route setup.
+    let spawn_unix_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_millis().to_string())
+        .unwrap_or_default();
+
     child
         .env("DJANGO_BOLT_DEV_WORKER", "1")
         .env("DJANGO_BOLT_DEV_RELOAD_COUNT", reload_count.to_string())
+        .env("DJANGO_BOLT_DEV_SPAWN_UNIX_MS", spawn_unix_ms)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
@@ -239,10 +316,7 @@ fn format_exit_status(status: std::process::ExitStatus) -> String {
 /// Signal-terminated first starts stay non-terminal: Ctrl-C before the Rust
 /// server installs its own handlers kills the worker by SIGINT, and that must
 /// not be reported as a startup failure.
-fn terminal_worker_exit_code(
-    status: std::process::ExitStatus,
-    reload_count: u64,
-) -> Option<i32> {
+fn terminal_worker_exit_code(status: std::process::ExitStatus, reload_count: u64) -> Option<i32> {
     if reload_count > 0 {
         return None;
     }
@@ -314,8 +388,10 @@ fn run_dev_reloader_inner(
         )
     };
 
+    let paint = Paint::detect();
+
     if force_polling {
-        eprintln!("[django-bolt] Dev reload using PollWatcher (interval=500ms)");
+        paint.log(&paint.dim("watching via stat() polling (interval 500ms)"));
     }
 
     let mut watched = 0usize;
@@ -363,27 +439,30 @@ fn run_dev_reloader_inner(
 
                 if !shutdown.load(Ordering::SeqCst) {
                     if let Some(code) = terminal_worker_exit_code(status, reload_count) {
-                        eprintln!(
-                            "[django-bolt] Dev worker failed to start ({}). \
-                             A startup failure cannot be fixed by editing a file, \
-                             so dev reload is exiting.",
+                        paint.log(&paint.red(&format!(
+                            "server failed to start ({}); a startup failure cannot be \
+                             fixed by editing a file, exiting",
                             exit_detail
-                        );
+                        )));
                         return Ok(code);
                     }
                 }
 
-                eprintln!(
-                    "[django-bolt] Dev worker exited with {}. Waiting for changes...",
+                paint.log(&paint.yellow(&format!(
+                    "server exited with {}. Waiting for changes...",
                     exit_detail
-                );
+                )));
                 worker_exited = true;
             }
         }
 
         match recv_change(&rx, &filter, debounce, recv_timeout) {
             Ok(Some(changed_path)) => {
-                eprintln!("[django-bolt] 🔄 Reloading ({})", changed_path.display());
+                paint.log(&format!(
+                    "{} {}",
+                    paint.green("reloading"),
+                    display_path(&changed_path)
+                ));
                 reload_count += 1;
                 stop_worker(&mut worker, WORKER_STOP_TIMEOUT_RELOAD)?;
                 worker = Some(spawn_worker(&command, reload_count)?);
@@ -400,7 +479,7 @@ fn run_dev_reloader_inner(
                     continue;
                 }
 
-                eprintln!("[django-bolt] Dev reload watcher error: {}", err);
+                paint.log(&paint.yellow(&format!("watcher error: {}", err)));
             }
         }
     }


### PR DESCRIPTION
## Problem

`runbolt --dev` missed most edits. The dev supervisor never imports the api module, so its watch list was only `django.setup()`'s import graph plus `api.py` itself:

- Editing a helper/service module that `api.py` imports did nothing.
- Creating a new module or package did nothing.
- Code outside the project root (PYTHONPATH apps, editable installs) had no escape hatch.
- A `python -m pkg.manage` launch was respawned as a plain script, breaking src-layout projects (manage.py's own dir heads `sys.path`, so `import src.project.settings` fails).
- A worker that failed on its *first* start (port in use, broken settings) left a live-looking supervisor waiting forever for a change that could never fix it, and exited 0.

## Changes

- **Prime the watch list**: import the modules autodiscovery will import (explicit `BOLT_API` entries, else project/app api candidates gated by the same AST scan autodiscovery uses) so their transitive imports are watched. Import failures print a warning and are non-fatal — the worker surfaces the real error, and the api file stays watched so fixing it reloads.
- **Watch the project root recursively** (`BASE_DIR`, falling back to cwd), uvicorn-style, so new files/packages reload. Import-graph entries inside the root collapse into it; entries outside stay individually watched.
- **`--reload-dir PATH`** (repeatable, uvicorn-shaped) for code outside both. Warns when the path doesn't exist, and when passed without `--dev`.
- **Preserve `-m` invocations** when rebuilding the worker command, via `__main__.__spec__` (`sys.argv[0]` is rewritten to the file path, so the flag itself doesn't survive). `python -m pkg` respawns the package, not `__main__.py`.
- **Exit on a failed first start** with the worker's own exit code (matching `runserver`, where only Django's reload signal respawns). Crashes *after* a reload still keep the session alive — the next save is the fix. Signal-terminated first starts (Ctrl-C before the Rust server installs handlers) are not treated as failures.
- **Drop the sync-handler-uses-ORM warning** (`warn_blocking_handler` / `HandlerAnalysis.get_warning_message`). It fired on every route registration and was already being hand-suppressed on dev reloads; the thread-pool behavior it described is documented and unchanged.

## Tests

- `src/dev_reload.rs`: unit tests for `terminal_worker_exit_code` — failed first start propagates, post-reload crash keeps waiting, clean exit and SIGINT are not failures.
- `python/tests/test_runbolt_dev.py`: watch-path collection (imported helpers, `BOLT_API`, `--reload-dir`), `-m` command rebuilding including src layout and `python -m pkg`.
- `python/tests/integration/test_dev_reload.py` (`server_integration`, real `runbolt --dev` subprocess): reload on an imported helper change, on a brand-new module in the project root, on a `--reload-dir` entry outside the root, `python -m src.manage` serving and reloading, exit when the first start fails, survival when a reloaded worker crashes, and force-polling.
- New app fixtures under `python/tests/integration/apps/`: `reload_import_dep` plus the `_reload_helper`/`_reload_helper_v2` support modules. `test_apps_smoke` now skips underscore-prefixed support modules and syntax-checks `reload_import_dep`, which by design only imports inside the temp project.

Full suite green (`just test-py`), `just lint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The PR does **not** touch the hot request-dispatch path.

- Runtime behavior change on route registration: it removes `warn_blocking_handler(...)` / `get_warning_message(...)` from the `_route_decorator` flow in `python/django_bolt/api.py`, eliminating warning generation entirely (no new per-request overhead).
- Dev reload/watch behavior (`_collect_dev_watch_paths`, dev worker command rebuild, import-dependency watching, and the worker lifecycle/exit-code handling in `src/dev_reload.rs`) is invoked from the **dev supervisor/startup/reload machinery** (`python/django_bolt/management/commands/runbolt.py` and Rust dev reloader), not during request dispatch.
- The only AST analysis calls in `api.py` (`analyze_handler(...)` / `analyze_dependency_tree(...)`) occur in the **registration/build phase** when wiring routes/metadata, not inside `_dispatch(...)` / `_dispatch_sync(...)`.

Net: the added work is dev-only and setup/reload-time; the hot path remains unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->